### PR TITLE
Update SDK to 0.4.9 to fix Team path inconsistencies

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,8 +2,8 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.4.8"
-		    springBootVersion = '2.2.4.RELEASE'
+        CxSBSDK = "0.4.9"
+        springBootVersion = '2.2.4.RELEASE'
         sonarqubeVersion = '2.8'
         atlassianVersion = "5.2.0"
         atlassianFugueVersion = "4.7.2"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	ext {
-        CxSBSDK = "0.4.8"
+        CxSBSDK = "0.4.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.2.4.RELEASE'
         sonarqubeVersion = '2.8'


### PR DESCRIPTION
Resolving team path inconsistencies by initializing the team path with a leading path separator (\ or / depending on 8.X vs 9.X)