### PR TITLE
Fix for issue where GitLabIssueTrack would sometimes find the wrong project when searching for exciting project information

### DIFF
--- a/src/main/java/com/checkmarx/flow/custom/GitLabIssueTracker.java
+++ b/src/main/java/com/checkmarx/flow/custom/GitLabIssueTracker.java
@@ -79,8 +79,14 @@ public class GitLabIssueTracker implements IssueTracker {
             HttpEntity httpEntity = new HttpEntity<>(createAuthHeaders());
             ResponseEntity<String> response = restTemplate.exchange(uri, HttpMethod.GET, httpEntity, String.class);
             JSONArray arr = new JSONArray(response.getBody());
-            JSONObject obj = (JSONObject)arr.get(0);
-            return obj.getInt("id");
+            for(Object obj: arr){
+                JSONObject realObj = (JSONObject) obj;
+                String name = realObj.getString("name");
+                if(name.equals(repoName)) {
+                    return realObj.getInt("id");
+                }
+            }
+            return 0;
         } catch(HttpClientErrorException e) {
             log.error("Error calling gitlab project api {}", e.getResponseBodyAsString(), e);
         } catch(JSONException e) {
@@ -90,7 +96,6 @@ public class GitLabIssueTracker implements IssueTracker {
         }
         return UNKNOWN_INT;
     }
-
 
     /**
      * Get list of issues associated with the project in GitLab


### PR DESCRIPTION
GitLabIssueTrack would sometimes find the wrong project when searching for exciting project information. The API call returns a list of all Projects that match the string being searched for but the code assumed that an exact match would occur and only one project would ever be returned. This resulted in situations where issues were sometimes being cut to the wrong project. For example when searching for: dvna-0429-1 the API would return dvna-0429-1 but also projects with names dvna-0429-11 and dvna-0429-10. If dvna-0429-1 was the first project in the list then the wrong project would be selected.


By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ts/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change.

### References

> Include supporting link to GitHub Issue/PR number

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used
