### PR TITLE
Fix Threshold when using Flow Summary

### DIFF
--- a/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
+++ b/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
@@ -525,7 +525,7 @@ public class ScanUtils {
             }
             body.append("Severity|Count").append(CRLF);
             body.append("---|---").append(CRLF);
-            Map<String, Integer> flow = (Map<String, Integer>) results.getAdditionalDetails().put(Constants.SUMMARY_KEY, summary);
+            Map<String, Integer> flow = (Map<String, Integer>) results.getAdditionalDetails().get(Constants.SUMMARY_KEY);
             if(flow != null) {
                 for (Map.Entry<String, Integer> severity : flow.entrySet()) {
                     body.append(severity.getKey()).append("|").append(severity.getValue().toString()).append(CRLF);


### PR DESCRIPTION
Azure Item 74 - Threshold functionality doesn't work if flow-summary is true

Update logic to get instead of put, which is not accurate.

