### PR TITLE
Rolled back the functionality that updates GitHub comments

### DIFF
--- a/src/main/java/com/checkmarx/flow/service/GitHubService.java
+++ b/src/main/java/com/checkmarx/flow/service/GitHubService.java
@@ -124,11 +124,7 @@ public class GitHubService extends RepoService {
         try {
             List<RepoComment> repoComments = getComments(request.getMergeNoteUri());
             log.debug("There are {} checkmarx comments on this pull request", repoComments.size());
-            if (repoComments.size() == 1) {
-                updateComment(getEditCommentUrl(request.getMergeNoteUri(), repoComments.get(0)), comment);
-            } else {
-                addComment(request, comment);
-            }
+            addComment(request, comment);
         }
         catch (IOException ioe) {
             throw new GitHubClientException("Error while adding or updating repo pull request comment", ioe);


### PR DESCRIPTION
Rolled back the functionality that updates GitHub comments, because it currently causes errors.