### PR TITLE
Fix SDK False Positive count

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.4.6"
+        CxSBSDK = "0.4.8"
 		springBootVersion = '2.2.4.RELEASE'
         sonarqubeVersion = '2.8'
         atlassianVersion = "5.2.0"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	ext {
-        CxSBSDK = "0.4.6"
+        CxSBSDK = "0.4.8"
         //cxVersion = "8.90.5"
         springBootVersion = '2.2.4.RELEASE'
         sonarqubeVersion = '2.8'


### PR DESCRIPTION
Fix issue with Checkmarx SDK (Version 0.4.8) where the false positive calculation was inaccurate.