### PR TITLE
Modified Jira status comparison to be case-insensitive

### DIFF
--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -1131,12 +1131,21 @@ public class JiraService {
     }
 
     private void closeIssueInCaseOfIssueIsInOpenState(ScanRequest request, List<String> closedIssues, Issue fpIssue) throws JiraClientException {
-        if (request.getBugTracker().getOpenStatus().contains(fpIssue.getStatus().getName())) { //If the status is of open state, close it
+        if (containsIgnoreCase(request.getBugTracker().getOpenStatus(), fpIssue.getStatus().getName())) {
             /*Close the issue*/
             log.info("Closing issue with key {}", fpIssue.getKey());
             this.transitionCloseIssue(fpIssue.getKey(), request.getBugTracker().getCloseTransition(), request.getBugTracker(), true);
             closedIssues.add(fpIssue.getKey());
         }
+    }
+
+    private boolean containsIgnoreCase(List<String> openStatuses, String fpIssueStatusName) {
+        for (String status : openStatuses) {
+            if (status.equalsIgnoreCase(fpIssueStatusName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private Issue checkForFalsePositiveIssuesInList(ScanRequest request, Map.Entry<String, ScanResults.XIssue> xIssue, ScanResults.XIssue currentIssue, Issue issue) throws JiraClientException {


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ts/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
Relates to issue: https://github.com/checkmarx-ltd/cx-flow/issues/212. This PR allows the case insensitive comparison of Jira statuses in the config file to the response from the Jira API.

### References
https://github.com/checkmarx-ltd/cx-flow/issues/212

### Testing
I tested this by:
- configuring the CxFlow config to have 'PRIORITISED BACKLOG' as an entry
- starting the current production release of CxFlow
- marked a finding as a false positive within Checkmarx
- created a new PR on my DVWA repo
- once the scan was completed, I clicked the 'Merge' button for the PR, the result was that the existing issue in Jira was not closed
- I then closed the current production release of CxFlow and started the version built with this PR included
- I repeated the steps above, created a new PR, waited for the scan to finish and then merged it, this caused the issue to be closed as expected


### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
