### PR TITLE
Fixed errors in ADO-to-ADO flow

### DIFF
--- a/src/main/java/com/checkmarx/flow/controller/ADOController.java
+++ b/src/main/java/com/checkmarx/flow/controller/ADOController.java
@@ -212,8 +212,6 @@ public class ADOController {
 
             request = ScanUtils.overrideMap(request, o);
             request.putAdditionalMetadata("statuses_url", pullUrl.concat("/statuses"));
-            String baseUrl = body.getResourceContainers().getAccount().getBaseUrl();
-            request.putAdditionalMetadata(Constants.ADO_BASE_URL_KEY,baseUrl);
             request.putAdditionalMetadata(Constants.ADO_ISSUE_KEY, adoIssueType);
             request.putAdditionalMetadata(Constants.ADO_ISSUE_BODY_KEY, adoIssueBody);
             request.putAdditionalMetadata(Constants.ADO_OPENED_STATE_KEY, adoOpenedState);
@@ -401,8 +399,7 @@ public class ADOController {
                     .bugTracker(bt)
                     .filters(filters)
                     .build();
-            String baseUrl = body.getResourceContainers().getAccount().getBaseUrl();
-            request.putAdditionalMetadata(Constants.ADO_BASE_URL_KEY,baseUrl);
+
             request.putAdditionalMetadata(Constants.ADO_ISSUE_KEY, adoIssueType);
             request.putAdditionalMetadata(Constants.ADO_ISSUE_BODY_KEY, adoIssueBody);
             request.putAdditionalMetadata(Constants.ADO_OPENED_STATE_KEY, adoOpenedState);

--- a/src/main/java/com/checkmarx/flow/controller/ADOController.java
+++ b/src/main/java/com/checkmarx/flow/controller/ADOController.java
@@ -192,7 +192,7 @@ public class ADOController {
                     .product(p)
                     .project(project)
                     .team(team)
-                    .namespace(repository.getProject().getName().replaceAll(" ","_"))
+                    .namespace(determineNamespace(repository))
                     .repoName(repository.getName())
                     .repoUrl(gitUrl)
                     .repoUrlWithAuth(gitAuthUrl)
@@ -385,7 +385,7 @@ public class ADOController {
                     .product(p)
                     .project(project)
                     .team(team)
-                    .namespace(repository.getProject().getName().replaceAll(" ","_"))
+                    .namespace(determineNamespace(repository))
                     .repoName(repository.getName())
                     .repoUrl(gitUrl)
                     .repoUrlWithAuth(gitAuthUrl)
@@ -432,6 +432,12 @@ public class ADOController {
                 .success(true)
                 .build());
 
+    }
+
+    private String determineNamespace(Repository repository) {
+        String result = repository.getProject().getName().replaceAll(" ", "_");
+        log.debug("Using namespace based on repository.project.name: {}", result);
+        return result;
     }
 
     /** Validates the base64 / basic auth received in the request. */

--- a/src/main/java/com/checkmarx/flow/controller/TfsController.java
+++ b/src/main/java/com/checkmarx/flow/controller/TfsController.java
@@ -196,8 +196,6 @@ public class TfsController {
         if ("pull".equals(action)) {     
             request.putAdditionalMetadata("statuses_url", resource.getUrl().concat("/statuses"));
         }
-        String baseUrl = body.getResourceContainers().getCollection().getBaseUrl();
-        request.putAdditionalMetadata(Constants.ADO_BASE_URL_KEY,baseUrl);
         request.putAdditionalMetadata(Constants.ADO_ISSUE_KEY, adoIssueType.orElse(properties.getIssueType()));
         request.putAdditionalMetadata(Constants.ADO_ISSUE_BODY_KEY, adoIssueBody.orElse(properties.getIssueBody()));
         request.putAdditionalMetadata(Constants.ADO_OPENED_STATE_KEY, adoOpenedState.orElse(properties.getOpenStatus()));

--- a/src/main/java/com/checkmarx/flow/custom/ADOIssueTracker.java
+++ b/src/main/java/com/checkmarx/flow/custom/ADOIssueTracker.java
@@ -87,15 +87,11 @@ public class ADOIssueTracker implements IssueTracker {
             throw new MachinaException("Namespace / RepoName / Branch are required");
         }
 
-        if(ScanUtils.empty(request.getAdditionalMetadata(Constants.ADO_BASE_URL_KEY))){
-            if(ScanUtils.empty(properties.getUrl())) {
-                throw new MachinaException("Azure API Url must be provided in property config");
-            }
-            else{
-                if(!properties.getUrl().endsWith("/")){
-                    properties.setUrl(properties.getUrl().concat("/"));
-                }
-                request.putAdditionalMetadata(Constants.ADO_BASE_URL_KEY, properties.getUrl());
+        if (ScanUtils.empty(properties.getUrl())) {
+            throw new MachinaException("Azure API Url must be provided in configuration.");
+        } else {
+            if (!properties.getUrl().endsWith("/")) {
+                properties.setUrl(properties.getUrl().concat("/"));
             }
         }
     }
@@ -274,9 +270,8 @@ public class ADOIssueTracker implements IssueTracker {
         String adoProject = properties.getProjectName();
         if(StringUtils.isEmpty(adoProject)) {
             adoProject = request.getProject();
+            log.debug("Checking scan request: {}", adoProject);
         }
-        
-        log.debug("Checking main project field: {}", adoProject);
 
         if (StringUtils.isEmpty(adoProject)) {
             adoProject = request.getAltProject();
@@ -299,8 +294,7 @@ public class ADOIssueTracker implements IssueTracker {
     }
 
     private URI getCreationEndpoint(String adoProject, ScanRequest request) {
-        String baseUrl = request.getAdditionalMetadata(Constants.ADO_BASE_URL_KEY);
-        String urlTemplate = String.format(CREATE_WORK_ITEM_URL_TEMPLATE, baseUrl);
+        String urlTemplate = String.format(CREATE_WORK_ITEM_URL_TEMPLATE, properties.getUrl());
         String workItemType = request.getAdditionalMetadata(Constants.ADO_ISSUE_KEY);
 
         String adoNamespace = determineNamespace(request);
@@ -313,9 +307,7 @@ public class ADOIssueTracker implements IssueTracker {
     }
 
     private URI getSearchEndpoint(String adoProject, ScanRequest request) {
-        String baseUrl = request.getAdditionalMetadata(Constants.ADO_BASE_URL_KEY);
-        String urlTemplate = String.format(SEARCH_WORK_ITEM_URL_TEMPLATE, baseUrl);
-
+        String urlTemplate = String.format(SEARCH_WORK_ITEM_URL_TEMPLATE, properties.getUrl());
         String adoNamespace = determineNamespace(request);
 
         URI result = new DefaultUriBuilderFactory()


### PR DESCRIPTION
### Description

An error occurred during ADO-to-ADO 'push' flow. Namespace appeared twice in API URLs, e.g.
`https://dev.azure.com/MyNamespace/MyNamespace/MyProject/...`
was used instead of
`https://dev.azure.com/MyNamespace/MyProject/...`
As a result, ADO API calls failed.

Fixed by using ADO API base URL from CxFlow config, instead of using account.baseUrl from a webhook request.