### PR TITLE
Add Support for JVM Http Proxy Settings

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.4.9"
+        CxSBSDK = "0.4.12"
         springBootVersion = '2.2.4.RELEASE'
         sonarqubeVersion = '2.8'
         atlassianVersion = "5.2.0"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.4.9"
+        CxSBSDK = "0.4.12"
         //cxVersion = "8.90.5"
         springBootVersion = '2.2.4.RELEASE'
         sonarqubeVersion = '2.8'

--- a/src/main/java/com/checkmarx/flow/config/FlowConfig.java
+++ b/src/main/java/com/checkmarx/flow/config/FlowConfig.java
@@ -1,7 +1,7 @@
 package com.checkmarx.flow.config;
 
 import com.checkmarx.flow.utils.ScanUtils;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
@@ -29,7 +29,7 @@ public class FlowConfig {
         RestTemplate restTemplate = new RestTemplate();
 
         HttpComponentsClientHttpRequestFactory requestFactory = new
-                HttpComponentsClientHttpRequestFactory(HttpClients.createDefault());
+                HttpComponentsClientHttpRequestFactory(HttpClientBuilder.create().useSystemProperties().build());
         requestFactory.setConnectTimeout(properties.getHttpConnectionTimeout());
         requestFactory.setReadTimeout(properties.getHttpReadTimeout());
         restTemplate.setRequestFactory(requestFactory);


### PR DESCRIPTION
Fix For Azure Board Item 85
- Allow for Http Proxy settings provided to JVM
- Update Checkmarx SB SDK to 0.4.12
  - Adding TO_VERIFY as status filter option
  - Fix NPE when team is empty

