### PR TITLE
Remove hard coded Docker Registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,8 +45,6 @@ jobs:
   docker-push:
     docker:
       - image: docker:18.06.3-ce-git
-        environment:
-          DOCKER_REPO: docker.io/checkmarxts/cxflow
     steps:
       - setup_remote_docker
       - attach_workspace:


### PR DESCRIPTION
Remove Docker Registry reference.  This will require the Environment variable DOCKER_REPO to be set in the circleci settings.
ie., DOCKER_REPO=docker.io/checkmarxts/cxflow