### PR TITLE
Feature/retain event payload

### DIFF
--- a/src/main/java/com/checkmarx/flow/controller/ADOController.java
+++ b/src/main/java/com/checkmarx/flow/controller/ADOController.java
@@ -218,6 +218,7 @@ public class ADOController {
             request.putAdditionalMetadata(Constants.ADO_ISSUE_BODY_KEY, adoIssueBody);
             request.putAdditionalMetadata(Constants.ADO_OPENED_STATE_KEY, adoOpenedState);
             request.putAdditionalMetadata(Constants.ADO_CLOSED_STATE_KEY, adoClosedState);
+            request.putAdditionalMetadata(ScanUtils.WEB_HOOK_PAYLOAD, body.toString());
             request.setId(uid);
             //only initiate scan/automation if target branch is applicable
             if(helperService.isBranch2Scan(request, branches)){
@@ -398,6 +399,7 @@ public class ADOController {
             request.putAdditionalMetadata(Constants.ADO_ISSUE_BODY_KEY, adoIssueBody);
             request.putAdditionalMetadata(Constants.ADO_OPENED_STATE_KEY, adoOpenedState);
             request.putAdditionalMetadata(Constants.ADO_CLOSED_STATE_KEY, adoClosedState);
+            request.putAdditionalMetadata(ScanUtils.WEB_HOOK_PAYLOAD, body.toString());
             //if an override blob/file is provided, substitute these values
             request = ScanUtils.overrideMap(request, o);
 

--- a/src/main/java/com/checkmarx/flow/controller/BitbucketCloudController.java
+++ b/src/main/java/com/checkmarx/flow/controller/BitbucketCloudController.java
@@ -172,6 +172,7 @@ public class BitbucketCloudController {
                     .build();
 
             request = ScanUtils.overrideMap(request, o);
+            request.putAdditionalMetadata(ScanUtils.WEB_HOOK_PAYLOAD, body.toString());
             request.setId(uid);
 
             if(helperService.isBranch2Scan(request, branches)){
@@ -322,6 +323,7 @@ public class BitbucketCloudController {
                     .build();
 
             request = ScanUtils.overrideMap(request, o);
+            request.putAdditionalMetadata(ScanUtils.WEB_HOOK_PAYLOAD, body.toString());
             request.setId(uid);
 
             if(helperService.isBranch2Scan(request, branches)){

--- a/src/main/java/com/checkmarx/flow/controller/BitbucketServerController.java
+++ b/src/main/java/com/checkmarx/flow/controller/BitbucketServerController.java
@@ -293,6 +293,7 @@ public class BitbucketServerController {
                     .build();
 
             request = ScanUtils.overrideMap(request, o);
+            request.putAdditionalMetadata(ScanUtils.WEB_HOOK_PAYLOAD, body);
             request.setId(uid);
             try {
                 request.putAdditionalMetadata("BITBUCKET_BROWSE", fromRefRepository.getLinks().getSelf().get(0).getHref());
@@ -456,6 +457,7 @@ public class BitbucketServerController {
                 log.warn("Not able to determine file url for browsing", e);
             }
             request = ScanUtils.overrideMap(request, o);
+            request.putAdditionalMetadata(ScanUtils.WEB_HOOK_PAYLOAD, body);
             request.setId(uid);
             //only initiate scan/automation if target branch is applicable
             if(helperService.isBranch2Scan(request, branches)){

--- a/src/main/java/com/checkmarx/flow/controller/FlowController.java
+++ b/src/main/java/com/checkmarx/flow/controller/FlowController.java
@@ -211,6 +211,7 @@ public class FlowController {
                     .build();
             request.setId(uid);
 
+            request.putAdditionalMetadata(ScanUtils.WEB_HOOK_PAYLOAD, scanRequest.toString());
             if(!ScanUtils.empty(scanRequest.getResultUrl())){
                 request.putAdditionalMetadata("result_url", scanRequest.getResultUrl());
             }

--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -33,10 +33,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 
 /**
  * Class used to manage Controller for GitHub WebHooks
@@ -244,6 +241,7 @@ public class GitHubController {
             CxConfig cxConfig =  gitHubService.getCxConfigOverride(request);
             request = ScanUtils.overrideCxConfig(request, cxConfig, flowProperties, jiraProperties);
 
+            request.putAdditionalMetadata(ScanUtils.WEB_HOOK_PAYLOAD, body);
             request.putAdditionalMetadata("statuses_url", event.getPullRequest().getStatusesUrl());
             request.setId(uid);
             //only initiate scan/automation if target branch is applicable
@@ -420,6 +418,7 @@ public class GitHubController {
             CxConfig cxConfig =  gitHubService.getCxConfigOverride(request);
             request = ScanUtils.overrideCxConfig(request, cxConfig, flowProperties, jiraProperties);
 
+            request.putAdditionalMetadata(ScanUtils.WEB_HOOK_PAYLOAD, body);
             request.setId(uid);
 
             //only initiate scan/automation if branch is applicable

--- a/src/main/java/com/checkmarx/flow/controller/GitLabController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitLabController.java
@@ -206,6 +206,7 @@ public class GitLabController {
             CxConfig cxConfig =  gitLabService.getCxConfigOverride(request);
             request = ScanUtils.overrideCxConfig(request, cxConfig, flowProperties, jiraProperties);
 
+            request.putAdditionalMetadata(ScanUtils.WEB_HOOK_PAYLOAD, body.toString());
             request.putAdditionalMetadata("merge_id",objectAttributes.getIid().toString());
             request.putAdditionalMetadata("merge_title", objectAttributes.getTitle());
             if(proj.getId() != null) {
@@ -375,6 +376,7 @@ public class GitLabController {
             CxConfig cxConfig =  gitLabService.getCxConfigOverride(request);
             request = ScanUtils.overrideCxConfig(request, cxConfig, flowProperties, jiraProperties);
 
+            request.putAdditionalMetadata(ScanUtils.WEB_HOOK_PAYLOAD, body.toString());
             request.setId(uid);
             if(proj.getId() != null) {
                 request.setRepoProjectId(proj.getId());

--- a/src/main/java/com/checkmarx/flow/controller/TfsController.java
+++ b/src/main/java/com/checkmarx/flow/controller/TfsController.java
@@ -201,6 +201,7 @@ public class TfsController {
         request.putAdditionalMetadata(Constants.ADO_ISSUE_BODY_KEY, adoIssueBody.orElse(properties.getIssueBody()));
         request.putAdditionalMetadata(Constants.ADO_OPENED_STATE_KEY, adoOpenedState.orElse(properties.getOpenStatus()));
         request.putAdditionalMetadata(Constants.ADO_CLOSED_STATE_KEY, adoClosedState.orElse(properties.getClosedStatus()));
+        request.putAdditionalMetadata(ScanUtils.WEB_HOOK_PAYLOAD, body.toString());
         request.setId(uid);
         //only initiate scan/automation if target branch is applicable
         List<String> branches = new ArrayList<>();

--- a/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
+++ b/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
@@ -44,6 +44,7 @@ public class ScanUtils {
     public static final String JIRA_ISSUE_KEY_2 = "%s%s @ %s%s";
     public static final String JIRA_ISSUE_BODY = "*%s* issue exists @ *%s* in branch *%s*";
     public static final String JIRA_ISSUE_BODY_2 = "*%s* issue exists @ *%s*";
+    public static final String WEB_HOOK_PAYLOAD = "web-hook-payload";
 
     private static final Logger log = org.slf4j.LoggerFactory.getLogger(ScanUtils.class);
 


### PR DESCRIPTION
Adding functionality to store the original webhook event payload in the ScanRequest details to be used downstream.
