### PR TITLE
Fix hanging process when using CLI

### DIFF
--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -419,7 +419,7 @@ public class CxFlowRunner implements ApplicationRunner {
             exit(10);
         }
         log.info("Completed Successfully");
-//        exit(0);
+        exit(0);
     }
 
     private boolean containsRepoArgs(String namespace, String repoName, String branch){


### PR DESCRIPTION
Without this explicit exit, certain situations will cause a hanging process at the.  This fix was required for a client in their production environment with the latest build.