### PR TITLE
Pr udi update repo comment seperate comments

### DIFF
--- a/src/main/java/com/checkmarx/flow/bug_tracker_trigger/BugTrackerTriggerEvent.java
+++ b/src/main/java/com/checkmarx/flow/bug_tracker_trigger/BugTrackerTriggerEvent.java
@@ -2,8 +2,6 @@ package com.checkmarx.flow.bug_tracker_trigger;
 
 import com.checkmarx.flow.dto.BugTracker;
 import com.checkmarx.flow.dto.ScanRequest;
-import com.checkmarx.flow.exception.GitHubClientException;
-import com.checkmarx.flow.exception.GitHubClientRunTimeException;
 import com.checkmarx.flow.service.ADOService;
 import com.checkmarx.flow.service.BitBucketService;
 import com.checkmarx.flow.service.GitHubService;
@@ -40,11 +38,7 @@ public class BugTrackerTriggerEvent {
                 break;
 
             case GITHUBPULL:
-                try {
-                    gitService.sendMergeComment(request, SCAN_MESSAGE);
-                } catch (GitHubClientException e) {
-                    throw new GitHubClientRunTimeException(e.getMessage());
-                }
+                gitService.sendMergeComment(request, SCAN_MESSAGE);
                 gitService.startBlockMerge(request, cxProperties.getUrl());
                 break;
 

--- a/src/main/java/com/checkmarx/flow/dto/RepoComment.java
+++ b/src/main/java/com/checkmarx/flow/dto/RepoComment.java
@@ -5,10 +5,15 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.Date;
+
 @Getter
 @Setter
 @AllArgsConstructor
 public class RepoComment {
-    long Id;
+    long id;
     String comment;
+    String commentUrl;
+    Date createdAt;
+    Date updateTime;
 }

--- a/src/main/java/com/checkmarx/flow/service/GitHubService.java
+++ b/src/main/java/com/checkmarx/flow/service/GitHubService.java
@@ -130,23 +130,25 @@ public class GitHubService extends RepoService {
         }
     }
 
-    public void sendMergeComment(ScanRequest request, String comment) throws GitHubClientException {
+    public void sendMergeComment(ScanRequest request, String comment) {
         try {
             RepoComment commentToUpdate = PullRequestCommentsHelper.getCommentToUpdate(getComments(request.getMergeNoteUri()), comment);
             if (commentToUpdate !=  null) {
+                log.debug("Got candidate comment to update. comment: {}", commentToUpdate.getComment());
                 if (!PullRequestCommentsHelper.shouldUpdateComment(comment, commentToUpdate.getComment())) {
-                    log.debug("Comment should not be updated");
+                    log.debug("sendMergeComment: Comment should not be updated");
                     return;
                 }
-                log.debug("Going to update GitHub pull request comment");
+                log.debug("sendMergeComment: Going to update GitHub pull request comment");
                 updateComment(commentToUpdate.getCommentUrl(), comment);
             } else {
-                log.debug("Going to create a new GitHub pull request comment");
+                log.debug("sendMergeComment: Going to create a new GitHub pull request comment");
                 addComment(request, comment);
             }
         }
-        catch (IOException ioe) {
-            throw new GitHubClientException("Error while adding or updating repo pull request comment", ioe);
+        catch (Exception e) {
+            // We "swallow" the exception so that the flow will not be terminated because of errors in GIT comments
+            log.error("Error while adding or updating repo pull request comment", e);
         }
     }
 

--- a/src/main/java/com/checkmarx/flow/service/PullRequestCommentsHelper.java
+++ b/src/main/java/com/checkmarx/flow/service/PullRequestCommentsHelper.java
@@ -1,0 +1,57 @@
+package com.checkmarx.flow.service;
+
+import com.checkmarx.flow.dto.RepoComment;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PullRequestCommentsHelper {
+
+    private static final String COMMENT_TYPE_SCAN_STARTED = "Scan submitted to Checkmarx";
+    private static final String COMMENT_TYPE_FINDINGS_1 = "Checkmarx scan completed";
+    private static final String COMMENT_TYPE_FINDINGS_2 = "Full Scan Details";
+
+    public static boolean isCheckMarxComment(RepoComment comment) {
+        return comment.getComment().contains(COMMENT_TYPE_FINDINGS_2) && comment.getComment().contains(COMMENT_TYPE_FINDINGS_1) ||
+                comment.getComment().contains(COMMENT_TYPE_SCAN_STARTED);
+    }
+
+    public static RepoComment getCommentToUpdate(List<RepoComment> exisitingComments, String newComment) {
+        CommentType commnetType = getCommnetType(newComment);
+        List<RepoComment> relevantComments= getCheckmarxCommentsForType(exisitingComments, commnetType);
+        if (relevantComments.size() == 1) {
+            return relevantComments.get(0);
+        }
+        return null;
+    }
+
+    private static CommentType getCommnetType(String newComment) {
+        if (newComment.contains(COMMENT_TYPE_SCAN_STARTED)) {
+            return CommentType.SCAN_STARTED;
+        }
+        if (newComment.contains(COMMENT_TYPE_FINDINGS_2) &&
+                newComment.contains(COMMENT_TYPE_FINDINGS_1)) {
+            return CommentType.FINDINGS;
+        }
+        return CommentType.UNKNOWN;
+    }
+
+    private static List<RepoComment> getCheckmarxCommentsForType(List<RepoComment> allComments, CommentType commentType) {
+        if (commentType == CommentType.SCAN_STARTED) {
+            return allComments.stream().filter(rc -> rc.getComment().contains(COMMENT_TYPE_SCAN_STARTED)).collect(Collectors.toList());
+        }
+        else if (commentType == CommentType.FINDINGS) {
+            return allComments.stream().filter(rc ->
+                    (rc.getComment().contains(COMMENT_TYPE_FINDINGS_1) && rc.getComment().contains(COMMENT_TYPE_FINDINGS_2))).collect(Collectors.toList());
+        }
+        // We are not supposed to go in here at all.
+        return new ArrayList<>();
+    }
+
+    enum CommentType {
+        SCAN_STARTED,
+        FINDINGS,
+        UNKNOWN;
+    }
+}

--- a/src/main/java/com/checkmarx/flow/service/PullRequestCommentsHelper.java
+++ b/src/main/java/com/checkmarx/flow/service/PullRequestCommentsHelper.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 public class PullRequestCommentsHelper {
 
     private static final String COMMENT_TYPE_SCAN_STARTED = "Scan submitted to Checkmarx";
-    private static final String COMMENT_TYPE_FINDINGS_1 = "Checkmarx scan completed";
+    private static final String COMMENT_TYPE_FINDINGS_1 = "Checkmarx SAST Scan Summary";
     private static final String COMMENT_TYPE_FINDINGS_2 = "Full Scan Details";
 
     public static boolean isCheckMarxComment(RepoComment comment) {
@@ -47,6 +47,16 @@ public class PullRequestCommentsHelper {
         }
         // We are not supposed to go in here at all.
         return new ArrayList<>();
+    }
+
+    public static boolean shouldUpdateComment(String newComment, String oldComment) {
+        if (newComment == null) {
+            if (oldComment == null) {
+                return false;
+            }
+            return true;
+        }
+        return !newComment.equals(oldComment);
     }
 
     enum CommentType {

--- a/src/test/java/com/checkmarx/flow/cucumber/component/pullrequestanalytics/AnalyticsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/pullrequestanalytics/AnalyticsSteps.java
@@ -194,7 +194,7 @@ public class AnalyticsSteps {
                 anyString(), eq(HttpMethod.POST), any(HttpEntity.class), ArgumentMatchers.<Class<String>>any());
 
         when(sendingPostRequest).thenAnswer(invocation -> new ResponseEntity<>(HttpStatus.OK));
-        when(restTemplateMock.exchange(anyString(),eq(HttpMethod.GET),isNull(), any(Class.class) )).thenReturn(createResponseForGetComments());
+        when(restTemplateMock.exchange(anyString(),eq(HttpMethod.GET),any(), any(Class.class) )).thenReturn(createResponseForGetComments());
     }
 
     private ResponseEntity<String> createResponseForGetComments() {

--- a/src/test/java/com/checkmarx/flow/cucumber/component/thresholds/ThresholdsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/thresholds/ThresholdsSteps.java
@@ -231,7 +231,7 @@ public class ThresholdsSteps {
                 anyString(), eq(HttpMethod.POST), any(HttpEntity.class), ArgumentMatchers.<Class<String>>any());
   
         when(sendingPostRequest).thenAnswer(interceptor);
-        when(restTemplateMock.exchange(anyString(),eq(HttpMethod.GET),isNull(), any(Class.class) )).thenReturn(createResponseForGetComments());
+        when(restTemplateMock.exchange(anyString(),eq(HttpMethod.GET),any(), any(Class.class) )).thenReturn(createResponseForGetComments());
     }
 
     private ResponseEntity<String> createResponseForGetComments() {

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
@@ -39,7 +39,10 @@ public class UpdatePullRequestCommentsSteps {
 
 
     public static final int COMMENTS_POLL_INTERVAL = 5;
-    public static final String PULL_REQUEST_COMMENTS_URL = "https://api.github.com/repos/cxflowtestuser/vb_test_udi/issues/2/comments";
+    private static final String GIT_PROJECT_NAME = "vb_test_pr_comments";
+    private static final String GITHUB_PR_BASE_URL = "https://api.github.com/repos/cxflowtestuser/" + GIT_PROJECT_NAME;
+    public static final String PULL_REQUEST_COMMENTS_URL = GITHUB_PR_BASE_URL + "/issues/5/comments";
+    private static final String GIT_URL = "https://github.com/cxflowtestuser/" + GIT_PROJECT_NAME;
     private final GitHubService gitHubService;
     private GitHubController gitHubControllerSpy;
     private final ObjectMapper mapper = new ObjectMapper();
@@ -65,9 +68,9 @@ public class UpdatePullRequestCommentsSteps {
         initHelperServiceMock();
     }
 
-    @Given("branch is udi-tests-2")
+    @Given("branch is pr-comments-tests")
     public void setBranchName() {
-        branch = "udi-tests-2";
+        branch = "pr-comments-tests";
     }
 
     @Given("different filters configuration is set")
@@ -161,7 +164,7 @@ public class UpdatePullRequestCommentsSteps {
     private void initGitHubProperties() {
         this.gitHubProperties.setCxSummary(false);
         this.gitHubProperties.setFlowSummary(false);
-        this.gitHubProperties.setUrl("https://github.com/cxflowtestuser/vb_test_udi");
+        this.gitHubProperties.setUrl(GIT_URL);
         this.gitHubProperties.setWebhookToken("1234");
         this.gitHubProperties.setApiUrl("https://api.github.com/repos");
     }
@@ -187,7 +190,7 @@ public class UpdatePullRequestCommentsSteps {
         pullRequest.setHead(headBranch);
         pullRequest.setBase(new Base());
         pullRequest.setStatusesUrl("");
-        pullRequest.setIssueUrl("https://api.github.com/repos/cxflowtestuser/vb_test_udi/issues/2");
+        pullRequest.setIssueUrl(GITHUB_PR_BASE_URL + "/issues/5");
 
         pullEvent.setPullRequest(pullRequest);
 

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
@@ -1,0 +1,228 @@
+package com.checkmarx.flow.cucumber.integration.pullrequest.updatecomments;
+
+import com.checkmarx.flow.CxFlowApplication;
+import com.checkmarx.flow.config.GitHubProperties;
+import com.checkmarx.flow.controller.GitHubController;
+import com.checkmarx.flow.dto.RepoComment;
+import com.checkmarx.flow.dto.github.*;
+import com.checkmarx.flow.service.GitHubService;
+import com.checkmarx.flow.service.HelperService;
+import com.checkmarx.sdk.dto.ScanResults;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import lombok.extern.slf4j.Slf4j;
+import org.awaitility.Awaitility;
+import org.junit.Assert;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+
+@SpringBootTest(classes = {CxFlowApplication.class})
+@Slf4j
+public class UpdatePullRequestCommentsSteps {
+
+
+    public static final int COMMENTS_POLL_INTERVAL = 5;
+    public static final String PULL_REQUEST_COMMENTS_URL = "https://api.github.com/repos/cxflowtestuser/vb_test_udi/issues/2/comments";
+    private final GitHubService gitHubService;
+    private GitHubController gitHubControllerSpy;
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final GitHubProperties gitHubProperties;
+    private final HelperService helperService;
+    private ScanResults scanResultsToInject;
+
+    private String branch;
+
+    public UpdatePullRequestCommentsSteps(GitHubService gitHubService, GitHubProperties gitHubProperties, GitHubController gitHubController) {
+
+        this.helperService = mock(HelperService.class);
+        this.gitHubService = gitHubService;
+
+        this.gitHubProperties = gitHubProperties;
+        this.gitHubControllerSpy = Mockito.spy(gitHubController);
+        initGitHubProperties();
+    }
+
+    @Before
+    public void initMocks() {
+        initGitHubControllerSpy();
+        initHelperServiceMock();
+    }
+
+    @Given("branch is udi-tests-2")
+    public void setBranchName() {
+        branch = "udi-tests-2";
+    }
+
+    @Given("different filters configuration is set")
+    public void setConfigAsCodeFilters() {
+        gitHubProperties.setConfigAsCode("cx.config.high.json");
+    }
+
+    @Given("no comments on pull request")
+    public void deletePRComments() throws IOException, InterruptedException {
+        List<RepoComment> comments = getRepoComments();
+        for (RepoComment comment: comments) {
+            gitHubService.deleteComment(comment.getCommentUrl());
+        }
+        TimeUnit.SECONDS.sleep(20);
+    }
+
+    private List<RepoComment> getRepoComments() throws IOException {
+        return gitHubService.getComments(PULL_REQUEST_COMMENTS_URL);
+    }
+
+    @When("pull request arrives to CxFlow")
+    public void sendPullRequest() {
+        buildPullRequest();
+    }
+
+    private void validateCommentsUpdated(List<RepoComment> comments) throws IOException {
+        for (RepoComment comment: comments) {
+            Assert.assertTrue("Comment was not updated", isCommentUpdated(comment));
+        }
+    }
+
+    @Then("Wait for comments")
+    public void waitForNewComments() {
+        Awaitility.await().atMost(Duration.ofMinutes(2)).pollInterval(Duration.ofSeconds(COMMENTS_POLL_INTERVAL)).until(this::areThereCommentsAtAll);
+    }
+
+    @Then("verify 2 new comments")
+    public void verify2NewComments() throws IOException {
+        List<RepoComment> comments = getRepoComments();
+        Assert.assertEquals("Wrong number of comments", 2, comments.size());
+        comments.stream().forEach(c -> Assert.assertTrue("Comment is not new (probably updated", isCommentNew(c)));
+
+    }
+
+    @Then("Wait for updated comment")
+    public void waitForUpdatedComment() {
+        Awaitility.await().pollInterval(Duration.ofSeconds(COMMENTS_POLL_INTERVAL)).atMost(Duration.ofSeconds(125)).until(this::isThereUpdatedComment);
+    }
+
+/*    @Then("verify 2 updated comments")
+    public void verify2UpdatedComments() throws IOException {
+        List<RepoComment> comments = getRepoComments();
+        Assert.assertEquals("Wrong number of comments", 2, comments.size());
+        comments.stream().forEach(c -> Assert.assertTrue("Comment is not new (probably updated", isCommentUpdated(c)));
+    }*/
+
+
+    private boolean areThereCommentsAtAll() throws IOException {
+        List<RepoComment> comments = getRepoComments();
+        return comments.size() > 1;
+    }
+
+    private boolean isThereUpdatedComment() throws IOException {
+        List<RepoComment> comments = getRepoComments();
+        for (RepoComment comment: comments) {
+            if (isCommentUpdated(comment)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isCommentNew(RepoComment comment) {
+        return comment.getUpdateTime().equals(comment.getCreatedAt());
+    }
+
+    private boolean isCommentUpdated(RepoComment comment) {
+        return comment.getUpdateTime().after(comment.getCreatedAt());
+    }
+
+    private void initGitHubControllerSpy() {
+        doNothing().when(gitHubControllerSpy).verifyHmacSignature(any(), any());
+    }
+
+    private void initHelperServiceMock() {
+        when(helperService.isBranch2Scan(any(), anyList())).thenReturn(true);
+        when(helperService.getShortUid()).thenReturn("123456");
+    }
+
+
+    private void initGitHubProperties() {
+        this.gitHubProperties.setCxSummary(false);
+        this.gitHubProperties.setFlowSummary(false);
+        this.gitHubProperties.setUrl("https://github.com/cxflowtestuser/vb_test_udi");
+        this.gitHubProperties.setWebhookToken("1234");
+        this.gitHubProperties.setApiUrl("https://api.github.com/repos");
+    }
+
+
+    public void buildPullRequest() {
+        PullEvent pullEvent = new PullEvent();
+        Repository repo = new Repository();
+        repo.setName("vb_test_udi");
+
+        repo.setCloneUrl(gitHubProperties.getUrl());
+        Owner owner = new Owner();
+        owner.setName("");
+        owner.setLogin("cxflowtestuser");
+        repo.setOwner(owner);
+        pullEvent.setRepository(repo);
+        pullEvent.setAction("opened");
+        PullRequest pullRequest = new PullRequest();
+        pullRequest.setIssueUrl("");
+        Head headBranch = new Head();
+        headBranch.setRef(branch);
+
+        pullRequest.setHead(headBranch);
+        pullRequest.setBase(new Base());
+        pullRequest.setStatusesUrl("");
+        pullRequest.setIssueUrl("https://api.github.com/repos/cxflowtestuser/vb_test_udi/issues/2");
+
+        pullEvent.setPullRequest(pullRequest);
+
+        try {
+            String pullEventStr = mapper.writeValueAsString(pullEvent);
+
+            gitHubControllerSpy.pullRequest(
+                    pullEventStr,
+                    "SIGNATURE",
+                    "CX", "VB",
+                    Arrays.asList(branch), null,
+                    null,
+                    null,
+                    "VB",
+                    "\\CxServer\\SP",
+                    null,
+                    "",
+                    "default",
+                    false,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null);
+
+        } catch (JsonProcessingException e) {
+            fail("Unable to parse " + pullEvent.toString());
+        }
+    }
+
+    private class ScanResultsAnswerer implements Answer<ScanResults> {
+        @Override
+        public ScanResults answer(InvocationOnMock invocation) {
+            return scanResultsToInject;
+        }
+    }
+
+}

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsTestRunner.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsTestRunner.java
@@ -1,0 +1,15 @@
+package com.checkmarx.flow.cucumber.integration.pullrequest.updatecomments;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@RunWith(Cucumber.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@CucumberOptions(plugin = { "pretty", "summary", "html:build/cucumber/component/api", "json:build/cucumber/component/api/cucumber.json" },
+        features = "classpath:cucumber/features/integrationTests/pull-request-comments-update.feature",
+        glue = { "com.checkmarx.flow.cucumber.integration.pullrequest.updatecomments" },
+        tags = "@Integration and not @Skip")
+public class UpdatePullRequestCommentsTestRunner {
+}

--- a/src/test/resources/cucumber/features/integrationTests/pull-request-comments-update.feature
+++ b/src/test/resources/cucumber/features/integrationTests/pull-request-comments-update.feature
@@ -1,0 +1,20 @@
+@PullRequestUpdateComment @Integration
+  Feature: After scan that was initiated by pull request, CxFlow should update the PR comments, instead of creating new one.
+
+    Scenario: Pull request arrives to CxFlow, then scan is initiated, pull request should be without comments, and we should verify that the comments are new.
+      Given branch is udi-tests-2
+      And no comments on pull request
+      When pull request arrives to CxFlow
+      Then Wait for comments
+      And verify 2 new comments
+
+
+    Scenario: Pull request arrives to CxFlow, then scan is initiated, and pull request comments should be updated. number of comments should be 2.
+      Given branch is udi-tests-2
+      And no comments on pull request
+      And pull request arrives to CxFlow
+      And Wait for comments
+      And different filters configuration is set
+      When pull request arrives to CxFlow
+      Then Wait for updated comment
+

--- a/src/test/resources/cucumber/features/integrationTests/pull-request-comments-update.feature
+++ b/src/test/resources/cucumber/features/integrationTests/pull-request-comments-update.feature
@@ -2,7 +2,7 @@
   Feature: After scan that was initiated by pull request, CxFlow should update the PR comments, instead of creating new one.
 
     Scenario: Pull request arrives to CxFlow, then scan is initiated, pull request should be without comments, and we should verify that the comments are new.
-      Given branch is udi-tests-2
+      Given branch is pr-comments-tests
       And no comments on pull request
       When pull request arrives to CxFlow
       Then Wait for comments
@@ -10,7 +10,7 @@
 
 
     Scenario: Pull request arrives to CxFlow, then scan is initiated, and pull request comments should be updated. number of comments should be 2.
-      Given branch is udi-tests-2
+      Given branch is pr-comments-tests
       And no comments on pull request
       And pull request arrives to CxFlow
       And Wait for comments


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ts/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> CxFlow used to add comments to PR every time a scan was initiated for the PR. This caused a lot of verbosity in the PR page. Now CxFlow updates existing comments to reduce verbosity.

### References

> https://github.com/checkmarx-ltd/cx-flow/issues/185

### Testing

> There are two automation (integration) tests. First tests a PR without any comments and validates that there are two CxFlow comments. Second test tests for a PR that already have comments, and validates that one comment is updated.
> To test manually, you should add a webhook that points t CxFlow machine. open a pull request, and CxFlow should scan and create/update the comments in the PR

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
