### PR TITLE
fix bug #140 duplicated issues

### DIFF
--- a/src/main/java/com/checkmarx/flow/custom/GitHubIssueTracker.java
+++ b/src/main/java/com/checkmarx/flow/custom/GitHubIssueTracker.java
@@ -96,7 +96,7 @@ public class GitHubIssueTracker implements IssueTracker {
                     httpEntity, com.checkmarx.flow.dto.github.Issue[].class);
 
             if (responsePage.getBody() != null) {
-                for (com.checkmarx.flow.dto.github.Issue issue : response.getBody()) {
+                for (com.checkmarx.flow.dto.github.Issue issue : responsePage.getBody()) {
                     Issue i = mapToIssue(issue);
                     if (i != null && i.getTitle().startsWith(request.getProduct().getProduct())) {
                         issues.add(i);

--- a/src/main/java/com/checkmarx/flow/custom/GitLabIssueTracker.java
+++ b/src/main/java/com/checkmarx/flow/custom/GitLabIssueTracker.java
@@ -132,8 +132,10 @@ public class GitLabIssueTracker implements IssueTracker {
         String endpoint = properties.getApiUrl().concat(ISSUES_PATH);
         ResponseEntity<com.checkmarx.flow.dto.gitlab.Issue[]> response = restTemplate.exchange(endpoint,
                 HttpMethod.GET, httpEntity, com.checkmarx.flow.dto.gitlab.Issue[].class, request.getRepoProjectId());
-        if(response.getBody() == null) return new ArrayList<>();
-        for (com.checkmarx.flow.dto.gitlab.Issue issue : response.getBody()) {
+        if(response.getBody() == null) {
+            return issues;
+        }
+        for(com.checkmarx.flow.dto.gitlab.Issue issue: response.getBody()){
             Issue i = mapToIssue(issue);
             if (i != null) {
                 issues.add(i);
@@ -141,9 +143,9 @@ public class GitLabIssueTracker implements IssueTracker {
         }
         String next = getNextURIFromHeaders(response.getHeaders(), "link", "next");
         while (next != null) {
-            ResponseEntity<Issue[]> responsePage = restTemplate.exchange(next, HttpMethod.GET, httpEntity, Issue[].class);
+            ResponseEntity<com.checkmarx.flow.dto.gitlab.Issue[]> responsePage = restTemplate.exchange(next, HttpMethod.GET, httpEntity, com.checkmarx.flow.dto.gitlab.Issue[].class);
             if(responsePage.getBody() != null) {
-                for(com.checkmarx.flow.dto.gitlab.Issue issue: response.getBody()){
+                for(com.checkmarx.flow.dto.gitlab.Issue issue: responsePage.getBody()){
                     Issue i = mapToIssue(issue);
                     if(i != null && i.getTitle().startsWith(request.getProduct().getProduct())){
                         issues.add(i);


### PR DESCRIPTION
### Description
There was a bug in the way cx-flow loaded issues from GitHub and GitLab, it used pagination's of 100 issues per page, but read the issues only from the first page.

performing a scan with more than 100 xissues repeatedly, created new issues in each run. 

### References

https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/140/

### Testing

tested on a GitHub repo with 286 issues and a scan with 113 xissues + debug to confirm all issues and xissues correspond to expected.

manual steps for testing end-to-end or functionality not covered by unit/integration tests:
* create a repo with over 100 issues (I used a subset of OWASP benchmark)
* run scan multiple times
* verify that no new bugs are opened after first run.

### Checklist
- this is a bug, no change in documentation is needed
- test reproduced on master (1.6.1) and develop, and stopped with this fix. 
