### PR TITLE
Encapsulate webhook controller arguments into a single class

### DIFF
--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -169,7 +169,7 @@ public class CxFlowRunner implements ApplicationRunner {
         }
 
         ControllerRequest controllerRequest = new ControllerRequest(severity, cwe, category, status);
-        FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
+        FilterConfiguration filter = filterFactory.getFilter(controllerRequest, flowProperties);
 
         //Adding default file/folder exclusions from properties if they are not provided as an override
         if(excludeFiles == null && !ScanUtils.empty(cxProperties.getExcludeFiles())){

--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -1,10 +1,7 @@
 package com.checkmarx.flow;
 
 import com.checkmarx.flow.config.*;
-import com.checkmarx.flow.dto.BugTracker;
-import com.checkmarx.flow.dto.ExitCode;
-import com.checkmarx.flow.dto.FlowOverride;
-import com.checkmarx.flow.dto.ScanRequest;
+import com.checkmarx.flow.dto.*;
 import com.checkmarx.flow.exception.ExitThrowable;
 import com.checkmarx.flow.service.*;
 import com.checkmarx.flow.utils.ScanUtils;
@@ -171,7 +168,8 @@ public class CxFlowRunner implements ApplicationRunner {
             exit(1);
         }
 
-        FilterConfiguration filter = filterFactory.getFilter(severity, cwe, category, status, null, flowProperties);
+        ControllerRequest controllerRequest = new ControllerRequest(severity, cwe, category, status);
+        FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
 
         //Adding default file/folder exclusions from properties if they are not provided as an override
         if(excludeFiles == null && !ScanUtils.empty(cxProperties.getExcludeFiles())){
@@ -326,8 +324,8 @@ public class CxFlowRunner implements ApplicationRunner {
         else if(bbs){
             request.setRepoType(ScanRequest.Repository.BITBUCKETSERVER);
             if(repoUrl != null) {
-                repoUrl = repoUrl.replaceAll("\\/scm\\/", "/projects/");
-                repoUrl = repoUrl.replaceAll("\\/[\\w-]+.git$", "/repos$0");
+                repoUrl = repoUrl.replace("/scm/", "/projects/");
+                repoUrl = repoUrl.replaceAll("/[\\w-]+.git$", "/repos$0");
                 repoUrl = repoUrl.replaceAll(".git$", "");
                 repoUrl = repoUrl.concat("/browse");
             }

--- a/src/main/java/com/checkmarx/flow/controller/ADOController.java
+++ b/src/main/java/com/checkmarx/flow/controller/ADOController.java
@@ -111,7 +111,7 @@ public class ADOController extends AdoControllerBase {
 
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
 
-            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, flowProperties);
 
             setExclusionProperties(cxProperties, controllerRequest);
 
@@ -223,7 +223,7 @@ public class ADOController extends AdoControllerBase {
 
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
 
-            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, flowProperties);
 
             setExclusionProperties(cxProperties, controllerRequest);
 

--- a/src/main/java/com/checkmarx/flow/controller/ADOController.java
+++ b/src/main/java/com/checkmarx/flow/controller/ADOController.java
@@ -10,7 +10,6 @@ import com.checkmarx.flow.service.FilterFactory;
 import com.checkmarx.flow.service.FlowService;
 import com.checkmarx.flow.service.HelperService;
 import com.checkmarx.flow.utils.ScanUtils;
-import com.checkmarx.sdk.config.Constants;
 import com.checkmarx.sdk.config.CxProperties;
 import com.checkmarx.sdk.dto.filtering.FilterConfiguration;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +27,7 @@ import java.util.*;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping(value = "/")
-public class ADOController extends WebhookController{
+public class ADOController extends AdoControllerBase {
     private static final String HTTP = "http://";
     private static final String HTTPS = "https://";
     private static final List<String> PULL_EVENT = Arrays.asList("git.pullrequest.created", "git.pullrequest.updated");
@@ -58,7 +57,7 @@ public class ADOController extends WebhookController{
         log.info("Processing Azure PULL request");
         validateBasicAuth(auth);
         controllerRequest = ensureNotNull(controllerRequest);
-        adoDetailsRequest = ensureAdoDetailsNotNull(adoDetailsRequest);
+        adoDetailsRequest = ensureDetailsNotNull(adoDetailsRequest);
 
         if(!PULL_EVENT.contains(body.getEventType()) || !body.getResource().getStatus().equals("active")){
             log.info("Pull requested not processed.  Event was not opened ({})", body.getEventType());
@@ -184,7 +183,7 @@ public class ADOController extends WebhookController{
         log.info("Processing Azure Push request");
         validateBasicAuth(auth);
         controllerRequest = ensureNotNull(controllerRequest);
-        adoDetailsRequest = ensureAdoDetailsNotNull(adoDetailsRequest);
+        adoDetailsRequest = ensureDetailsNotNull(adoDetailsRequest);
 
         FlowOverride o = ScanUtils.getMachinaOverride(controllerRequest.getOverride());
 
@@ -327,17 +326,5 @@ public class ADOController extends WebhookController{
         if (ScanUtils.empty(request.getAdoClosed())) {
             request.setAdoClosed(properties.getClosedStatus());
         }
-    }
-
-    private static void addMetadataToScanRequest(AdoDetailsRequest source, ScanRequest target) {
-        target.putAdditionalMetadata(Constants.ADO_ISSUE_KEY, source.getAdoIssue());
-        target.putAdditionalMetadata(Constants.ADO_ISSUE_BODY_KEY, source.getAdoBody());
-        target.putAdditionalMetadata(Constants.ADO_OPENED_STATE_KEY, source.getAdoOpened());
-        target.putAdditionalMetadata(Constants.ADO_CLOSED_STATE_KEY, source.getAdoClosed());
-    }
-
-    private static AdoDetailsRequest ensureAdoDetailsNotNull(AdoDetailsRequest requestToCheck) {
-        return Optional.ofNullable(requestToCheck)
-                .orElseGet(() -> AdoDetailsRequest.builder().build());
     }
 }

--- a/src/main/java/com/checkmarx/flow/controller/ADOController.java
+++ b/src/main/java/com/checkmarx/flow/controller/ADOController.java
@@ -107,13 +107,13 @@ public class ADOController extends WebhookController{
             String currentBranch = ScanUtils.getBranchFromRef(ref);
             String targetBranch = ScanUtils.getBranchFromRef(resource.getTargetRefName());
 
-            List<String> branches = getBranches(controllerRequest.getBranch(), flowProperties);
+            List<String> branches = getBranches(controllerRequest, flowProperties);
 
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
 
             FilterConfiguration filter = filterFactory.getFilter(controllerRequest.getSeverity(), controllerRequest.getCwe(), controllerRequest.getCategory(), controllerRequest.getStatus(), null, flowProperties);
 
-            setExclusionProperties(controllerRequest, cxProperties);
+            setExclusionProperties(cxProperties, controllerRequest);
 
             //build request object
             String gitUrl = repository.getWebUrl();
@@ -164,7 +164,7 @@ public class ADOController extends WebhookController{
             return getBadRequestMessage(e, controllerRequest, product);
         }
 
-        return getSuccessResponse();
+        return getSuccessMessage();
     }
 
     /**
@@ -202,11 +202,8 @@ public class ADOController extends WebhookController{
             }
 
             //set the default bug tracker as per yml
-            BugTracker.Type bugType;
-            if (ScanUtils.empty(controllerRequest.getBug())) {
-                controllerRequest.setBug(flowProperties.getBugTracker());
-            }
-            bugType = ScanUtils.getBugTypeEnum(controllerRequest.getBug(), flowProperties.getBugTrackerImpl());
+            setBugTracker(flowProperties, controllerRequest);
+            BugTracker.Type bugType = ScanUtils.getBugTypeEnum(controllerRequest.getBug(), flowProperties.getBugTrackerImpl());
 
             initAdoSpecificParams(adoDetailsRequest);
 
@@ -222,13 +219,13 @@ public class ADOController extends WebhookController{
             String ref = resource.getRefUpdates().get(0).getName();
             String currentBranch = ScanUtils.getBranchFromRef(ref);
 
-            List<String> branches = getBranches(controllerRequest.getBranch(), flowProperties);
+            List<String> branches = getBranches(controllerRequest, flowProperties);
 
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
 
             FilterConfiguration filter = filterFactory.getFilter(controllerRequest.getSeverity(), controllerRequest.getCwe(), controllerRequest.getCategory(), controllerRequest.getStatus(), null, flowProperties);
 
-            setExclusionProperties(controllerRequest, cxProperties);
+            setExclusionProperties(cxProperties, controllerRequest);
 
             List<String> emails = determineEmails(resource);
 
@@ -287,7 +284,7 @@ public class ADOController extends WebhookController{
             return getBadRequestMessage(e, controllerRequest, product);
         }
 
-        return getSuccessResponse();
+        return getSuccessMessage();
     }
 
     private List<String> determineEmails(Resource resource) {

--- a/src/main/java/com/checkmarx/flow/controller/ADOController.java
+++ b/src/main/java/com/checkmarx/flow/controller/ADOController.java
@@ -111,7 +111,7 @@ public class ADOController extends AdoControllerBase {
 
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
 
-            FilterConfiguration filter = filterFactory.getFilter(controllerRequest.getSeverity(), controllerRequest.getCwe(), controllerRequest.getCategory(), controllerRequest.getStatus(), null, flowProperties);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
 
             setExclusionProperties(cxProperties, controllerRequest);
 
@@ -223,7 +223,7 @@ public class ADOController extends AdoControllerBase {
 
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
 
-            FilterConfiguration filter = filterFactory.getFilter(controllerRequest.getSeverity(), controllerRequest.getCwe(), controllerRequest.getCategory(), controllerRequest.getStatus(), null, flowProperties);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
 
             setExclusionProperties(cxProperties, controllerRequest);
 

--- a/src/main/java/com/checkmarx/flow/controller/AdoControllerBase.java
+++ b/src/main/java/com/checkmarx/flow/controller/AdoControllerBase.java
@@ -12,7 +12,7 @@ public abstract class AdoControllerBase extends WebhookController {
                 .orElseGet(() -> AdoDetailsRequest.builder().build());
     }
 
-   protected void addMetadataToScanRequest(AdoDetailsRequest source, ScanRequest target) {
+    protected void addMetadataToScanRequest(AdoDetailsRequest source, ScanRequest target) {
         target.putAdditionalMetadata(Constants.ADO_ISSUE_KEY, source.getAdoIssue());
         target.putAdditionalMetadata(Constants.ADO_ISSUE_BODY_KEY, source.getAdoBody());
         target.putAdditionalMetadata(Constants.ADO_OPENED_STATE_KEY, source.getAdoOpened());

--- a/src/main/java/com/checkmarx/flow/controller/AdoControllerBase.java
+++ b/src/main/java/com/checkmarx/flow/controller/AdoControllerBase.java
@@ -1,0 +1,21 @@
+package com.checkmarx.flow.controller;
+
+import com.checkmarx.flow.dto.ScanRequest;
+import com.checkmarx.flow.dto.azure.AdoDetailsRequest;
+import com.checkmarx.sdk.config.Constants;
+
+import java.util.Optional;
+
+public abstract class AdoControllerBase extends WebhookController {
+    protected AdoDetailsRequest ensureDetailsNotNull(AdoDetailsRequest requestToCheck) {
+        return Optional.ofNullable(requestToCheck)
+                .orElseGet(() -> AdoDetailsRequest.builder().build());
+    }
+
+   protected void addMetadataToScanRequest(AdoDetailsRequest source, ScanRequest target) {
+        target.putAdditionalMetadata(Constants.ADO_ISSUE_KEY, source.getAdoIssue());
+        target.putAdditionalMetadata(Constants.ADO_ISSUE_BODY_KEY, source.getAdoBody());
+        target.putAdditionalMetadata(Constants.ADO_OPENED_STATE_KEY, source.getAdoOpened());
+        target.putAdditionalMetadata(Constants.ADO_CLOSED_STATE_KEY, source.getAdoClosed());
+    }
+}

--- a/src/main/java/com/checkmarx/flow/controller/BitbucketCloudController.java
+++ b/src/main/java/com/checkmarx/flow/controller/BitbucketCloudController.java
@@ -86,7 +86,7 @@ public class BitbucketCloudController extends WebhookController {
 
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
 
-            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, flowProperties);
 
             setExclusionProperties(cxProperties, controllerRequest);
 
@@ -179,7 +179,7 @@ public class BitbucketCloudController extends WebhookController {
 
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
 
-            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, flowProperties);
 
             setExclusionProperties(cxProperties, controllerRequest);
 

--- a/src/main/java/com/checkmarx/flow/controller/BitbucketCloudController.java
+++ b/src/main/java/com/checkmarx/flow/controller/BitbucketCloudController.java
@@ -3,10 +3,7 @@ package com.checkmarx.flow.controller;
 import com.checkmarx.flow.config.BitBucketProperties;
 import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.config.JiraProperties;
-import com.checkmarx.flow.dto.BugTracker;
-import com.checkmarx.flow.dto.EventResponse;
-import com.checkmarx.flow.dto.FlowOverride;
-import com.checkmarx.flow.dto.ScanRequest;
+import com.checkmarx.flow.dto.*;
 import com.checkmarx.flow.dto.bitbucket.*;
 import com.checkmarx.flow.exception.InvalidTokenException;
 import com.checkmarx.flow.service.FilterFactory;
@@ -19,20 +16,17 @@ import com.checkmarx.sdk.dto.filtering.FilterConfiguration;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.MDC;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.beans.ConstructorProperties;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping(value = "/" )
-public class BitbucketCloudController {
+public class BitbucketCloudController extends WebhookController {
 
     private static final String EVENT = "X-Event-Key";
     private static final String PUSH = EVENT + "=repo:push";
@@ -54,22 +48,7 @@ public class BitbucketCloudController {
     public ResponseEntity<EventResponse> pushRequest(
             @RequestBody MergeEvent body,
             @PathVariable(value = "product", required = false) String product,
-            @RequestParam(value = "application", required = false) String application,
-            @RequestParam(value = "branch", required = false) List<String> branch,
-            @RequestParam(value = "severity", required = false) List<String> severity,
-            @RequestParam(value = "cwe", required = false) List<String> cwe,
-            @RequestParam(value = "category", required = false) List<String> category,
-            @RequestParam(value = "project", required = false) String project,
-            @RequestParam(value = "team", required = false) String team,
-            @RequestParam(value = "status", required = false) List<String> status,
-            @RequestParam(value = "assignee", required = false) String assignee,
-            @RequestParam(value = "preset", required = false) String preset,
-            @RequestParam(value = "incremental", required = false) Boolean incremental,
-            @RequestParam(value = "exclude-files", required = false) List<String> excludeFiles,
-            @RequestParam(value = "exclude-folders", required = false) List<String> excludeFolders,
-            @RequestParam(value = "override", required = false) String override,
-            @RequestParam(value = "bug", required = false) String bug,
-            @RequestParam(value = "app-only", required = false) Boolean appOnlyTracking,
+            ControllerRequest controllerRequest,
             @RequestParam(value = "token") String token
 
     ){
@@ -77,22 +56,23 @@ public class BitbucketCloudController {
         MDC.put("cx", uid);
         validateBitBucketRequest(token);
         log.info("Processing BitBucket MERGE request");
-        FlowOverride o = ScanUtils.getMachinaOverride(override);
+        FlowOverride o = ScanUtils.getMachinaOverride(controllerRequest.getOverride());
+        controllerRequest = ensureNotNull(controllerRequest);
 
         try {
             Repository repository = body.getRepository();
             String app = repository.getName();
-            if(!ScanUtils.empty(application)){
-                app = application;
+            if(!ScanUtils.empty(controllerRequest.getApplication())){
+                app = controllerRequest.getApplication();
             }
 
             BugTracker.Type bugType = BugTracker.Type.BITBUCKETPULL;
-            if(!ScanUtils.empty(bug)){
-                bugType = ScanUtils.getBugTypeEnum(bug, flowProperties.getBugTrackerImpl());
+            if (!ScanUtils.empty(controllerRequest.getBug())) {
+                bugType = ScanUtils.getBugTypeEnum(controllerRequest.getBug(), flowProperties.getBugTrackerImpl());
             }
 
-            if(appOnlyTracking != null){
-                flowProperties.setTrackApplicationOnly(appOnlyTracking);
+            if(controllerRequest.getAppOnly() != null){
+                flowProperties.setTrackApplicationOnly(controllerRequest.getAppOnly());
             }
 
             if(ScanUtils.empty(product)){
@@ -102,44 +82,28 @@ public class BitbucketCloudController {
             Pullrequest pullRequest = body.getPullrequest();
             String currentBranch = pullRequest.getSource().getBranch().getName();
             String targetBranch = pullRequest.getDestination().getBranch().getName();
-            List<String> branches = new ArrayList<>();
+            List<String> branches = getBranches(controllerRequest, flowProperties);
 
-            if(!ScanUtils.empty(branch)){
-                branches.addAll(branch);
-            }
-            else if(!ScanUtils.empty(flowProperties.getBranches())){
-                branches.addAll(flowProperties.getBranches());
-            }
+            BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
 
-            BugTracker bt = ScanUtils.getBugTracker(assignee, bugType, jiraProperties, bug);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest.getSeverity(), controllerRequest.getCwe(), controllerRequest.getCategory(), controllerRequest.getStatus(), null, flowProperties);
 
-            FilterConfiguration filter = filterFactory.getFilter(severity, cwe, category, status, null, flowProperties);
-
-            if(excludeFiles == null && !ScanUtils.empty(cxProperties.getExcludeFiles())){
-                excludeFiles = Arrays.asList(cxProperties.getExcludeFiles().split(","));
-            }
-            if(excludeFolders == null && !ScanUtils.empty(cxProperties.getExcludeFolders())){
-                excludeFolders = Arrays.asList(cxProperties.getExcludeFolders().split(","));
-            }
+            setExclusionProperties(cxProperties, controllerRequest);
 
             String gitUrl = repository.getLinks().getHtml().getHref().concat(".git");
             String mergeEndpoint = pullRequest.getLinks().getComments().getHref();
 
             String scanPreset = cxProperties.getScanPreset();
-            if(!ScanUtils.empty(preset)){
-                scanPreset = preset;
-            }
-            boolean inc = cxProperties.getIncremental();
-            if(incremental != null){
-                inc = incremental;
+            if(!ScanUtils.empty(controllerRequest.getPreset())){
+                scanPreset = controllerRequest.getPreset();
             }
 
             ScanRequest request = ScanRequest.builder()
                     .application(app)
                     .product(p)
-                    .project(project)
-                    .team(team)
-                    .namespace(repository.getOwner().getDisplayName().replaceAll(" ","_"))
+                    .project(controllerRequest.getProject())
+                    .team(controllerRequest.getTeam())
+                    .namespace(repository.getOwner().getDisplayName().replace(" ","_"))
                     .repoName(repository.getName())
                     .repoUrl(gitUrl)
                     .repoUrlWithAuth(gitUrl.replace(Constants.HTTPS, Constants.HTTPS.concat(properties.getToken()).concat("@")))
@@ -149,10 +113,10 @@ public class BitbucketCloudController {
                     .mergeNoteUri(mergeEndpoint)
                     .refs(Constants.CX_BRANCH_PREFIX.concat(currentBranch))
                     .email(null)
-                    .incremental(inc)
+                    .incremental(isScanIncremental(controllerRequest, cxProperties))
                     .scanPreset(scanPreset)
-                    .excludeFolders(excludeFolders)
-                    .excludeFiles(excludeFiles)
+                    .excludeFolders(controllerRequest.getExcludeFolders())
+                    .excludeFiles(controllerRequest.getExcludeFiles())
                     .bugTracker(bt)
                     .filter(filter)
                     .build();
@@ -161,24 +125,14 @@ public class BitbucketCloudController {
             request.putAdditionalMetadata(ScanUtils.WEB_HOOK_PAYLOAD, body.toString());
             request.setId(uid);
 
-            if(helperService.isBranch2Scan(request, branches)){
+            if (helperService.isBranch2Scan(request, branches)) {
                 flowService.initiateAutomation(request);
             }
 
-        }catch (IllegalArgumentException e){
-            String errorMessage = "Error submitting Scan Request.  Product or Bugtracker option incorrect ".concat(product != null ? product : "").concat(" | ").concat(bug != null ? bug : "");
-            log.error(errorMessage, e);
-            ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
-
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(EventResponse.builder()
-                    .message(errorMessage)
-                    .success(false)
-                    .build());
+        } catch (IllegalArgumentException e) {
+            return getBadRequestMessage(e, controllerRequest, product);
         }
-        return ResponseEntity.status(HttpStatus.OK).body(EventResponse.builder()
-                .message("Scan Request Successfully Submitted")
-                .success(true)
-                .build());
+        return getSuccessMessage();
     }
 
 
@@ -189,47 +143,30 @@ public class BitbucketCloudController {
     public ResponseEntity<EventResponse> pushRequest(
             @RequestBody PushEvent body,
             @PathVariable(value = "product", required = false) String product,
-            @RequestParam(value = "application", required = false) String application,
-            @RequestParam(value = "branch", required = false) List<String> branch,
-            @RequestParam(value = "severity", required = false) List<String> severity,
-            @RequestParam(value = "cwe", required = false) List<String> cwe,
-            @RequestParam(value = "category", required = false) List<String> category,
-            @RequestParam(value = "project", required = false) String project,
-            @RequestParam(value = "team", required = false) String team,
-            @RequestParam(value = "status", required = false) List<String> status,
-            @RequestParam(value = "assignee", required = false) String assignee,
-            @RequestParam(value = "preset", required = false) String preset,
-            @RequestParam(value = "incremental", required = false) Boolean incremental,
-            @RequestParam(value = "exclude-files", required = false) List<String> excludeFiles,
-            @RequestParam(value = "exclude-folders", required = false) List<String> excludeFolders,
-            @RequestParam(value = "override", required = false) String override,
-            @RequestParam(value = "bug", required = false) String bug,
-            @RequestParam(value = "app-only", required = false) Boolean appOnlyTracking,
+            ControllerRequest controllerRequest,
             @RequestParam(value = "token") String token
 
     ){
         String uid = helperService.getShortUid();
         MDC.put("cx", uid);
         validateBitBucketRequest(token);
+        controllerRequest = ensureNotNull(controllerRequest);
 
-        FlowOverride o = ScanUtils.getMachinaOverride(override);
+        FlowOverride o = ScanUtils.getMachinaOverride(controllerRequest.getOverride());
 
         try {
             Repository repository = body.getRepository();
             String app = repository.getName();
-            if(!ScanUtils.empty(application)){
-                app = application;
+            if(!ScanUtils.empty(controllerRequest.getApplication())){
+                app = controllerRequest.getApplication();
             }
 
             //set the default bug tracker as per yml
-            BugTracker.Type bugType;
-            if (ScanUtils.empty(bug)) {
-                bug =  flowProperties.getBugTracker();
-            }
-            bugType = ScanUtils.getBugTypeEnum(bug, flowProperties.getBugTrackerImpl());
+            setBugTracker(flowProperties, controllerRequest);
+            BugTracker.Type bugType = ScanUtils.getBugTypeEnum(controllerRequest.getBug(), flowProperties.getBugTrackerImpl());
 
-            if(appOnlyTracking != null){
-                flowProperties.setTrackApplicationOnly(appOnlyTracking);
+            if(controllerRequest.getAppOnly() != null){
+                flowProperties.setTrackApplicationOnly(controllerRequest.getAppOnly());
             }
 
             if(ScanUtils.empty(product)){
@@ -238,25 +175,13 @@ public class BitbucketCloudController {
             ScanRequest.Product p = ScanRequest.Product.valueOf(product.toUpperCase(Locale.ROOT));
             List<Change> changeList =  body.getPush().getChanges();
             String currentBranch = changeList.get(0).getNew().getName();
-            List<String> branches = new ArrayList<>();
+            List<String> branches = getBranches(controllerRequest, flowProperties);
 
-            if(!ScanUtils.empty(branch)){
-                branches.addAll(branch);
-            }
-            else if(!ScanUtils.empty(flowProperties.getBranches())){
-                branches.addAll(flowProperties.getBranches());
-            }
+            BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
 
-            BugTracker bt = ScanUtils.getBugTracker(assignee, bugType, jiraProperties, bug);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest.getSeverity(), controllerRequest.getCwe(), controllerRequest.getCategory(), controllerRequest.getStatus(), null, flowProperties);
 
-            FilterConfiguration filter = filterFactory.getFilter(severity, cwe, category, status, null, flowProperties);
-
-            if(excludeFiles == null && !ScanUtils.empty(cxProperties.getExcludeFiles())){
-                excludeFiles = Arrays.asList(cxProperties.getExcludeFiles().split(","));
-            }
-            if(excludeFolders == null && !ScanUtils.empty(cxProperties.getExcludeFolders())){
-                excludeFolders = Arrays.asList(cxProperties.getExcludeFolders().split(","));
-            }
+            setExclusionProperties(cxProperties, controllerRequest);
 
             /*Determine emails*/
             List<String> emails = new ArrayList<>();
@@ -273,20 +198,16 @@ public class BitbucketCloudController {
             String gitUrl = repository.getLinks().getHtml().getHref().concat(".git");
 
             String scanPreset = cxProperties.getScanPreset();
-            if(!ScanUtils.empty(preset)){
-                scanPreset = preset;
-            }
-            boolean inc = cxProperties.getIncremental();
-            if(incremental != null){
-                inc = incremental;
+            if(!ScanUtils.empty(controllerRequest.getPreset())){
+                scanPreset = controllerRequest.getPreset();
             }
 
             ScanRequest request = ScanRequest.builder()
                     .application(app)
                     .product(p)
-                    .project(project)
-                    .team(team)
-                    .namespace(repository.getOwner().getDisplayName().replaceAll(" ","_"))
+                    .project(controllerRequest.getProject())
+                    .team(controllerRequest.getTeam())
+                    .namespace(repository.getOwner().getDisplayName().replace(" ","_"))
                     .repoName(repository.getName())
                     .repoUrl(gitUrl)
                     .repoUrlWithAuth(gitUrl.replace(Constants.HTTPS, Constants.HTTPS.concat(properties.getToken()).concat("@")))
@@ -294,10 +215,10 @@ public class BitbucketCloudController {
                     .branch(currentBranch)
                     .refs(Constants.CX_BRANCH_PREFIX.concat(currentBranch))
                     .email(emails)
-                    .incremental(inc)
+                    .incremental(isScanIncremental(controllerRequest, cxProperties))
                     .scanPreset(scanPreset)
-                    .excludeFolders(excludeFolders)
-                    .excludeFiles(excludeFiles)
+                    .excludeFolders(controllerRequest.getExcludeFolders())
+                    .excludeFiles(controllerRequest.getExcludeFiles())
                     .bugTracker(bt)
                     .filter(filter)
                     .build();
@@ -306,30 +227,17 @@ public class BitbucketCloudController {
             request.putAdditionalMetadata(ScanUtils.WEB_HOOK_PAYLOAD, body.toString());
             request.setId(uid);
 
-            if(helperService.isBranch2Scan(request, branches)){
+            if (helperService.isBranch2Scan(request, branches)) {
                 flowService.initiateAutomation(request);
             }
-
-
-        }catch (IllegalArgumentException e){
-            String errorMessage = "Error submitting Scan Request.  Product or Bugtracker option incorrect ".concat(product != null ? product : "").concat(" | ").concat(bug != null ? bug : "");
-            log.error(errorMessage, e);
-            ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
-
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(EventResponse.builder()
-                    .message(errorMessage)
-                    .success(false)
-                    .build());
+        } catch (IllegalArgumentException e) {
+            return getBadRequestMessage(e, controllerRequest, product);
         }
-        return ResponseEntity.status(HttpStatus.OK).body(EventResponse.builder()
-                .message("Scan Request Successfully Submitted")
-                .success(true)
-                .build());
+        return getSuccessMessage();
     }
 
     /**
      * Token/Credential validation
-     * @param token
      */
     private void validateBitBucketRequest(String token){
         log.info("Validating BitBucket request token");

--- a/src/main/java/com/checkmarx/flow/controller/BitbucketCloudController.java
+++ b/src/main/java/com/checkmarx/flow/controller/BitbucketCloudController.java
@@ -86,7 +86,7 @@ public class BitbucketCloudController extends WebhookController {
 
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
 
-            FilterConfiguration filter = filterFactory.getFilter(controllerRequest.getSeverity(), controllerRequest.getCwe(), controllerRequest.getCategory(), controllerRequest.getStatus(), null, flowProperties);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
 
             setExclusionProperties(cxProperties, controllerRequest);
 
@@ -179,7 +179,7 @@ public class BitbucketCloudController extends WebhookController {
 
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
 
-            FilterConfiguration filter = filterFactory.getFilter(controllerRequest.getSeverity(), controllerRequest.getCwe(), controllerRequest.getCategory(), controllerRequest.getStatus(), null, flowProperties);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
 
             setExclusionProperties(cxProperties, controllerRequest);
 

--- a/src/main/java/com/checkmarx/flow/controller/BitbucketServerController.java
+++ b/src/main/java/com/checkmarx/flow/controller/BitbucketServerController.java
@@ -168,7 +168,7 @@ public class BitbucketServerController extends WebhookController {
 
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
 
-            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, flowProperties);
 
             setExclusionProperties(cxProperties, controllerRequest);
 
@@ -290,7 +290,7 @@ public class BitbucketServerController extends WebhookController {
             List<String> branches = getBranches(controllerRequest, flowProperties);
 
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
-            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, flowProperties);
 
             setExclusionProperties(cxProperties, controllerRequest);
 

--- a/src/main/java/com/checkmarx/flow/controller/BitbucketServerController.java
+++ b/src/main/java/com/checkmarx/flow/controller/BitbucketServerController.java
@@ -3,10 +3,7 @@ package com.checkmarx.flow.controller;
 import com.checkmarx.flow.config.BitBucketProperties;
 import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.config.JiraProperties;
-import com.checkmarx.flow.dto.BugTracker;
-import com.checkmarx.flow.dto.EventResponse;
-import com.checkmarx.flow.dto.FlowOverride;
-import com.checkmarx.flow.dto.ScanRequest;
+import com.checkmarx.flow.dto.*;
 import com.checkmarx.flow.dto.bitbucketserver.*;
 import com.checkmarx.flow.exception.InvalidTokenException;
 import com.checkmarx.flow.exception.MachinaRuntimeException;
@@ -21,7 +18,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.MDC;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -29,14 +25,12 @@ import javax.annotation.PostConstruct;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import javax.xml.bind.DatatypeConverter;
-import java.beans.ConstructorProperties;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -45,7 +39,7 @@ import java.util.Optional;
 @RestController
 @RequestMapping(value = "/" )
 @RequiredArgsConstructor
-public class BitbucketServerController {
+public class BitbucketServerController extends WebhookController {
 
     private static final String SIGNATURE = "X-Hub-Signature";
     private static final String EVENT = "X-Event-Key";
@@ -95,42 +89,9 @@ public class BitbucketServerController {
             @RequestBody String body,
             @PathVariable(value = "product", required = false) String product,
             @RequestHeader(value = SIGNATURE) String signature,
-            @RequestParam(value = "application", required = false) String application,
-            @RequestParam(value = "branch", required = false) List<String> branch,
-            @RequestParam(value = "severity", required = false) List<String> severity,
-            @RequestParam(value = "cwe", required = false) List<String> cwe,
-            @RequestParam(value = "category", required = false) List<String> category,
-            @RequestParam(value = "project", required = false) String project,
-            @RequestParam(value = "team", required = false) String team,
-            @RequestParam(value = "status", required = false) List<String> status,
-            @RequestParam(value = "assignee", required = false) String assignee,
-            @RequestParam(value = "preset", required = false) String preset,
-            @RequestParam(value = "incremental", required = false) Boolean incremental,
-            @RequestParam(value = "exclude-files", required = false) List<String> excludeFiles,
-            @RequestParam(value = "exclude-folders", required = false) List<String> excludeFolders,
-            @RequestParam(value = "override", required = false) String override,
-            @RequestParam(value = "bug", required = false) String bug,
-            @RequestParam(value = "app-only", required = false) Boolean appOnlyTracking
+            ControllerRequest controllerRequest
     ){
-        return doMergeEvent(body,
-                product,
-                signature,
-                application,
-                branch,
-                severity,
-                cwe,
-                category,
-                project,
-                team,
-                status,
-                assignee,
-                preset,
-                incremental,
-                excludeFiles,
-                excludeFolders,
-                override,
-                bug,
-                appOnlyTracking);
+        return doMergeEvent(body, product, signature, controllerRequest);
     }
 
     /**
@@ -141,42 +102,9 @@ public class BitbucketServerController {
             @RequestBody String body,
             @PathVariable(value = "product", required = false) String product,
             @RequestHeader(value = SIGNATURE) String signature,
-            @RequestParam(value = "application", required = false) String application,
-            @RequestParam(value = "branch", required = false) List<String> branch,
-            @RequestParam(value = "severity", required = false) List<String> severity,
-            @RequestParam(value = "cwe", required = false) List<String> cwe,
-            @RequestParam(value = "category", required = false) List<String> category,
-            @RequestParam(value = "project", required = false) String project,
-            @RequestParam(value = "team", required = false) String team,
-            @RequestParam(value = "status", required = false) List<String> status,
-            @RequestParam(value = "assignee", required = false) String assignee,
-            @RequestParam(value = "preset", required = false) String preset,
-            @RequestParam(value = "incremental", required = false) Boolean incremental,
-            @RequestParam(value = "exclude-files", required = false) List<String> excludeFiles,
-            @RequestParam(value = "exclude-folders", required = false) List<String> excludeFolders,
-            @RequestParam(value = "override", required = false) String override,
-            @RequestParam(value = "bug", required = false) String bug,
-            @RequestParam(value = "app-only", required = false) Boolean appOnlyTracking
+            ControllerRequest controllerRequest
     ){
-        return doMergeEvent(body,
-                product,
-                signature,
-                application,
-                branch,
-                severity,
-                cwe,
-                category,
-                project,
-                team,
-                status,
-                assignee,
-                preset,
-                incremental,
-                excludeFiles,
-                excludeFolders,
-                override,
-                bug,
-                appOnlyTracking);
+        return doMergeEvent(body, product, signature, controllerRequest);
     }
 
     /**
@@ -187,50 +115,21 @@ public class BitbucketServerController {
             @RequestBody String body,
             @PathVariable(value = "product", required = false) String product,
             @RequestHeader(value = SIGNATURE) String signature,
-            @RequestParam(value = "application", required = false) String application,
-            @RequestParam(value = "branch", required = false) List<String> branch,
-            @RequestParam(value = "severity", required = false) List<String> severity,
-            @RequestParam(value = "cwe", required = false) List<String> cwe,
-            @RequestParam(value = "category", required = false) List<String> category,
-            @RequestParam(value = "project", required = false) String project,
-            @RequestParam(value = "team", required = false) String team,
-            @RequestParam(value = "status", required = false) List<String> status,
-            @RequestParam(value = "assignee", required = false) String assignee,
-            @RequestParam(value = "preset", required = false) String preset,
-            @RequestParam(value = "incremental", required = false) Boolean incremental,
-            @RequestParam(value = "exclude-files", required = false) List<String> excludeFiles,
-            @RequestParam(value = "exclude-folders", required = false) List<String> excludeFolders,
-            @RequestParam(value = "override", required = false) String override,
-            @RequestParam(value = "bug", required = false) String bug,
-            @RequestParam(value = "app-only", required = false) Boolean appOnlyTracking
+            ControllerRequest controllerRequest
     ){
-        return doMergeEvent(body,
-                product,
-                signature,
-                application,
-                branch,
-                severity,
-                cwe,
-                category,
-                project,
-                team,
-                status,
-                assignee,
-                preset,
-                incremental,
-                excludeFiles,
-                excludeFolders,
-                override,
-                bug,
-                appOnlyTracking);
+        return doMergeEvent(body, product, signature,controllerRequest);
     }
 
-    private ResponseEntity<EventResponse> doMergeEvent(@RequestBody String body, @PathVariable(value = "product", required = false) String product, @RequestHeader(SIGNATURE) String signature, @RequestParam(value = "application", required = false) String application, @RequestParam(value = "branch", required = false) List<String> branch, @RequestParam(value = "severity", required = false) List<String> severity, @RequestParam(value = "cwe", required = false) List<String> cwe, @RequestParam(value = "category", required = false) List<String> category, @RequestParam(value = "project", required = false) String project, @RequestParam(value = "team", required = false) String team, @RequestParam(value = "status", required = false) List<String> status, @RequestParam(value = "assignee", required = false) String assignee, @RequestParam(value = "preset", required = false) String preset, @RequestParam(value = "incremental", required = false) Boolean incremental, @RequestParam(value = "exclude-files", required = false) List<String> excludeFiles, @RequestParam(value = "exclude-folders", required = false) List<String> excludeFolders, @RequestParam(value = "override", required = false) String override, @RequestParam(value = "bug", required = false) String bug, @RequestParam(value = "app-only", required = false) Boolean appOnlyTracking) {
+    private ResponseEntity<EventResponse> doMergeEvent(String body,
+                                                       String product,
+                                                       String signature,
+                                                       ControllerRequest controllerRequest) {
         String uid = helperService.getShortUid();
         MDC.put("cx", uid);
         verifyHmacSignature(body, signature);
+        controllerRequest = ensureNotNull(controllerRequest);
 
-        FlowOverride o = ScanUtils.getMachinaOverride(override);
+        FlowOverride o = ScanUtils.getMachinaOverride(controllerRequest.getOverride());
         ObjectMapper mapper = new ObjectMapper();
         PullEvent event;
 
@@ -249,15 +148,15 @@ public class BitbucketServerController {
             Repository fromRefRepository = fromRef.getRepository();
             Repository_ toRefRepository = toRef.getRepository();
             String app = fromRefRepository.getName();
-            if (!ScanUtils.empty(application)) {
-                app = application;
+            if (!ScanUtils.empty(controllerRequest.getApplication())) {
+                app = controllerRequest.getApplication();
             }
 
             BugTracker.Type bugType = BugTracker.Type.BITBUCKETSERVERPULL;
-            if (!ScanUtils.empty(bug)) {
-                bugType = ScanUtils.getBugTypeEnum(bug, flowProperties.getBugTrackerImpl());
+            if (!ScanUtils.empty(controllerRequest.getBug())) {
+                bugType = ScanUtils.getBugTypeEnum(controllerRequest.getBug(), flowProperties.getBugTrackerImpl());
             }
-            Optional.ofNullable(appOnlyTracking).ifPresent(flowProperties::setTrackApplicationOnly);
+            Optional.ofNullable(controllerRequest.getAppOnly()).ifPresent(flowProperties::setTrackApplicationOnly);
 
             if (ScanUtils.empty(product)) {
                 product = ScanRequest.Product.CX.getProduct();
@@ -265,32 +164,17 @@ public class BitbucketServerController {
             ScanRequest.Product p = ScanRequest.Product.valueOf(product.toUpperCase(Locale.ROOT));
             String currentBranch = fromRef.getDisplayId();
             String targetBranch = toRef.getDisplayId();
-            List<String> branches = new ArrayList<>();
+            List<String> branches = getBranches(controllerRequest, flowProperties);
 
-            if (!ScanUtils.empty(branch)) {
-                branches.addAll(branch);
-            } else if (!ScanUtils.empty(flowProperties.getBranches())) {
-                branches.addAll(flowProperties.getBranches());
-            }
+            BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
 
-            BugTracker bt = ScanUtils.getBugTracker(assignee, bugType, jiraProperties, bug);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest.getSeverity(), controllerRequest.getCwe(), controllerRequest.getCategory(), controllerRequest.getStatus(), null, flowProperties);
 
-            FilterConfiguration filter = filterFactory.getFilter(severity, cwe, category, status, null, flowProperties);
+            setExclusionProperties(cxProperties, controllerRequest);
 
-            if (excludeFiles == null && !ScanUtils.empty(cxProperties.getExcludeFiles())) {
-                excludeFiles = Arrays.asList(cxProperties.getExcludeFiles().split(","));
-            }
-            if (excludeFolders == null && !ScanUtils.empty(cxProperties.getExcludeFolders())) {
-                excludeFolders = Arrays.asList(cxProperties.getExcludeFolders().split(","));
-            }
 
-            String projectKey = fromRefRepository.getProject().getKey();
-            String gitUrl = properties.getUrl().concat("/scm/")
-                    .concat(projectKey.concat("/"))
-                    .concat(fromRefRepository.getSlug()).concat(".git");
-
-            String gitAuthUrl = gitUrl.replace(Constants.HTTPS, Constants.HTTPS.concat(getEncodedAccessToken()).concat("@"));
-            gitAuthUrl = gitAuthUrl.replace(Constants.HTTP, Constants.HTTP.concat(getEncodedAccessToken()).concat("@"));
+            String gitUrl = getGitUrl(fromRefRepository);
+            String gitAuthUrl = getGitAuthUrl(gitUrl);
 
             String mergeEndpoint = properties.getUrl().concat(properties.getApiPath()).concat(MERGE_COMMENT);
             mergeEndpoint = mergeEndpoint.replace("{project}", toRefRepository.getProject().getKey());
@@ -307,20 +191,16 @@ public class BitbucketServerController {
 
 
             String scanPreset = cxProperties.getScanPreset();
-            if (!ScanUtils.empty(preset)) {
-                scanPreset = preset;
-            }
-            boolean inc = cxProperties.getIncremental();
-            if (incremental != null) {
-                inc = incremental;
+            if (!ScanUtils.empty(controllerRequest.getPreset())) {
+                scanPreset = controllerRequest.getPreset();
             }
 
             ScanRequest request = ScanRequest.builder()
                     .application(app)
                     .product(p)
-                    .project(project)
-                    .team(team)
-                    .namespace(projectKey.replace(" ", "_"))
+                    .project(controllerRequest.getProject())
+                    .team(controllerRequest.getTeam())
+                    .namespace(getNamespace(fromRefRepository))
                     .repoName(fromRefRepository.getName())
                     .repoUrl(gitUrl)
                     .repoUrlWithAuth(gitAuthUrl)
@@ -330,10 +210,10 @@ public class BitbucketServerController {
                     .mergeNoteUri(mergeEndpoint)
                     .refs(fromRef.getId())
                     .email(null)
-                    .incremental(inc)
+                    .incremental(isScanIncremental(controllerRequest, cxProperties))
                     .scanPreset(scanPreset)
-                    .excludeFolders(excludeFolders)
-                    .excludeFiles(excludeFiles)
+                    .excludeFolders(controllerRequest.getExcludeFolders())
+                    .excludeFiles(controllerRequest.getExcludeFiles())
                     .bugTracker(bt)
                     .filter(filter)
                     .build();
@@ -353,26 +233,11 @@ public class BitbucketServerController {
             if (helperService.isBranch2Scan(request, branches)) {
                 flowService.initiateAutomation(request);
             }
-
-
         } catch (IllegalArgumentException e) {
-            String errorMessage = "Error submitting Scan Request.  Product or Bugtracker option incorrect ".concat(product != null ? product : "").concat(" | ").concat(bug != null ? bug : "");
-            log.error(errorMessage,e );
-            ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
-
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(EventResponse.builder()
-                    .message(errorMessage)
-                    .success(false)
-                    .build());
+            return getBadRequestMessage(e, controllerRequest, product);
         }
-        return ResponseEntity.status(HttpStatus.OK).body(EventResponse.builder()
-                .message("Scan Request Successfully Submitted")
-                .success(true)
-                .build());
+        return getSuccessMessage();
     }
-
-
-
 
     /**
      * Receive Push event submitted from Bitbucket
@@ -382,29 +247,15 @@ public class BitbucketServerController {
             @RequestBody String body,
             @PathVariable(value = "product", required = false) String product,
             @RequestHeader(value = SIGNATURE) String signature,
-            @RequestParam(value = "application", required = false) String application,
-            @RequestParam(value = "branch", required = false) List<String> branch,
-            @RequestParam(value = "severity", required = false) List<String> severity,
-            @RequestParam(value = "cwe", required = false) List<String> cwe,
-            @RequestParam(value = "category", required = false) List<String> category,
-            @RequestParam(value = "project", required = false) String project,
-            @RequestParam(value = "team", required = false) String team,
-            @RequestParam(value = "status", required = false) List<String> status,
-            @RequestParam(value = "assignee", required = false) String assignee,
-            @RequestParam(value = "preset", required = false) String preset,
-            @RequestParam(value = "incremental", required = false) Boolean incremental,
-            @RequestParam(value = "exclude-files", required = false) List<String> excludeFiles,
-            @RequestParam(value = "exclude-folders", required = false) List<String> excludeFolders,
-            @RequestParam(value = "override", required = false) String override,
-            @RequestParam(value = "bug", required = false) String bug,
-            @RequestParam(value = "app-only", required = false) Boolean appOnlyTracking
+            ControllerRequest controllerRequest
 
     ){
         String uid = helperService.getShortUid();
         MDC.put("cx", uid);
         verifyHmacSignature(body, signature);
+        controllerRequest = ensureNotNull(controllerRequest);
 
-        FlowOverride o = ScanUtils.getMachinaOverride(override);
+        FlowOverride o = ScanUtils.getMachinaOverride(controllerRequest.getOverride());
         ObjectMapper mapper = new ObjectMapper();
         PushEvent event;
 
@@ -417,70 +268,45 @@ public class BitbucketServerController {
         try {
             Repository repository = event.getRepository();
             String app = repository.getName();
-            if(!ScanUtils.empty(application)){
-                app = application;
+            if(!ScanUtils.empty(controllerRequest.getApplication())){
+                app = controllerRequest.getApplication();
             }
 
             //set the default bug tracker as per yml
-            BugTracker.Type bugType;
-            if (ScanUtils.empty(bug)) {
-                bug =  flowProperties.getBugTracker();
-            }
-            bugType = ScanUtils.getBugTypeEnum(bug, flowProperties.getBugTrackerImpl());
+            setBugTracker(flowProperties, controllerRequest);
+            BugTracker.Type bugType = ScanUtils.getBugTypeEnum(controllerRequest.getBug(), flowProperties.getBugTrackerImpl());
 
-            Optional.ofNullable(appOnlyTracking).ifPresent(flowProperties::setTrackApplicationOnly);
+            Optional.ofNullable(controllerRequest.getAppOnly()).ifPresent(flowProperties::setTrackApplicationOnly);
 
             if(ScanUtils.empty(product)){
                 product = ScanRequest.Product.CX.getProduct();
             }
             ScanRequest.Product p = ScanRequest.Product.valueOf(product.toUpperCase(Locale.ROOT));
             String currentBranch = ScanUtils.getBranchFromRef(event.getChanges().get(0).getRefId());
-            List<String> branches = new ArrayList<>();
+            List<String> branches = getBranches(controllerRequest, flowProperties);
 
-            if(!ScanUtils.empty(branch)){
-                branches.addAll(branch);
-            }
-            else if(!ScanUtils.empty(flowProperties.getBranches())){
-                branches.addAll(flowProperties.getBranches());
-            }
+            BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest.getSeverity(), controllerRequest.getCwe(), controllerRequest.getCategory(), controllerRequest.getStatus(), null, flowProperties);
 
-            BugTracker bt = ScanUtils.getBugTracker(assignee, bugType, jiraProperties, bug);
-            FilterConfiguration filter = filterFactory.getFilter(severity, cwe, category, status, null, flowProperties);
-
-            if(excludeFiles == null && !ScanUtils.empty(cxProperties.getExcludeFiles())){
-                excludeFiles = Arrays.asList(cxProperties.getExcludeFiles().split(","));
-            }
-            if(excludeFolders == null && !ScanUtils.empty(cxProperties.getExcludeFolders())){
-                excludeFolders = Arrays.asList(cxProperties.getExcludeFolders().split(","));
-            }
+            setExclusionProperties(cxProperties, controllerRequest);
 
             List<String> emails = new ArrayList<>();
-
             emails.add(event.getActor().getEmailAddress());
 
-            String projectKey = repository.getProject().getKey();
-            String gitUrl = properties.getUrl().concat("/scm/")
-                    .concat(projectKey.concat("/"))
-                    .concat(repository.getSlug()).concat(".git");
-
-            String gitAuthUrl = gitUrl.replace(Constants.HTTPS, Constants.HTTPS.concat(getEncodedAccessToken()).concat("@"));
-            gitAuthUrl = gitAuthUrl.replace(Constants.HTTP, Constants.HTTP.concat(getEncodedAccessToken()).concat("@"));
+            String gitUrl = getGitUrl(repository);
+            String gitAuthUrl = getGitAuthUrl(gitUrl);
 
             String scanPreset = cxProperties.getScanPreset();
-            if(!ScanUtils.empty(preset)){
-                scanPreset = preset;
-            }
-            boolean inc = cxProperties.getIncremental();
-            if(incremental != null){
-                inc = incremental;
+            if(!ScanUtils.empty(controllerRequest.getPreset())){
+                scanPreset = controllerRequest.getPreset();
             }
 
             ScanRequest request = ScanRequest.builder()
                     .application(app)
                     .product(p)
-                    .project(project)
-                    .team(team)
-                    .namespace(projectKey.replace(" ","_"))
+                    .project(controllerRequest.getProject())
+                    .team(controllerRequest.getTeam())
+                    .namespace(getNamespace(repository))
                     .repoName(repository.getName())
                     .repoUrl(gitUrl)
                     .repoUrlWithAuth(gitAuthUrl)
@@ -488,10 +314,10 @@ public class BitbucketServerController {
                     .branch(currentBranch)
                     .refs(event.getChanges().get(0).getRefId())
                     .email(emails)
-                    .incremental(inc)
+                    .incremental(isScanIncremental(controllerRequest, cxProperties))
                     .scanPreset(scanPreset)
-                    .excludeFolders(excludeFolders)
-                    .excludeFiles(excludeFiles)
+                    .excludeFolders(controllerRequest.getExcludeFolders())
+                    .excludeFiles(controllerRequest.getExcludeFiles())
                     .bugTracker(bt)
                     .filter(filter)
                     .build();
@@ -507,25 +333,15 @@ public class BitbucketServerController {
             if(helperService.isBranch2Scan(request, branches)){
                 flowService.initiateAutomation(request);
             }
-
-
-        }catch (IllegalArgumentException e){
-            String errorMessage = "Error submitting Scan Request.  Product or Bugtracker option incorrect ".concat(product != null ? product : "").concat(" | ").concat(bug != null ? bug : "");
-            log.error(errorMessage, e);
-            ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
-
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(EventResponse.builder()
-                    .message(errorMessage)
-                    .success(false)
-                    .build());
+        } catch (IllegalArgumentException e) {
+            return getBadRequestMessage(e, controllerRequest, product);
         }
-        return ResponseEntity.status(HttpStatus.OK).body(EventResponse.builder()
-                .message("Scan Request Successfully Submitted")
-                .success(true)
-                .build());
+        return getSuccessMessage();
     }
 
-    /** Validates the received body using the BB hook secret. */
+    /**
+     * Validates the received body using the BB hook secret.
+     */
     private void verifyHmacSignature(String message, String signature) {
         byte[] sig = hmac.doFinal(message.getBytes(CHARSET));
         String computedSignature = "sha256=" + DatatypeConverter.printHexBinary(sig);
@@ -536,15 +352,29 @@ public class BitbucketServerController {
     }
 
     private String getEncodedAccessToken() {
-        String[] basicAuthCredentials = properties.getToken().split(":");
+        final String CREDENTIAL_SEPARATOR = ":";
+        String[] basicAuthCredentials = properties.getToken().split(CREDENTIAL_SEPARATOR);
         String accessToken = basicAuthCredentials[1];
 
-        String encodedTokenString =  ScanUtils.getStringWithEncodedCharacter(accessToken);
+        String encodedTokenString = ScanUtils.getStringWithEncodedCharacter(accessToken);
 
-         return basicAuthCredentials[0].concat(":").concat(encodedTokenString);
-
+        return basicAuthCredentials[0].concat(CREDENTIAL_SEPARATOR).concat(encodedTokenString);
     }
 
+    private String getNamespace(Repository repo) {
+        return repo.getProject().getKey().replace(" ", "_");
+    }
+
+    private String getGitAuthUrl(String gitUrl) {
+        String gitAuthUrl = gitUrl.replace(Constants.HTTPS, Constants.HTTPS.concat(getEncodedAccessToken()).concat("@"));
+        return gitAuthUrl.replace(Constants.HTTP, Constants.HTTP.concat(getEncodedAccessToken()).concat("@"));
+    }
+
+    private String getGitUrl(Repository repository) {
+        return properties.getUrl().concat("/scm/")
+                .concat(repository.getProject().getKey().concat("/"))
+                .concat(repository.getSlug()).concat(".git");
+    }
 }
 
 

--- a/src/main/java/com/checkmarx/flow/controller/FlowController.java
+++ b/src/main/java/com/checkmarx/flow/controller/FlowController.java
@@ -2,10 +2,7 @@ package com.checkmarx.flow.controller;
 
 import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.config.JiraProperties;
-import com.checkmarx.flow.dto.BugTracker;
-import com.checkmarx.flow.dto.EventResponse;
-import com.checkmarx.flow.dto.FlowOverride;
-import com.checkmarx.flow.dto.ScanRequest;
+import com.checkmarx.flow.dto.*;
 import com.checkmarx.flow.exception.InvalidTokenException;
 import com.checkmarx.flow.service.FilterFactory;
 import com.checkmarx.flow.service.FlowService;
@@ -32,7 +29,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.beans.ConstructorProperties;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -60,7 +56,7 @@ public class FlowController {
     private final ResultsService resultsService;
     private final FilterFactory filterFactory;
 
-    @RequestMapping(value = "/scanresults", method = RequestMethod.GET, produces = "application/json")
+    @GetMapping(value = "/scanresults", produces = "application/json")
     public ScanResults latestScanResults(
             // Mandatory parameters
             @RequestParam(value = "project") String project,
@@ -85,7 +81,8 @@ public class FlowController {
         BugTracker bugTracker = getBugTracker(assignee, bug);
 
         // Create filters if available
-        FilterConfiguration filter = filterFactory.getFilter(severity, cwe, category, status, null, properties);
+        ControllerRequest request = new ControllerRequest(severity, cwe, category, status);
+        FilterConfiguration filter = filterFactory.getFilter(request, null, properties);
 
         // Create the scan request
         ScanRequest scanRequest = ScanRequest.builder()
@@ -233,8 +230,7 @@ public class FlowController {
     }
 
     private FilterConfiguration determineFilter(CxScanRequest scanRequest) {
-        FilterConfiguration filter = filterFactory.getFilter(null, null, null, null, null,
-                properties);
+        FilterConfiguration filter = filterFactory.getFilter(null, null, properties);
 
         boolean hasSimpleFilters = CollectionUtils.isNotEmpty(scanRequest.getFilters());
         boolean hasFilterScript = StringUtils.isNotEmpty(scanRequest.getFilterScript());

--- a/src/main/java/com/checkmarx/flow/controller/FlowController.java
+++ b/src/main/java/com/checkmarx/flow/controller/FlowController.java
@@ -82,7 +82,7 @@ public class FlowController {
 
         // Create filters if available
         ControllerRequest request = new ControllerRequest(severity, cwe, category, status);
-        FilterConfiguration filter = filterFactory.getFilter(request, null, properties);
+        FilterConfiguration filter = filterFactory.getFilter(request, properties);
 
         // Create the scan request
         ScanRequest scanRequest = ScanRequest.builder()
@@ -230,7 +230,7 @@ public class FlowController {
     }
 
     private FilterConfiguration determineFilter(CxScanRequest scanRequest) {
-        FilterConfiguration filter = filterFactory.getFilter(null, null, properties);
+        FilterConfiguration filter = filterFactory.getFilter(null, properties);
 
         boolean hasSimpleFilters = CollectionUtils.isNotEmpty(scanRequest.getFilters());
         boolean hasFilterScript = StringUtils.isNotEmpty(scanRequest.getFilterScript());

--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -155,12 +155,7 @@ public class GitHubController extends WebhookController {
             String targetBranch = pullRequest.getBase().getRef();
             List<String> branches = getBranches(controllerRequest, flowProperties);
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
-            FilterConfiguration filter = filterFactory.getFilter(controllerRequest.getSeverity(),
-                    controllerRequest.getCwe(),
-                    controllerRequest.getCategory(),
-                    controllerRequest.getStatus(),
-                    null,
-                    flowProperties);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
 
             setExclusionProperties(cxProperties, controllerRequest);
             //build request object
@@ -271,7 +266,7 @@ public class GitHubController extends WebhookController {
             List<String> branches = getBranches(controllerRequest, flowProperties);
 
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
-            FilterConfiguration filter = filterFactory.getFilter(controllerRequest.getSeverity(), controllerRequest.getCwe(), controllerRequest.getCategory(), controllerRequest.getStatus(), null, flowProperties);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
 
             setExclusionProperties(cxProperties, controllerRequest);
 

--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -34,7 +34,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 
 /**
  * Class used to manage Controller for GitHub WebHooks
@@ -103,8 +105,7 @@ public class GitHubController extends WebhookController {
         log.info("Processing GitHub PULL request");
         PullEvent event;
         ObjectMapper mapper = new ObjectMapper();
-        controllerRequest = Optional.ofNullable(controllerRequest)
-                .orElseGet(() -> ControllerRequest.builder().build());
+        controllerRequest = ensureNotNull(controllerRequest);
 
         try {
             event = mapper.readValue(body, PullEvent.class);
@@ -228,8 +229,7 @@ public class GitHubController extends WebhookController {
         log.info("Processing GitHub PUSH request");
         PushEvent event;
         ObjectMapper mapper = new ObjectMapper();
-        controllerRequest = Optional.ofNullable(controllerRequest)
-                .orElseGet(() -> ControllerRequest.builder().build());
+        controllerRequest = ensureNotNull(controllerRequest);
 
         try {
             event = mapper.readValue(body, PushEvent.class);

--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -155,7 +155,7 @@ public class GitHubController extends WebhookController {
             String targetBranch = pullRequest.getBase().getRef();
             List<String> branches = getBranches(controllerRequest, flowProperties);
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
-            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, flowProperties);
 
             setExclusionProperties(cxProperties, controllerRequest);
             //build request object
@@ -266,7 +266,7 @@ public class GitHubController extends WebhookController {
             List<String> branches = getBranches(controllerRequest, flowProperties);
 
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
-            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, flowProperties);
 
             setExclusionProperties(cxProperties, controllerRequest);
 

--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -19,7 +19,6 @@ import com.checkmarx.sdk.dto.filtering.FilterConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
@@ -472,7 +471,6 @@ public class GitHubController {
         return result;
     }
 
-    @NotNull
     private ResponseEntity<EventResponse> getSuccessResponse() {
         return ResponseEntity.status(HttpStatus.OK).body(EventResponse.builder()
                 .message("Scan Request Successfully Submitted")
@@ -480,7 +478,6 @@ public class GitHubController {
                 .build());
     }
 
-    @NotNull
     private ResponseEntity<EventResponse> getBadRequestMessage(IllegalArgumentException cause, ControllerRequest controllerRequest, String product) {
         String errorMessage = String.format("Error submitting Scan Request. Product or Bugtracker option incorrect %s | %s",
                 StringUtils.defaultIfEmpty(product, ""),

--- a/src/main/java/com/checkmarx/flow/controller/GitLabController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitLabController.java
@@ -110,7 +110,7 @@ public class GitLabController extends WebhookController {
 
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
 
-            FilterConfiguration filter = filterFactory.getFilter(controllerRequest.getSeverity(), controllerRequest.getCwe(), controllerRequest.getCategory(), controllerRequest.getStatus(), null, flowProperties);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
 
             setExclusionProperties(cxProperties, controllerRequest);
 
@@ -220,7 +220,7 @@ public class GitLabController extends WebhookController {
             }
 
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
-            FilterConfiguration filter = filterFactory.getFilter(controllerRequest.getSeverity(), controllerRequest.getCwe(), controllerRequest.getCategory(), controllerRequest.getStatus(), null, flowProperties);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
 
             setExclusionProperties(cxProperties, controllerRequest);
 

--- a/src/main/java/com/checkmarx/flow/controller/GitLabController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitLabController.java
@@ -19,6 +19,8 @@ import com.checkmarx.sdk.config.CxProperties;
 import com.checkmarx.sdk.dto.CxConfig;
 import com.checkmarx.sdk.dto.filtering.FilterConfiguration;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
@@ -83,12 +85,12 @@ public class GitLabController extends WebhookController {
                         .build());
             }
             String app = body.getRepository().getName();
-            if(!ScanUtils.empty(controllerRequest.getApplication())){
+            if(StringUtils.isNotEmpty(controllerRequest.getApplication())){
                 app = controllerRequest.getApplication();
             }
 
             BugTracker.Type bugType = BugTracker.Type.GITLABMERGE;
-            if (!ScanUtils.empty(controllerRequest.getBug())) {
+            if (StringUtils.isNotEmpty(controllerRequest.getBug())) {
                 bugType = ScanUtils.getBugTypeEnum(controllerRequest.getBug(), flowProperties.getBugTrackerImpl());
             }
 
@@ -121,7 +123,7 @@ public class GitLabController extends WebhookController {
             String gitAuthUrl = gitUrl.replace(Constants.HTTPS, Constants.HTTPS_OAUTH2.concat(properties.getToken()).concat("@"));
             gitAuthUrl = gitAuthUrl.replace(Constants.HTTP, Constants.HTTP_OAUTH2.concat(properties.getToken()).concat("@"));
             String scanPreset = cxProperties.getScanPreset();
-            if(!ScanUtils.empty(controllerRequest.getPreset())){
+            if(StringUtils.isNotEmpty(controllerRequest.getPreset())){
                 scanPreset = controllerRequest.getPreset();
             }
 
@@ -191,7 +193,7 @@ public class GitLabController extends WebhookController {
         String commitEndpoint = null;
         try {
             String app = body.getRepository().getName();
-            if(!ScanUtils.empty(controllerRequest.getApplication())){
+            if(StringUtils.isNotEmpty(controllerRequest.getApplication())){
                 app = controllerRequest.getApplication();
             }
 
@@ -210,10 +212,10 @@ public class GitLabController extends WebhookController {
             String currentBranch = ScanUtils.getBranchFromRef(body.getRef());
             List<String> branches = new ArrayList<>();
 
-            if(!ScanUtils.empty(controllerRequest.getBranch())){
+            if(CollectionUtils.isNotEmpty(controllerRequest.getBranch())){
                 branches.addAll(controllerRequest.getBranch());
             }
-            else if(!ScanUtils.empty(flowProperties.getBranches())){
+            else if(CollectionUtils.isNotEmpty(flowProperties.getBranches())){
                 branches.addAll(flowProperties.getBranches());
             }
 
@@ -227,17 +229,17 @@ public class GitLabController extends WebhookController {
             List<String> emails = new ArrayList<>();
             for(Commit c: body.getCommits()){
                 Author author = c.getAuthor();
-                if (author != null && !ScanUtils.empty(author.getEmail())){
+                if (author != null && StringUtils.isNotEmpty(author.getEmail())){
                     emails.add(author.getEmail());
                 }
-                if(!ScanUtils.empty(c.getUrl()) && bugType.equals(BugTracker.Type.GITLABCOMMIT)) {
+                if(StringUtils.isNotEmpty(c.getUrl()) && bugType.equals(BugTracker.Type.GITLABCOMMIT)) {
                     commitEndpoint = properties.getApiUrl().concat(GitLabService.COMMIT_PATH);
                     commitEndpoint = commitEndpoint.replace("{id}", proj.getId().toString());
                     commitEndpoint = commitEndpoint.replace("{sha}", c.getId());
                 }
             }
 
-            if(!ScanUtils.empty(body.getUserEmail())) {
+            if(StringUtils.isNotEmpty(body.getUserEmail())) {
                 emails.add(body.getUserEmail());
             }
             String gitUrl = proj.getGitHttpUrl();
@@ -246,7 +248,7 @@ public class GitLabController extends WebhookController {
             gitAuthUrl = gitAuthUrl.replace(Constants.HTTP, Constants.HTTP_OAUTH2.concat(properties.getToken()).concat("@"));
 
             String scanPreset = cxProperties.getScanPreset();
-            if(!ScanUtils.empty(controllerRequest.getPreset())){
+            if(StringUtils.isNotEmpty(controllerRequest.getPreset())){
                 scanPreset = controllerRequest.getPreset();
             }
 
@@ -273,7 +275,7 @@ public class GitLabController extends WebhookController {
                     .filter(filter)
                     .build();
 
-            if(!ScanUtils.empty(controllerRequest.getPreset())){
+            if(StringUtils.isNotEmpty(controllerRequest.getPreset())){
                 request.setScanPreset(controllerRequest.getPreset());
                 request.setScanPresetOverride(true);
             }

--- a/src/main/java/com/checkmarx/flow/controller/GitLabController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitLabController.java
@@ -110,7 +110,7 @@ public class GitLabController extends WebhookController {
 
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
 
-            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, flowProperties);
 
             setExclusionProperties(cxProperties, controllerRequest);
 
@@ -220,7 +220,7 @@ public class GitLabController extends WebhookController {
             }
 
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
-            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, flowProperties);
 
             setExclusionProperties(cxProperties, controllerRequest);
 

--- a/src/main/java/com/checkmarx/flow/controller/GitLabController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitLabController.java
@@ -69,6 +69,7 @@ public class GitLabController extends WebhookController {
         MDC.put("cx", uid);
         log.info("Processing GitLab MERGE request");
         validateGitLabRequest(token);
+        controllerRequest = ensureNotNull(controllerRequest);
 
         try {
             ObjectAttributes objectAttributes = body.getObjectAttributes();
@@ -185,6 +186,7 @@ public class GitLabController extends WebhookController {
         String uid = helperService.getShortUid();
         MDC.put("cx", uid);
         validateGitLabRequest(token);
+        controllerRequest = ensureNotNull(controllerRequest);
 
         String commitEndpoint = null;
         try {

--- a/src/main/java/com/checkmarx/flow/controller/GitLabController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitLabController.java
@@ -88,7 +88,7 @@ public class GitLabController extends WebhookController {
             }
 
             BugTracker.Type bugType = BugTracker.Type.GITLABMERGE;
-            if(!ScanUtils.empty(controllerRequest.getBug())){
+            if (!ScanUtils.empty(controllerRequest.getBug())) {
                 bugType = ScanUtils.getBugTypeEnum(controllerRequest.getBug(), flowProperties.getBugTrackerImpl());
             }
 
@@ -104,13 +104,13 @@ public class GitLabController extends WebhookController {
             String targetBranch = objectAttributes.getTargetBranch();
             String defaultBranch = objectAttributes.getTarget().getDefaultBranch();
 
-            List<String> branches = getBranches(controllerRequest.getBranch(), flowProperties);
+            List<String> branches = getBranches(controllerRequest, flowProperties);
 
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
 
             FilterConfiguration filter = filterFactory.getFilter(controllerRequest.getSeverity(), controllerRequest.getCwe(), controllerRequest.getCategory(), controllerRequest.getStatus(), null, flowProperties);
 
-            setExclusionProperties(controllerRequest, cxProperties);
+            setExclusionProperties(cxProperties, controllerRequest);
 
             Project proj = body.getProject();
             String mergeEndpoint = properties.getApiUrl().concat(GitLabService.MERGE_NOTE_PATH);
@@ -170,7 +170,7 @@ public class GitLabController extends WebhookController {
         } catch (IllegalArgumentException e) {
             return getBadRequestMessage(e, controllerRequest, product);
         }
-        return getSuccessResponse();
+        return getSuccessMessage();
     }
 
     /**
@@ -196,11 +196,8 @@ public class GitLabController extends WebhookController {
             }
 
             //set the default bug tracker as per yml
-            BugTracker.Type bugType;
-            if (ScanUtils.empty(controllerRequest.getBug())) {
-                controllerRequest.setBug(flowProperties.getBugTracker());
-            }
-            bugType = ScanUtils.getBugTypeEnum(controllerRequest.getBug(), flowProperties.getBugTrackerImpl());
+            setBugTracker(flowProperties, controllerRequest);
+            BugTracker.Type bugType = ScanUtils.getBugTypeEnum(controllerRequest.getBug(), flowProperties.getBugTrackerImpl());
 
             if(controllerRequest.getAppOnly() != null){
                 flowProperties.setTrackApplicationOnly(controllerRequest.getAppOnly());
@@ -223,7 +220,7 @@ public class GitLabController extends WebhookController {
             BugTracker bt = ScanUtils.getBugTracker(controllerRequest.getAssignee(), bugType, jiraProperties, controllerRequest.getBug());
             FilterConfiguration filter = filterFactory.getFilter(controllerRequest.getSeverity(), controllerRequest.getCwe(), controllerRequest.getCategory(), controllerRequest.getStatus(), null, flowProperties);
 
-            setExclusionProperties(controllerRequest, cxProperties);
+            setExclusionProperties(cxProperties, controllerRequest);
 
             Project proj = body.getProject();
             /*Determine emails*/
@@ -296,7 +293,7 @@ public class GitLabController extends WebhookController {
         } catch (IllegalArgumentException e) {
             return getBadRequestMessage(e, controllerRequest, product);
         }
-        return getSuccessResponse();
+        return getSuccessMessage();
     }
 
     private void validateGitLabRequest(String token){

--- a/src/main/java/com/checkmarx/flow/controller/TfsController.java
+++ b/src/main/java/com/checkmarx/flow/controller/TfsController.java
@@ -3,12 +3,10 @@ package com.checkmarx.flow.controller;
 import com.checkmarx.flow.config.ADOProperties;
 import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.config.JiraProperties;
-import com.checkmarx.flow.dto.BugTracker;
-import com.checkmarx.flow.dto.EventResponse;
-import com.checkmarx.flow.dto.FlowOverride;
-import com.checkmarx.flow.dto.ScanRequest;
+import com.checkmarx.flow.dto.*;
 import com.checkmarx.flow.dto.ScanRequest.Product;
 import com.checkmarx.flow.dto.ScanRequest.ScanRequestBuilder;
+import com.checkmarx.flow.dto.azure.AdoDetailsRequest;
 import com.checkmarx.flow.dto.azure.PullEvent;
 import com.checkmarx.flow.dto.azure.Repository;
 import com.checkmarx.flow.dto.azure.Resource;
@@ -17,12 +15,10 @@ import com.checkmarx.flow.service.FilterFactory;
 import com.checkmarx.flow.service.FlowService;
 import com.checkmarx.flow.service.HelperService;
 import com.checkmarx.flow.utils.ScanUtils;
-import com.checkmarx.sdk.config.Constants;
 import com.checkmarx.sdk.config.CxProperties;
 import com.checkmarx.sdk.dto.filtering.FilterConfiguration;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -34,10 +30,12 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping(value = "/")
 @RequiredArgsConstructor
-public class TfsController {
+@Slf4j
+public class TfsController extends AdoControllerBase {
     private static final String PULL_EVENT = "git.pullrequest.created";
     private static final String AUTHORIZATION = "authorization";
-    private static final Logger log = org.slf4j.LoggerFactory.getLogger(TfsController.class);
+    public static final String ACTION_PULL = "pull";
+    public static final String ACTION_PUSH = "push";
 
     private final ADOProperties properties;
     private final FlowProperties flowProperties;
@@ -51,28 +49,10 @@ public class TfsController {
     public ResponseEntity<EventResponse> pullPushRequest(
             HttpServletRequest httpRequest,
             @RequestBody PullEvent body,
-            @RequestHeader(value = AUTHORIZATION) String auth, 
-            @PathVariable Optional<String> product,
-            @RequestParam Optional<String> application, 
-            @RequestParam Optional<List<String>> branch,
-            @RequestParam Optional<List<String>> severity, 
-            @RequestParam Optional<List<String>> cwe,
-            @RequestParam Optional<List<String>> category, 
-            @RequestParam Optional<String> project,
-            @RequestParam Optional<String> team, 
-            @RequestParam Optional<List<String>> status,
-            @RequestParam Optional<String> assignee, 
-            @RequestParam Optional<String> preset,
-            @RequestParam Optional<Boolean> incremental,
-            @RequestParam(value = "exclude-files") Optional<List<String>> excludeFiles,
-            @RequestParam(value = "exclude-folders") Optional<List<String>> excludeFolders,
-            @RequestParam Optional<String> override, 
-            @RequestParam Optional<String> bug,
-            @RequestParam(value = "ado-issue") Optional<String> adoIssueType,
-            @RequestParam(value = "ado-body") Optional<String> adoIssueBody,
-            @RequestParam(value = "ado-opened") Optional<String> adoOpenedState,
-            @RequestParam(value = "ado-closed") Optional<String> adoClosedState,
-            @RequestParam(value = "app-only") Optional<Boolean> appOnlyTracking
+            @RequestHeader(value = AUTHORIZATION) String auth,
+            @PathVariable(value = "product", required = false) String product,
+            ControllerRequest controllerRequest,
+            AdoDetailsRequest adoDetailsRequest
     ) {
         String action = getAction(httpRequest);
         
@@ -83,16 +63,19 @@ public class TfsController {
         }
         validateBasicAuth(auth);
         Resource resource = body.getResource();
+        controllerRequest = ensureNotNull(controllerRequest);
+        adoDetailsRequest = ensureDetailsNotNull(adoDetailsRequest);
 
-        if("pull".equals(action) && !body.getEventType().equals(PULL_EVENT)){
-            log.info("Pull requested not processed.  Event was not opened ({})", body.getEventType());
+        if(ACTION_PULL.equals(action) && !body.getEventType().equals(PULL_EVENT)){
+            log.info("Pull requested not processed.  Event was not 'opened' ({})", body.getEventType());
             return ResponseEntity.accepted().body(EventResponse.builder()
                     .message("No processing occurred for updates to Pull Request")
                     .success(true)
                     .build());
         }
 
-        FlowOverride o = ScanUtils.getMachinaOverride(override.orElse(null));
+        FlowOverride o = ScanUtils.getMachinaOverride(Optional.ofNullable(controllerRequest.getOverride())
+                .orElse(null));
 
         Repository repository = resource.getRepository();
         String app = repository.getName();
@@ -102,35 +85,50 @@ public class TfsController {
                     .message("Test Event").success(true).build());
         }
 
-        appOnlyTracking.ifPresent(flowProperties::setTrackApplicationOnly);
+        Optional.ofNullable(controllerRequest.getAppOnly())
+                .ifPresent(flowProperties::setTrackApplicationOnly);
 
-        List<String> severityList = severity.orElse(Collections.emptyList());
-        List<String> cweList = cwe.orElse(Collections.emptyList());
-        List<String> categoryList = category.orElse(Collections.emptyList());
-        List<String> statusList = status.orElse(Collections.emptyList());
+        List<String> severityList = Optional.ofNullable(controllerRequest.getSeverity())
+                .orElse(Collections.emptyList());
+        List<String> cweList = Optional.ofNullable(controllerRequest.getCwe())
+                .orElse(Collections.emptyList());
+        List<String> categoryList = Optional.ofNullable(controllerRequest.getCategory())
+                .orElse(Collections.emptyList());
+        List<String> statusList = Optional.ofNullable(controllerRequest.getStatus())
+                .orElse(Collections.emptyList());
 
         FilterConfiguration filter = filterFactory.getFilter(severityList, cweList, categoryList, statusList, null, flowProperties);
 
+        setExclusionProperties(cxProperties, controllerRequest);
+
         ScanRequestBuilder requestBuilder = ScanRequest.builder()
-                .application(application.orElse(app))
+                .application(Optional.ofNullable(controllerRequest.getApplication()).orElse(app))
                 .product(getProductForName(product))
-                .project(project.orElse(null))
-                .team(team.orElse(null))
+                .project(Optional.ofNullable(controllerRequest.getProject()).orElse(null))
+                .team(Optional.ofNullable(controllerRequest.getTeam()).orElse(null))
                 .namespace(repository.getProject().getName().replace(" ","_"))
                 .repoName(repository.getName())
                 .repoType(ScanRequest.Repository.ADO)
-                .incremental(incremental.orElse(cxProperties.getIncremental()))
-                .scanPreset(preset.orElse(cxProperties.getScanPreset()))
-                .excludeFolders(createExludeList(excludeFolders , cxProperties.getExcludeFolders()))
-                .excludeFiles(createExludeList(excludeFiles , cxProperties.getExcludeFiles()))
+                .incremental(isScanIncremental(controllerRequest, cxProperties))
+                .scanPreset(Optional.ofNullable(controllerRequest.getPreset()).orElse(cxProperties.getScanPreset()))
+                .excludeFolders(controllerRequest.getExcludeFolders())
+                .excludeFiles(controllerRequest.getExcludeFiles())
                 .filter(filter);
-        if("pull".equals(action)) {
-            BugTracker.Type bugType = 
-            bug.map(theBug -> ScanUtils.getBugTypeEnum(theBug, flowProperties.getBugTrackerImpl()))
-            .orElse(BugTracker.Type.ADOPULL);
-        
-            appOnlyTracking.ifPresent(flowProperties::setTrackApplicationOnly);
-            
+
+        if(ACTION_PULL.equals(action)) {
+            BugTracker.Type bugType = Optional.ofNullable(controllerRequest.getBug())
+                    .map(theBug -> ScanUtils.getBugTypeEnum(theBug, flowProperties.getBugTrackerImpl()))
+                    .orElse(BugTracker.Type.ADOPULL);
+
+            Optional.ofNullable(controllerRequest.getAppOnly())
+                    .ifPresent(flowProperties::setTrackApplicationOnly);
+
+            BugTracker bugTracker = ScanUtils.getBugTracker(
+                    Optional.ofNullable(controllerRequest.getAssignee()).orElse(null),
+                    bugType,
+                    jiraProperties,
+                    Optional.ofNullable(controllerRequest.getBug()).orElse(null));
+
             requestBuilder
                 .refs(resource.getSourceRefName())
                 .repoUrl(repository.getWebUrl())
@@ -139,16 +137,18 @@ public class TfsController {
                 .branch(ScanUtils.getBranchFromRef(resource.getSourceRefName()))
                 .mergeTargetBranch(ScanUtils.getBranchFromRef(resource.getTargetRefName()))
                 .email(null)
-                .bugTracker(ScanUtils.getBugTracker(
-                    assignee.orElse(null), 
-                        bugType, 
-                        jiraProperties, 
-                        bug.orElse(null)));
-        } else if ("push".equals(action)) {
-            BugTracker.Type bugType = ScanUtils.getBugTypeEnum(
-                bug.orElse(flowProperties.getBugTracker()), 
-                flowProperties.getBugTrackerImpl());
+                .bugTracker(bugTracker);
+        } else if (ACTION_PUSH.equals(action)) {
+            String bug = Optional.ofNullable(controllerRequest.getBug())
+                    .orElse(flowProperties.getBugTracker());
 
+            BugTracker.Type bugType = ScanUtils.getBugTypeEnum(bug, flowProperties.getBugTrackerImpl());
+
+            BugTracker bugTracker = ScanUtils.getBugTracker(
+                    Optional.ofNullable(controllerRequest.getAssignee()).orElse(null),
+                    bugType,
+                    jiraProperties,
+                    Optional.ofNullable(controllerRequest.getBug()).orElse(null));
 
             requestBuilder
                 .refs(resource.getRefUpdates().get(0).getName())
@@ -157,26 +157,21 @@ public class TfsController {
                 .branch(ScanUtils.getBranchFromRef(resource.getRefUpdates().get(0).getName()))
                     .defaultBranch(repository.getDefaultBranch())
                 .email(determineEmails(resource))
-                .bugTracker(ScanUtils.getBugTracker(
-                    assignee.orElse(null), 
-                        bugType, 
-                        jiraProperties, 
-                        bug.orElse(null)));
+                .bugTracker(bugTracker);
         }
         ScanRequest request = requestBuilder.build();
 
         request = ScanUtils.overrideMap(request, o);
-        if ("pull".equals(action)) {     
+        if (ACTION_PULL.equals(action)) {
             request.putAdditionalMetadata("statuses_url", resource.getUrl().concat("/statuses"));
         }
-        request.putAdditionalMetadata(Constants.ADO_ISSUE_KEY, adoIssueType.orElse(properties.getIssueType()));
-        request.putAdditionalMetadata(Constants.ADO_ISSUE_BODY_KEY, adoIssueBody.orElse(properties.getIssueBody()));
-        request.putAdditionalMetadata(Constants.ADO_OPENED_STATE_KEY, adoOpenedState.orElse(properties.getOpenStatus()));
-        request.putAdditionalMetadata(Constants.ADO_CLOSED_STATE_KEY, adoClosedState.orElse(properties.getClosedStatus()));
+        addMetadataToScanRequest(adoDetailsRequest, request);
         request.putAdditionalMetadata(ScanUtils.WEB_HOOK_PAYLOAD, body.toString());
         request.setId(uid);
         //only initiate scan/automation if target branch is applicable
         List<String> branches = new ArrayList<>();
+
+        Optional<List<String>> branch = Optional.ofNullable(controllerRequest.getBranch());
         if (branch.isPresent()) {
             branches.addAll(branch.get());
         } else if(!ScanUtils.empty(flowProperties.getBranches())) {
@@ -195,11 +190,10 @@ public class TfsController {
     private List<String> determineEmails(Resource resource) {
         List<String> emails = new ArrayList<>();
         if(resource.getCommits() != null) {
-            emails = new ArrayList<>(resource.getCommits()
+            emails = resource.getCommits()
                     .stream()
                     .filter(c -> c.getAuthor() != null && !ScanUtils.empty(c.getAuthor().getEmail()))
-                    .map(c -> c.getAuthor().getEmail())
-                    .collect(Collectors.toList()));
+                    .map(c -> c.getAuthor().getEmail()).collect(Collectors.toList());
             emails.add(resource.getPushedBy().getUniqueName());
         }
         return emails;
@@ -207,28 +201,20 @@ public class TfsController {
 
     private String getAction(HttpServletRequest request) {
         String pathInfo = request.getRequestURI();
-        return pathInfo.substring(pathInfo.length()-4);
+        return pathInfo.substring(pathInfo.length() - 4);
     }
 
-    private Product getProductForName(Optional<String> product) {
-        return product.map(pr -> ScanRequest.Product.valueOf(pr.toUpperCase(Locale.ROOT)))
-            .orElse(ScanRequest.Product.CX);
+    private Product getProductForName(String product) {
+        return Optional.ofNullable(product).map(pr -> ScanRequest.Product.valueOf(pr.toUpperCase(Locale.ROOT)))
+                .orElse(ScanRequest.Product.CX);
     }
 
     /*
      * $1 is http or https
      * $2 is the remainder of the url.
      */
-    private String addTokenToUrl(String url , String token) {
-        return url.replaceAll("^(https?:\\/\\/)(.+$)", "$1"+ token +"@"+"$2");
-    }
-
-    private List<String> createExludeList(Optional<List<String>> list , String defaultString) {
-        return list.orElse(
-                defaultString == null ?
-                    Collections.emptyList()
-                    : Arrays.asList(StringUtils.split(defaultString, ","))
-        );
+    private String addTokenToUrl(String url, String token) {
+        return url.replaceAll("^(https?://)(.+$)", "$1" + token + "@" + "$2");
     }
 
     private void validateBasicAuth(String token){

--- a/src/main/java/com/checkmarx/flow/controller/TfsController.java
+++ b/src/main/java/com/checkmarx/flow/controller/TfsController.java
@@ -90,16 +90,7 @@ public class TfsController extends AdoControllerBase {
         Optional.ofNullable(controllerRequest.getAppOnly())
                 .ifPresent(flowProperties::setTrackApplicationOnly);
 
-        List<String> severityList = Optional.ofNullable(controllerRequest.getSeverity())
-                .orElse(Collections.emptyList());
-        List<String> cweList = Optional.ofNullable(controllerRequest.getCwe())
-                .orElse(Collections.emptyList());
-        List<String> categoryList = Optional.ofNullable(controllerRequest.getCategory())
-                .orElse(Collections.emptyList());
-        List<String> statusList = Optional.ofNullable(controllerRequest.getStatus())
-                .orElse(Collections.emptyList());
-
-        FilterConfiguration filter = filterFactory.getFilter(severityList, cweList, categoryList, statusList, null, flowProperties);
+        FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
 
         setExclusionProperties(cxProperties, controllerRequest);
 

--- a/src/main/java/com/checkmarx/flow/controller/TfsController.java
+++ b/src/main/java/com/checkmarx/flow/controller/TfsController.java
@@ -90,7 +90,7 @@ public class TfsController extends AdoControllerBase {
         Optional.ofNullable(controllerRequest.getAppOnly())
                 .ifPresent(flowProperties::setTrackApplicationOnly);
 
-        FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, flowProperties);
+        FilterConfiguration filter = filterFactory.getFilter(controllerRequest, flowProperties);
 
         setExclusionProperties(cxProperties, controllerRequest);
 

--- a/src/main/java/com/checkmarx/flow/controller/WebhookController.java
+++ b/src/main/java/com/checkmarx/flow/controller/WebhookController.java
@@ -4,9 +4,9 @@ import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.dto.ControllerRequest;
 import com.checkmarx.flow.dto.EventResponse;
 import com.checkmarx.flow.dto.ScanRequest;
-import com.checkmarx.flow.utils.ScanUtils;
 import com.checkmarx.sdk.config.CxProperties;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -43,10 +43,10 @@ public abstract class WebhookController {
     }
 
     protected void setExclusionProperties(CxProperties cxProperties, ControllerRequest target) {
-        if (target.getExcludeFiles() == null && !ScanUtils.empty(cxProperties.getExcludeFiles())) {
+        if (target.getExcludeFiles() == null && StringUtils.isNotEmpty(cxProperties.getExcludeFiles())) {
             target.setExcludeFiles(Arrays.asList(cxProperties.getExcludeFiles().split(",")));
         }
-        if (target.getExcludeFolders() == null && !ScanUtils.empty(cxProperties.getExcludeFolders())) {
+        if (target.getExcludeFolders() == null && StringUtils.isNotEmpty(cxProperties.getExcludeFolders())) {
             target.setExcludeFolders(Arrays.asList(cxProperties.getExcludeFolders().split(",")));
         }
     }
@@ -59,16 +59,16 @@ public abstract class WebhookController {
 
     protected List<String> getBranches(ControllerRequest request, FlowProperties flowProperties) {
         List<String> result = new ArrayList<>();
-        if (!ScanUtils.empty(request.getBranch())) {
+        if (CollectionUtils.isNotEmpty(request.getBranch())) {
             result.addAll(request.getBranch());
-        } else if (!ScanUtils.empty(flowProperties.getBranches())) {
+        } else if (CollectionUtils.isNotEmpty(flowProperties.getBranches())) {
             result.addAll(flowProperties.getBranches());
         }
         return result;
     }
 
     protected void overrideScanPreset(ControllerRequest controllerRequest, ScanRequest scanRequest) {
-        if (!ScanUtils.empty(controllerRequest.getPreset())) {
+        if (StringUtils.isNotEmpty(controllerRequest.getPreset())) {
             scanRequest.setScanPreset(controllerRequest.getPreset());
             scanRequest.setScanPresetOverride(true);
         }

--- a/src/main/java/com/checkmarx/flow/controller/WebhookController.java
+++ b/src/main/java/com/checkmarx/flow/controller/WebhookController.java
@@ -20,8 +20,8 @@ import java.util.Optional;
  * Contains common logic for controllers that receive webhook requests.
  */
 @Slf4j
-public class WebhookController {
-    protected ResponseEntity<EventResponse> getSuccessResponse() {
+public abstract class WebhookController {
+    protected ResponseEntity<EventResponse> getSuccessMessage() {
         return ResponseEntity.status(HttpStatus.OK).body(EventResponse.builder()
                 .message("Scan Request Successfully Submitted")
                 .success(true)
@@ -42,7 +42,7 @@ public class WebhookController {
                 .build());
     }
 
-    protected void setExclusionProperties(ControllerRequest target, CxProperties cxProperties) {
+    protected void setExclusionProperties(CxProperties cxProperties, ControllerRequest target) {
         if (target.getExcludeFiles() == null && !ScanUtils.empty(cxProperties.getExcludeFiles())) {
             target.setExcludeFiles(Arrays.asList(cxProperties.getExcludeFiles().split(",")));
         }
@@ -51,10 +51,16 @@ public class WebhookController {
         }
     }
 
-    protected List<String> getBranches(List<String> branchesFromQuery, FlowProperties flowProperties) {
+    protected void setBugTracker(FlowProperties flowProperties, ControllerRequest target) {
+        if (StringUtils.isEmpty(target.getBug())) {
+            target.setBug(flowProperties.getBugTracker());
+        }
+    }
+
+    protected List<String> getBranches(ControllerRequest request, FlowProperties flowProperties) {
         List<String> result = new ArrayList<>();
-        if (!ScanUtils.empty(branchesFromQuery)) {
-            result.addAll(branchesFromQuery);
+        if (!ScanUtils.empty(request.getBranch())) {
+            result.addAll(request.getBranch());
         } else if (!ScanUtils.empty(flowProperties.getBranches())) {
             result.addAll(flowProperties.getBranches());
         }

--- a/src/main/java/com/checkmarx/flow/controller/WebhookController.java
+++ b/src/main/java/com/checkmarx/flow/controller/WebhookController.java
@@ -72,4 +72,9 @@ public class WebhookController {
         return Optional.ofNullable(request.getIncremental())
                 .orElse(cxProperties.getIncremental());
     }
+
+    protected ControllerRequest ensureNotNull(ControllerRequest requestToCheck) {
+        return Optional.ofNullable(requestToCheck)
+                .orElseGet(() -> ControllerRequest.builder().build());
+    }
 }

--- a/src/main/java/com/checkmarx/flow/controller/WebhookController.java
+++ b/src/main/java/com/checkmarx/flow/controller/WebhookController.java
@@ -1,0 +1,75 @@
+package com.checkmarx.flow.controller;
+
+import com.checkmarx.flow.config.FlowProperties;
+import com.checkmarx.flow.dto.ControllerRequest;
+import com.checkmarx.flow.dto.EventResponse;
+import com.checkmarx.flow.dto.ScanRequest;
+import com.checkmarx.flow.utils.ScanUtils;
+import com.checkmarx.sdk.config.CxProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Contains common logic for controllers that receive webhook requests.
+ */
+@Slf4j
+public class WebhookController {
+    protected ResponseEntity<EventResponse> getSuccessResponse() {
+        return ResponseEntity.status(HttpStatus.OK).body(EventResponse.builder()
+                .message("Scan Request Successfully Submitted")
+                .success(true)
+                .build());
+    }
+
+    protected ResponseEntity<EventResponse> getBadRequestMessage(IllegalArgumentException cause, ControllerRequest controllerRequest, String product) {
+        String errorMessage = String.format("Error submitting Scan Request. Product or Bugtracker option incorrect %s | %s",
+                StringUtils.defaultIfEmpty(product, ""),
+                StringUtils.defaultIfEmpty(controllerRequest.getBug(), ""));
+
+        log.error(errorMessage, cause);
+        ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(EventResponse.builder()
+                .message(errorMessage)
+                .success(false)
+                .build());
+    }
+
+    protected void setExclusionProperties(ControllerRequest target, CxProperties cxProperties) {
+        if (target.getExcludeFiles() == null && !ScanUtils.empty(cxProperties.getExcludeFiles())) {
+            target.setExcludeFiles(Arrays.asList(cxProperties.getExcludeFiles().split(",")));
+        }
+        if (target.getExcludeFolders() == null && !ScanUtils.empty(cxProperties.getExcludeFolders())) {
+            target.setExcludeFolders(Arrays.asList(cxProperties.getExcludeFolders().split(",")));
+        }
+    }
+
+    protected List<String> getBranches(List<String> branchesFromQuery, FlowProperties flowProperties) {
+        List<String> result = new ArrayList<>();
+        if (!ScanUtils.empty(branchesFromQuery)) {
+            result.addAll(branchesFromQuery);
+        } else if (!ScanUtils.empty(flowProperties.getBranches())) {
+            result.addAll(flowProperties.getBranches());
+        }
+        return result;
+    }
+
+    protected void overrideScanPreset(ControllerRequest controllerRequest, ScanRequest scanRequest) {
+        if (!ScanUtils.empty(controllerRequest.getPreset())) {
+            scanRequest.setScanPreset(controllerRequest.getPreset());
+            scanRequest.setScanPresetOverride(true);
+        }
+    }
+
+    protected boolean isScanIncremental(ControllerRequest request, CxProperties cxProperties) {
+        return Optional.ofNullable(request.getIncremental())
+                .orElse(cxProperties.getIncremental());
+    }
+}

--- a/src/main/java/com/checkmarx/flow/dto/ControllerRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/ControllerRequest.java
@@ -4,6 +4,12 @@ import lombok.*;
 
 import java.util.List;
 
+/**
+ * Represents a standard list of parameters that are passed to webhook controllers.
+ * All the parameters are optional.
+ *
+ * Field names need to be kept as is for backward compatibility unless we find a better solution.
+ */
 @Getter
 @Setter
 @Builder
@@ -23,6 +29,11 @@ public class ControllerRequest {
     private Boolean incremental;
     private List<String> excludeFiles;
     private List<String> excludeFolders;
+    private String override;
+
+    // Bug tracker.
     private String bug;
+
+    // trackApplicationOnly
     private Boolean appOnly;
 }

--- a/src/main/java/com/checkmarx/flow/dto/ControllerRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/ControllerRequest.java
@@ -23,7 +23,6 @@ public class ControllerRequest {
     private Boolean incremental;
     private List<String> excludeFiles;
     private List<String> excludeFolders;
-    private String override;    // never used
     private String bug;
     private Boolean appOnly;
 }

--- a/src/main/java/com/checkmarx/flow/dto/ControllerRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/ControllerRequest.java
@@ -1,0 +1,15 @@
+package com.checkmarx.flow.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ControllerRequest {
+    private String application;
+    private List<String> branch;
+}

--- a/src/main/java/com/checkmarx/flow/dto/ControllerRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/ControllerRequest.java
@@ -9,6 +9,9 @@ import java.util.List;
  * All the parameters are optional.
  *
  * Field names need to be kept as is for backward compatibility unless we find a better solution.
+ *
+ * Raw query string values use kebab case (e.g. exclude-files). To support this, a custom filter had to be used.
+ * See {@link com.checkmarx.flow.filter.CaseTransformingFilter}.
  */
 @Getter
 @Setter

--- a/src/main/java/com/checkmarx/flow/dto/ControllerRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/ControllerRequest.java
@@ -39,4 +39,14 @@ public class ControllerRequest {
 
     // trackApplicationOnly
     private Boolean appOnly;
+
+    public ControllerRequest(List<String> severity,
+                             List<String> cwe,
+                             List<String> category,
+                             List<String> status) {
+        this.severity = severity;
+        this.cwe = cwe;
+        this.category = category;
+        this.status = status;
+    }
 }

--- a/src/main/java/com/checkmarx/flow/dto/ControllerRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/ControllerRequest.java
@@ -12,4 +12,18 @@ import java.util.List;
 public class ControllerRequest {
     private String application;
     private List<String> branch;
+    private List<String> severity;
+    private List<String> cwe;
+    private List<String> category;
+    private String project;
+    private String team;
+    private List<String> status;
+    private String assignee;
+    private String preset;
+    private Boolean incremental;
+    private List<String> excludeFiles;
+    private List<String> excludeFolders;
+    private String override;    // never used
+    private String bug;
+    private Boolean appOnly;
 }

--- a/src/main/java/com/checkmarx/flow/dto/azure/AdoDetailsRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/azure/AdoDetailsRequest.java
@@ -1,0 +1,28 @@
+package com.checkmarx.flow.dto.azure;
+
+import lombok.*;
+
+/**
+ * Represents ADO-specific parameters that are passed to {@link com.checkmarx.flow.controller.ADOController}.
+ * All the parameters are optional.
+ *
+ * Field names are quite awkward but have to be kept for backward compatibility, unless we find a better solution.
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdoDetailsRequest {
+    // Issue type
+    private String adoIssue;
+
+    // Issue body
+    private String adoBody;
+
+    // Opened state
+    private String adoOpened;
+
+    // Closed state
+    private String adoClosed;
+}

--- a/src/main/java/com/checkmarx/flow/filter/CaseTransformingFilter.java
+++ b/src/main/java/com/checkmarx/flow/filter/CaseTransformingFilter.java
@@ -1,7 +1,6 @@
 package com.checkmarx.flow.filter;
 
 import com.google.common.base.CaseFormat;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -18,9 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class CaseTransformingFilter extends OncePerRequestFilter {
     @Override
-    protected void doFilterInternal(@NotNull HttpServletRequest request,
-                                    @NotNull HttpServletResponse response,
-                                    @NotNull FilterChain filterChain)
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
         Map<String, String[]> camelCaseParams = new ConcurrentHashMap<>();
 

--- a/src/main/java/com/checkmarx/flow/filter/CaseTransformingFilter.java
+++ b/src/main/java/com/checkmarx/flow/filter/CaseTransformingFilter.java
@@ -1,0 +1,35 @@
+package com.checkmarx.flow.filter;
+
+import com.google.common.base.CaseFormat;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Transforms kebab-case request params to lower camel case.
+ */
+public class CaseTransformingFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(@NotNull HttpServletRequest request,
+                                    @NotNull HttpServletResponse response,
+                                    @NotNull FilterChain filterChain)
+            throws ServletException, IOException {
+        Map<String, String[]> camelCaseParams = new ConcurrentHashMap<>();
+
+        for (String param : request.getParameterMap().keySet()) {
+            String formattedParam = CaseFormat.LOWER_HYPHEN.to(CaseFormat.LOWER_CAMEL, param);
+            camelCaseParams.put(formattedParam, request.getParameterValues(param));
+        }
+
+        ServletRequest requestWrapper = new ParameterOverridingWrapper(camelCaseParams, request);
+        filterChain.doFilter(requestWrapper, response);
+    }
+}

--- a/src/main/java/com/checkmarx/flow/filter/ParameterOverridingWrapper.java
+++ b/src/main/java/com/checkmarx/flow/filter/ParameterOverridingWrapper.java
@@ -1,0 +1,39 @@
+package com.checkmarx.flow.filter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Map;
+
+/**
+ * Returns parameter values from a provided Map instead of taking them from request.
+ */
+class ParameterOverridingWrapper extends HttpServletRequestWrapper {
+    private final Map<String, String[]> parameterOverride;
+
+    public ParameterOverridingWrapper(Map<String, String[]> parameterOverride, HttpServletRequest request) {
+        super(request);
+        this.parameterOverride = parameterOverride;
+    }
+
+    @Override
+    public String getParameter(String name) {
+        return parameterOverride.containsKey(name) ? parameterOverride.get(name)[0] : null;
+    }
+
+    @Override
+    public Enumeration<String> getParameterNames() {
+        return Collections.enumeration(parameterOverride.keySet());
+    }
+
+    @Override
+    public String[] getParameterValues(String name) {
+        return parameterOverride.get(name);
+    }
+
+    @Override
+    public Map<String, String[]> getParameterMap() {
+        return parameterOverride;
+    }
+}

--- a/src/main/java/com/checkmarx/flow/service/FilterFactory.java
+++ b/src/main/java/com/checkmarx/flow/service/FilterFactory.java
@@ -21,19 +21,18 @@ import java.util.Optional;
 @Service
 public class FilterFactory {
     public FilterConfiguration getFilter(ControllerRequest request,
-                                         List<String> state,
                                          @Nullable FlowProperties flowProperties) {
         FilterConfiguration result;
 
         request = Optional.ofNullable(request)
                 .orElse(ControllerRequest.builder().build());
 
-        if (hasRequiredProperties(request) || CollectionUtils.isNotEmpty(state)) {
+        if (hasRequiredProperties(request)) {
             result = getFilter(request.getSeverity(),
                     request.getCwe(),
                     request.getCategory(),
                     request.getStatus(),
-                    state,
+                    null,
                     null);
         } else if (flowProperties != null) {
             result = getFilter(flowProperties);

--- a/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
+++ b/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
@@ -42,7 +42,7 @@ import static java.util.Map.Entry.comparingByKey;
 
 public class ScanUtils {
 
-    private static final String DIV_A_HREF = "<div><a href=\'";
+    private static final String DIV_A_HREF = "<div><a href='";
     public static final String RUNNING = "running";
     public static final String CRLF = "\r\n";
     public static final String MD_H3 = "###";
@@ -179,12 +179,11 @@ public class ScanUtils {
 
         if (filtersObj != null) {
             FilterFactory filterFactory = new FilterFactory();
-            FilterConfiguration filter = filterFactory.getFilter(filtersObj.getSeverity(),
+            ControllerRequest controllerRequest = new ControllerRequest(filtersObj.getSeverity(),
                     filtersObj.getCwe(),
                     filtersObj.getCategory(),
-                    filtersObj.getStatus(),
-                    null,
-                    null);
+                    filtersObj.getStatus());
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, null);
             request.setFilter(filter);
         }
 
@@ -296,12 +295,11 @@ public class ScanUtils {
 
                     Optional.ofNullable(fo.getFilters()).ifPresent(f -> {
                         FilterFactory filterFactory = new FilterFactory();
-                        FilterConfiguration filter = filterFactory.getFilter(f.getSeverity(),
+                        ControllerRequest controllerRequest = new ControllerRequest(f.getSeverity(),
                                 f.getCwe(),
                                 f.getCategory(),
-                                f.getStatus(),
-                                null,
-                                null);
+                                f.getStatus());
+                        FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, null);
                         request.setFilter(filter);
 
                         String filterDescr;
@@ -313,8 +311,6 @@ public class ScanUtils {
                         }
                         overridePropertiesMap.put("filters", filterDescr);
                     });
-
-                    FlowOverride.Thresholds thresholds = flowOverride.getThresholds();
 
                     Optional.ofNullable(flowOverride.getThresholds()).ifPresent(th -> {
                         if ( !(
@@ -391,23 +387,22 @@ public class ScanUtils {
     }
 
     private static Map<FindingSeverity, Integer> getThresholdsMap(FlowOverride.Thresholds thresholds) {
-
-        Map<FindingSeverity, Integer> map = new HashMap<>();
-       if(thresholds.getHigh()!=null){
-           map.put(FindingSeverity.HIGH, thresholds.getHigh());
-       }
-        if(thresholds.getMedium()!=null){
+        Map<FindingSeverity, Integer> map = new EnumMap<>(FindingSeverity.class);
+        if (thresholds.getHigh() != null) {
+            map.put(FindingSeverity.HIGH, thresholds.getHigh());
+        }
+        if (thresholds.getMedium() != null) {
             map.put(FindingSeverity.MEDIUM, thresholds.getMedium());
         }
-        if(thresholds.getLow()!=null){
+        if (thresholds.getLow() != null) {
             map.put(FindingSeverity.LOW, thresholds.getLow());
         }
-        if(thresholds.getInfo()!=null){
+        if (thresholds.getInfo() != null) {
             map.put(FindingSeverity.INFO, thresholds.getInfo());
         }
 
-        return  map;
-     }
+        return map;
+    }
 
     public static BugTracker getBugTracker(@RequestParam(value = "assignee", required = false) String assignee,
                                            BugTracker.Type bugType, JiraProperties jiraProperties, String bugTracker) {

--- a/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
+++ b/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
@@ -183,7 +183,7 @@ public class ScanUtils {
                     filtersObj.getCwe(),
                     filtersObj.getCategory(),
                     filtersObj.getStatus());
-            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, null);
+            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null);
             request.setFilter(filter);
         }
 
@@ -299,7 +299,7 @@ public class ScanUtils {
                                 f.getCwe(),
                                 f.getCategory(),
                                 f.getStatus());
-                        FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null, null);
+                        FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null);
                         request.setFilter(filter);
 
                         String filterDescr;

--- a/src/test/java/com/checkmarx/flow/controller/GitHubControllerTest.java
+++ b/src/test/java/com/checkmarx/flow/controller/GitHubControllerTest.java
@@ -143,9 +143,7 @@ public class GitHubControllerTest {
     public void pushRequestNullControllerNullParameters() {
         GitHubController gitHubController = new GitHubController(null, null, null, null, null, helperService, null, null, null);
         try {
-            gitHubController.pushRequest(null, null, null, null, null, null,
-                    null, null, null, null, null, null, null, null,
-                    null, null, null, null, null);
+            gitHubController.pushRequest(null, null, null, null);
             assert false;
         } catch (MachinaRuntimeException e) {
             assert true;
@@ -156,9 +154,7 @@ public class GitHubControllerTest {
     public void pushRequestNullControllerNullParametersWithBody() {
         GitHubController gitHubController = new GitHubController(null, null, null, null, null, helperService, null, null, null);
         try {
-            gitHubController.pushRequest(validBody, null, null, null, null, null,
-                    null, null, null, null, null, null, null, null,
-                    null, null, null, null, null);
+            gitHubController.pushRequest(validBody, null, null, null);
             assert false;
         } catch (MachinaRuntimeException | InvalidTokenException e) {
             assert true;
@@ -170,9 +166,7 @@ public class GitHubControllerTest {
         properties.setWebhookToken(invalidWebhookToken);
         GitHubController gitHubController = new GitHubController(properties, null, null, null, null, helperService, null, null, null);
         try {
-            gitHubController.pushRequest(validBody, null, null, null, null, null,
-                    null, null, null, null, null, null, null, null,
-                    null, null, null, null, null);
+            gitHubController.pushRequest(validBody, null, null, null);
             assert false;
         } catch (MachinaRuntimeException | InvalidTokenException e) {
             assert true;
@@ -185,9 +179,7 @@ public class GitHubControllerTest {
         properties.setWebhookToken(validWebhookToken);
         GitHubController gitHubController = new GitHubController(properties, null, null, null, null, helperService,null, null, null);
         try {
-            gitHubController.pushRequest(validBody, null, null, null, null, null,
-                    null, null, null, null, null, null, null, null,
-                    null, null, null, null, null);
+            gitHubController.pushRequest(validBody, null, null, null);
             assert false;
         } catch (MachinaRuntimeException | InvalidTokenException e) {
             assert true;
@@ -199,9 +191,7 @@ public class GitHubControllerTest {
         properties.setWebhookToken(validWebhookToken);
         GitHubController gitHubController = new GitHubController(properties, null, null, null, null, helperService, null, null, null);
         try {
-            gitHubController.pushRequest(validBody,validSignature2, null, null, null, null,
-                    null, null, null, null, null, null, null, null,
-                    null, null, null, null, null);
+            gitHubController.pushRequest(validBody,validSignature2, null, null);
             assert false;
         } catch (MachinaRuntimeException e) {
             assert true;
@@ -213,9 +203,7 @@ public class GitHubControllerTest {
         properties.setWebhookToken(validWebhookToken);
         GitHubController gitHubController = new GitHubController(properties, flowProperties, null, null, null, helperService, null, null, null);
         try {
-            gitHubController.pushRequest(validBody, validSignature2, null, null, null, null,
-                    null, null, null, null, null, null, null, null,
-                    null, null, null, null, null);
+            gitHubController.pushRequest(validBody, validSignature2, null, null);
             assert false;
         } catch (MachinaRuntimeException e) {
             assert true;
@@ -229,9 +217,7 @@ public class GitHubControllerTest {
         properties.setToken(invalidWebhookToken);
         GitHubController gitHubController = new GitHubController(properties, flowProperties, null, null, null, helperService, null, null, filterFactory);
         try {
-            gitHubController.pushRequest(validBody, validSignature2, null, null, null, null,
-                    null, null, null, null, null, null, null, null,
-                    null, null, null, null, null);
+            gitHubController.pushRequest(validBody, validSignature2, null, null);
             assert false;
         } catch (MachinaRuntimeException e) {
             assert true;
@@ -260,9 +246,7 @@ public class GitHubControllerTest {
         properties.setToken(invalidWebhookToken);
         GitHubController gitHubController = new GitHubController(properties, flowProperties, cxProperties, null, flowService, helperService, null, null, filterFactory);
         try {
-            gitHubController.pushRequest(validBody, validSignature2, null, null, null, null,
-                    null, null, null, null, null, null, null, null,
-                    null, null, null, null, null);
+            gitHubController.pushRequest(validBody, validSignature2, null, null);
             assert false;
         } catch (InvalidTokenException | InvalidCredentialsException e) {
             assert true;

--- a/src/test/java/com/checkmarx/flow/cucumber/component/filterscript/FilterScriptSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/filterscript/FilterScriptSteps.java
@@ -148,7 +148,7 @@ public class FilterScriptSteps {
     }
 
     private FilterConfiguration getFilterConfiguration() {
-        return filterFactory.getFilter(null, null, flowProperties);
+        return filterFactory.getFilter(null, flowProperties);
     }
 
     private void generateIssues(CxClient cxClientSpy) {

--- a/src/test/java/com/checkmarx/flow/cucumber/component/filterscript/FilterScriptSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/filterscript/FilterScriptSteps.java
@@ -148,12 +148,7 @@ public class FilterScriptSteps {
     }
 
     private FilterConfiguration getFilterConfiguration() {
-        return filterFactory.getFilter(null,
-                null,
-                null,
-                null,
-                null,
-                flowProperties);
+        return filterFactory.getFilter(null, null, flowProperties);
     }
 
     private void generateIssues(CxClient cxClientSpy) {

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/azure/publishing/github2ado/Github2AdoSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/azure/publishing/github2ado/Github2AdoSteps.java
@@ -7,6 +7,7 @@ import com.checkmarx.flow.config.GitHubProperties;
 import com.checkmarx.flow.controller.GitHubController;
 import com.checkmarx.flow.cucumber.integration.azure.publishing.AzureDevopsClient;
 import com.checkmarx.flow.cucumber.integration.azure.publishing.githubflow.ScanResultsBuilder;
+import com.checkmarx.flow.dto.ControllerRequest;
 import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.dto.github.*;
 import com.checkmarx.flow.exception.MachinaException;
@@ -109,7 +110,7 @@ public class Github2AdoSteps {
     @Before("@Github2AdoFeature")
     public void prepareServices() {
         this.flowProperties.setBugTracker(AZURE);
-        this.flowProperties.setBugTrackerImpl(Arrays.asList(AZURE));
+        this.flowProperties.setBugTrackerImpl(Collections.singletonList(AZURE));
         this.adoProperties.setUrl("https://dev.azure.com/");
         issueService = new IssueService(flowProperties);
         issueService.setApplicationContext(applicationContext);
@@ -170,25 +171,16 @@ public class Github2AdoSteps {
 
         try {
             String pullEventStr = mapper.writeValueAsString(pushEvent);
+            ControllerRequest request = ControllerRequest.builder()
+                    .application(repoName)
+                    .branch(Collections.singletonList(branch))
+                    .project(repoName)
+                    .team("\\CxServer\\SP")
+                    .assignee("")
+                    .preset("default")
+                    .build();
 
-            gitHubControllerSpy.pushRequest(
-                    pullEventStr,
-                    "SIGNATURE",
-                    "CX", repoName,
-                    Collections.singletonList(branch), null,
-                    null,
-                    null,
-                    repoName,
-                    "\\CxServer\\SP",
-                    null,
-                    "",
-                    "default",
-                    false,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null);
+            gitHubControllerSpy.pushRequest(pullEventStr, "SIGNATURE", "CX", request);
 
         } catch (JsonProcessingException e) {
             fail("Unable to parse " + pushEvent.toString());

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
@@ -175,27 +175,12 @@ public class CxConfigSteps {
             ControllerRequest request = ControllerRequest.builder()
                     .branch(Collections.singletonList(branch))
                     .application("VB")
+                    .team("\\CxServer\\SP")
+                    .assignee("")
+                    .preset("default")
                     .build();
 
-            gitHubControllerSpy.pullRequest(
-                    pullEventStr,
-                    "SIGNATURE",
-                    "CX",
-                    request,
-                    null,
-                    null,
-                    null,
-                    "VB",
-                    "\\CxServer\\SP",
-                    null,
-                    "",
-                    "default",
-                    false,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null);
+            gitHubControllerSpy.pullRequest(pullEventStr, "SIGNATURE", "CX", request);
 
         } catch (JsonProcessingException e) {
             fail("Unable to parse " + pullEvent.toString());

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
@@ -107,7 +107,7 @@ public class CxConfigSteps {
         this.gitHubProperties.setWebhookToken("1234");
         this.gitHubProperties.setConfigAsCode("cx.config");
         this.gitHubProperties.setApiUrl("https://api.github.com/repos");
-                                         
+
     }
 
     @Before("@CxConfigFeature")
@@ -129,28 +129,28 @@ public class CxConfigSteps {
     }
 
     @Given("github branch is {string} and threshods section is not set application.yml")
-    public void setBranchAndCreatePullReqeust(String branch){
+    public void setBranchAndCreatePullReqeust(String branch) {
         this.branch = branch;
         buildPullRequest();
     }
 
     @And("github branch is {string} with cx.config")
-    public void setBranchAppSet(String branch){
+    public void setBranchAppSet(String branch) {
         setBranchAndCreatePullReqeust(branch);
     }
 
     @Given("github branch is {string} with invalid cx.config")
-    public void setBranchInvalid(String branch){
+    public void setBranchInvalid(String branch) {
         //set filter from application.yml
         setCurrentFilter("severity");
         setBranchAndCreatePullReqeust(branch);
     }
-    
+
     public void buildPullRequest() {
         PullEvent pullEvent = new PullEvent();
         Repository repo = new Repository();
         repo.setName("CxConfigTests");
-                      
+
         repo.setCloneUrl(gitHubProperties.getUrl());
         Owner owner = new Owner();
         owner.setName("");
@@ -162,13 +162,13 @@ public class CxConfigSteps {
         pullRequest.setIssueUrl("");
         Head headBranch = new Head();
         headBranch.setRef(branch);
-                
+
         pullRequest.setHead(headBranch);
         pullRequest.setBase(new Base());
         pullRequest.setStatusesUrl("");
-        
+
         pullEvent.setPullRequest(pullRequest);
-       
+
         try {
             String pullEventStr = mapper.writeValueAsString(pullEvent);
 
@@ -204,62 +204,62 @@ public class CxConfigSteps {
 
     @Given("application.xml contains high thresholds {string} medium thresholds {string} and low thresholds {string}")
     public void thresholdForFindingsOfSeverityIs(String highCount, String mediumCount, String lowCount) {
-        
+
         flowProperties.setThresholds(new HashMap<>());
-        if(StringUtils.isEmptyOrNull(highCount) && StringUtils.isEmptyOrNull(mediumCount) && StringUtils.isEmptyOrNull(lowCount)){
+        if (StringUtils.isEmptyOrNull(highCount) && StringUtils.isEmptyOrNull(mediumCount) && StringUtils.isEmptyOrNull(lowCount)) {
             flowProperties.setThresholds(null);
-        }else {
+        } else {
             if (!StringUtils.isEmptyOrNull(highCount)) {
                 flowProperties.getThresholds().put(FindingSeverity.HIGH, Integer.parseInt(highCount));
             }
             if (!StringUtils.isEmptyOrNull(mediumCount)) {
                 flowProperties.getThresholds().put(FindingSeverity.MEDIUM, Integer.parseInt(mediumCount));
-            } 
+            }
             if (!StringUtils.isEmptyOrNull(lowCount)) {
                 flowProperties.getThresholds().put(FindingSeverity.LOW, Integer.parseInt(lowCount));
             }
         }
     }
-    
-    
+
+
     @Given("application.xml contains filters section with filter type {string}")
     public void setFilter(String filterType) {
-        if(!StringUtils.isEmptyOrNull(filterType)) {
-            String[] filterTypeArr ;
-            if(filterType.contains(",")) {
+        if (!StringUtils.isEmptyOrNull(filterType)) {
+            String[] filterTypeArr;
+            if (filterType.contains(",")) {
                 filterTypeArr = filterType.trim().split(",");
-            }else{
+            } else {
                 filterTypeArr = new String[1];
                 filterTypeArr[0] = filterType;
             }
-            for (String currfilterType: filterTypeArr) {
+            for (String currfilterType : filterTypeArr) {
                 setCurrentFilter(currfilterType);
             }
         }
     }
 
     private void setCurrentFilter(String currSeverity) {
-        
-        switch(currSeverity){
-            case("severity"):
+
+        switch (currSeverity) {
+            case ("severity"):
                 List<String> severity = Arrays.asList(FindingSeverity.HIGH.toString(), FindingSeverity.LOW.toString());
                 flowProperties.setFilterSeverity(severity);
                 break;
-            case("cwe"):
-                List<String> cwe = Arrays.asList("anyOther1","anyOther2","anyOther3");
+            case ("cwe"):
+                List<String> cwe = Arrays.asList("anyOther1", "anyOther2", "anyOther3");
                 flowProperties.setFilterCwe(cwe);
                 break;
-            case("category"):
-                List<String> category = Arrays.asList("anyOther1","anyOther2","anyOther3");
+            case ("category"):
+                List<String> category = Arrays.asList("anyOther1", "anyOther2", "anyOther3");
                 flowProperties.setFilterCategory(category);
                 break;
             default:
                 fail("Invalid Filter");
                 break;
         }
-        
+
     }
-    
+
 
     @And("^(?:SAST detects )?(.*) findings of \"(.+)\" severity$")
     public void sastDetectsFindings(int expectedFindingCount, String severity) {
@@ -267,17 +267,17 @@ public class CxConfigSteps {
     }
 
     private void addFindingsTo(ScanResults target, int count, String severityName) {
-             Object summary = target.getAdditionalDetails().get(Constants.SUMMARY_KEY);
-            assertTrue(summary instanceof Map);
-            ((Map) summary).put(severityName, count);
+        Object summary = target.getAdditionalDetails().get(Constants.SUMMARY_KEY);
+        assertTrue(summary instanceof Map);
+        ((Map) summary).put(severityName, count);
 
     }
 
     @Then("CxFlow {string} the pull request")
     public void cxflowApprovesOrFailsThePullRequest(String approvesOrFails) throws InterruptedException {
-        
+
         validateRequestByConfig(Boolean.FALSE);
-        
+
         processScanResultsInCxFlow();
 
         boolean expectingApproval = approvesOrFails.equals("approves");
@@ -294,6 +294,7 @@ public class CxConfigSteps {
     public void validateFilterFromApp() {
         validateRequestFilter();
     }
+
     private List<String> getFilter(List<Filter> filters, Filter.Type type) {
 
         List<String> filterByType = new ArrayList<>();
@@ -301,43 +302,42 @@ public class CxConfigSteps {
         if (filters == null || filters.isEmpty()) {
             return filterByType;
         }
-        
-        for(Filter filter: filters){
-            if(filter.getType().equals(type)) {
+
+        for (Filter filter : filters) {
+            if (filter.getType().equals(type)) {
                 String value = filter.getValue();
-                if (type.equals(type)) {
-                    filterByType.add(value.toUpperCase(Locale.ROOT));
-                }
+                filterByType.add(value.toUpperCase(Locale.ROOT));
             }
         }
-        
+
         return filterByType;
     }
+
     private void validateRequestFilter() {
         List<Filter> filters = request.getFilter().getSimpleFilters();
         List<String> filterSeverity = getFilter(filters, Filter.Type.SEVERITY);
         List<String> filterCwe = getFilter(filters, Filter.Type.CWE);
         List<String> filterCatergory = getFilter(filters, Filter.Type.TYPE);
-        
+
         boolean asExpected = false;
-        switch(branch){
+        switch (branch) {
             case "test7":
                 //Filter Severity High and Medium:
-                asExpected = filterSeverity.size() ==2 &&
+                asExpected = filterSeverity.size() == 2 &&
                         filterSeverity.contains(FindingSeverity.HIGH.toString()) &&
                         filterSeverity.contains(FindingSeverity.MEDIUM.toString()) &&
                         filterCwe.isEmpty() && filterCatergory.isEmpty();
                 break;
             case "test8":
                 //Filter cwe: "79", "89"
-                asExpected = filterCwe.size() ==2 &&
+                asExpected = filterCwe.size() == 2 &&
                         filterCwe.contains(CWE_79) &&
                         filterCwe.contains(CWE_89) &&
                         filterCatergory.isEmpty() && filterSeverity.isEmpty();
                 break;
             case "test9":
                 // filter category: "XSS_Reflected", "SQL_Injection"
-                asExpected = filterCatergory.size() ==2 &&
+                asExpected = filterCatergory.size() == 2 &&
                         filterCatergory.contains(XSS_REFLECTED) &&
                         filterCatergory.contains(SQL_INJECTION) &&
                         filterCwe.isEmpty() && filterSeverity.isEmpty();
@@ -345,30 +345,30 @@ public class CxConfigSteps {
             case "test10":
                 // filter cwe:    "79", "89"
                 // filter category:   "XSS_Reflected", "SQL_Injection"
-                    
-                asExpected = filterCwe.size() ==2 &&
-                            filterCwe.contains(CWE_79) &&
-                            filterCwe.contains(CWE_89) &&
-                            filterCatergory.size() ==2 &&
-                            filterCatergory.contains(XSS_REFLECTED) &&
-                            filterCatergory.contains(SQL_INJECTION) &&
-                            filterSeverity.isEmpty();
+
+                asExpected = filterCwe.size() == 2 &&
+                        filterCwe.contains(CWE_79) &&
+                        filterCwe.contains(CWE_89) &&
+                        filterCatergory.size() == 2 &&
+                        filterCatergory.contains(XSS_REFLECTED) &&
+                        filterCatergory.contains(SQL_INJECTION) &&
+                        filterSeverity.isEmpty();
                 break;
             case "test11":
                 // filter filter severity: High, Medium
                 // filter category:   "XSS_Reflected", "SQL_Injection"       
                 asExpected =
-                        filterSeverity.size() ==2 &&
+                        filterSeverity.size() == 2 &&
                                 filterSeverity.contains(FindingSeverity.HIGH.toString()) &&
                                 filterSeverity.contains(FindingSeverity.MEDIUM.toString()) &&
                                 filterCatergory.size() == 2 &&
                                 filterCatergory.contains(XSS_REFLECTED) &&
                                 filterCatergory.contains(SQL_INJECTION) &&
-                                filterCwe.isEmpty();        
+                                filterCwe.isEmpty();
                 break;
             case "test12":
                 //Filter Severity High and Low as set by application.yml, cxconfig is ignored due to errors
-                asExpected = filterSeverity.size() ==2 &&
+                asExpected = filterSeverity.size() == 2 &&
                         filterSeverity.contains(FindingSeverity.HIGH.toString()) &&
                         filterSeverity.contains(FindingSeverity.LOW.toString()) &&
                         filterCwe.isEmpty() && filterCatergory.isEmpty();
@@ -378,13 +378,12 @@ public class CxConfigSteps {
                 break;
         }
 
-        if(!asExpected){
+        if (!asExpected) {
             fail("Invalid Filter for branch " + branch + ": " + flowProperties.getThresholds().toString());
         }
-        
+
     }
 
-   
 
     @Then("CxFlow {string} the pull request and cx.config truncates the data in application.yml")
     public void cxflowApprovesOrFailsThePullRequestOverride(String approvesOrFails) throws InterruptedException {
@@ -396,21 +395,21 @@ public class CxConfigSteps {
         boolean expectingApproval = approvesOrFails.equals("approves");
         verifyPullRequestState(expectingApproval);
     }
-    
+
     private void validateRequestByConfig(Boolean thresholdsOverrideTest) {
         boolean asExpected = false;
-        switch(branch){
+        switch (branch) {
             case "test1":
                 //High: 3  Medium: 8  Low: 15
                 asExpected = flowProperties.getThresholds().get(FindingSeverity.HIGH) == 3 &&
-                            flowProperties.getThresholds().get(FindingSeverity.MEDIUM) == 8 &&
-                            flowProperties.getThresholds().get(FindingSeverity.LOW) == 15;
+                        flowProperties.getThresholds().get(FindingSeverity.MEDIUM) == 8 &&
+                        flowProperties.getThresholds().get(FindingSeverity.LOW) == 15;
                 break;
             case "test2":
                 //High: not set  Medium: 8  Low: 15
                 asExpected = flowProperties.getThresholds().get(FindingSeverity.HIGH) == null &&
-                             flowProperties.getThresholds().get(FindingSeverity.MEDIUM) == 8 &&
-                             flowProperties.getThresholds().get(FindingSeverity.LOW) == 15;
+                        flowProperties.getThresholds().get(FindingSeverity.MEDIUM) == 8 &&
+                        flowProperties.getThresholds().get(FindingSeverity.LOW) == 15;
                 break;
             case "test3":
                 //High: 3  Medium: 8  Low: 15
@@ -420,12 +419,11 @@ public class CxConfigSteps {
                 break;
             case "test4":
             case "test5":
-                if(Boolean.TRUE.equals(thresholdsOverrideTest)){
+                if (Boolean.TRUE.equals(thresholdsOverrideTest)) {
                     asExpected = flowProperties.getThresholds().get(FindingSeverity.HIGH) == 2 &&
                             flowProperties.getThresholds().get(FindingSeverity.MEDIUM) == 5 &&
                             flowProperties.getThresholds().get(FindingSeverity.LOW) == 10;
-                }
-                else {
+                } else {
                     asExpected = flowProperties.getThresholds() == null || flowProperties.getThresholds().isEmpty();
                 }
                 break;
@@ -433,14 +431,14 @@ public class CxConfigSteps {
                 fail("Invalid Branch");
                 break;
         }
-        
-        if(!asExpected){
+
+        if (!asExpected) {
             fail("Invalid Threshods for branch " + branch + ": " + flowProperties.getThresholds().toString());
         }
-  
+
     }
 
-    private void processScanResultsInCxFlow() throws InterruptedException{
+    private void processScanResultsInCxFlow() throws InterruptedException {
         try {
             ScanRequest scanRequest = createScanRequest();
 
@@ -472,12 +470,12 @@ public class CxConfigSteps {
 
         scanRequest.setBugTracker(BugTracker.builder().type(BugTracker.Type.GITHUBPULL).build());
         scanRequest.setMergeNoteUri(MERGE_NOTE_URL);
-        
+
         HashMap<String, String> additionalMetdata = new HashMap<>();
         additionalMetdata.put("statuses_url", PULL_REQUEST_STATUSES_URL);
-        
+
         scanRequest.setAdditionalMetadata(additionalMetdata);
-        
+
         return scanRequest;
     }
 
@@ -487,13 +485,12 @@ public class CxConfigSteps {
         when(restTemplateMock.exchange(
                 anyString(), eq(HttpMethod.POST), any(HttpEntity.class), ArgumentMatchers.<Class<String>>any()))
                 .thenAnswer(interceptor);
-        when(restTemplateMock.exchange(anyString(),eq(HttpMethod.GET),isNull(), any(Class.class) )).thenReturn(createResponseForGetComments());
-     }
+        when(restTemplateMock.exchange(anyString(), eq(HttpMethod.GET), isNull(), any(Class.class))).thenReturn(createResponseForGetComments());
+    }
 
     private ResponseEntity<String> createResponseForGetComments() {
         return new ResponseEntity<>("{}", HttpStatus.OK);
     }
-
 
 
     private void initCxClientMock() {
@@ -526,7 +523,7 @@ public class CxConfigSteps {
     private void initMockGitHubController() {
         doNothing().when(gitHubControllerSpy).verifyHmacSignature(any(), any());
     }
-    
+
     private void initServices() {
 
         //gitHubControllerSpy is a spy which will run real methods.
@@ -541,14 +538,14 @@ public class CxConfigSteps {
                 gitHubService,
                 null,
                 filterFactory));
-        
+
         //results service will be a Mock and will work with gitHubService Mock
         //and will not not connect to any external 
         initResultsServiceMock();
     }
 
     private void initResultsServiceMock() {
-        
+
         RestTemplate restTemplateMock = mock(RestTemplate.class);
 
         initMock(restTemplateMock);
@@ -573,9 +570,9 @@ public class CxConfigSteps {
 
     private static ScanResults createFakeScanResults() {
         ScanResults result = new ScanResults();
-        
+
         result.setScanSummary(new CxScanSummary());
-        
+
         Map<String, Object> details = new HashMap<>();
         details.put(Constants.SUMMARY_KEY, new HashMap<>());
         result.setAdditionalDetails(details);
@@ -618,7 +615,7 @@ public class CxConfigSteps {
             return result;
         }
     }
-    
+
     /**
      * Returns scan results as if they were produced by SAST.
      */

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
@@ -7,6 +7,7 @@ import com.checkmarx.flow.config.GitHubProperties;
 import com.checkmarx.flow.config.JiraProperties;
 import com.checkmarx.flow.controller.GitHubController;
 import com.checkmarx.flow.dto.BugTracker;
+import com.checkmarx.flow.dto.ControllerRequest;
 import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.dto.github.*;
 import com.checkmarx.flow.exception.MachinaException;
@@ -171,11 +172,17 @@ public class CxConfigSteps {
         try {
             String pullEventStr = mapper.writeValueAsString(pullEvent);
 
+            ControllerRequest request = ControllerRequest.builder()
+                    .branch(Collections.singletonList(branch))
+                    .application("VB")
+                    .build();
+
             gitHubControllerSpy.pullRequest(
                     pullEventStr,
                     "SIGNATURE",
-                    "CX", "VB",
-                    Arrays.asList(branch), null,
+                    "CX",
+                    request,
+                    null,
                     null,
                     null,
                     "VB",
@@ -235,15 +242,15 @@ public class CxConfigSteps {
         
         switch(currSeverity){
             case("severity"):
-                List<String> severity = Arrays.asList(new String[]{FindingSeverity.HIGH.toString(), FindingSeverity.LOW.toString()});
+                List<String> severity = Arrays.asList(FindingSeverity.HIGH.toString(), FindingSeverity.LOW.toString());
                 flowProperties.setFilterSeverity(severity);
                 break;
             case("cwe"):
-                List<String> cwe = Arrays.asList(new String[]{"anyOther1","anyOther2","anyOther3"});
+                List<String> cwe = Arrays.asList("anyOther1","anyOther2","anyOther3");
                 flowProperties.setFilterCwe(cwe);
                 break;
             case("category"):
-                List<String> category = Arrays.asList(new String[]{"anyOther1","anyOther2","anyOther3"});
+                List<String> category = Arrays.asList("anyOther1","anyOther2","anyOther3");
                 flowProperties.setFilterCategory(category);
                 break;
             default:
@@ -484,8 +491,7 @@ public class CxConfigSteps {
      }
 
     private ResponseEntity<String> createResponseForGetComments() {
-        ResponseEntity<String> result = new ResponseEntity<>("{}", HttpStatus.OK);
-        return result;
+        return new ResponseEntity<>("{}", HttpStatus.OK);
     }
 
 

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/CxConfigBugTrackerSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/CxConfigBugTrackerSteps.java
@@ -6,6 +6,7 @@ import com.checkmarx.flow.config.GitHubProperties;
 import com.checkmarx.flow.config.JiraProperties;
 import com.checkmarx.flow.controller.GitHubController;
 import com.checkmarx.flow.dto.BugTracker;
+import com.checkmarx.flow.dto.ControllerRequest;
 import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.dto.github.*;
 import com.checkmarx.flow.service.FilterFactory;
@@ -197,11 +198,13 @@ public class CxConfigBugTrackerSteps {
         try {
             String pullEventStr = mapper.writeValueAsString(pullEvent);
 
+            ControllerRequest request = ControllerRequest.builder().branch(Collections.singletonList(branch)).application("VB").build();
             gitHubControllerSpy.pullRequest(
                     pullEventStr,
                     "SIGNATURE",
-                    "CX", "VB",
-                    Collections.singletonList(branch), null,
+                    "CX",
+                    request,
+                    null,
                     null,
                     null,
                     "VB",

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/CxConfigBugTrackerSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/CxConfigBugTrackerSteps.java
@@ -198,26 +198,15 @@ public class CxConfigBugTrackerSteps {
         try {
             String pullEventStr = mapper.writeValueAsString(pullEvent);
 
-            ControllerRequest request = ControllerRequest.builder().branch(Collections.singletonList(branch)).application("VB").build();
-            gitHubControllerSpy.pullRequest(
-                    pullEventStr,
-                    "SIGNATURE",
-                    "CX",
-                    request,
-                    null,
-                    null,
-                    null,
-                    "VB",
-                    "\\CxServer\\SP",
-                    null,
-                    "",
-                    "default",
-                    false,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null);
+            ControllerRequest request = ControllerRequest.builder()
+                    .branch(Collections.singletonList(branch))
+                    .application("VB")
+                    .team("\\CxServer\\SP")
+                    .assignee("")
+                    .preset("default")
+                    .build();
+
+            gitHubControllerSpy.pullRequest(pullEventStr, "SIGNATURE", "CX", request);
 
         } catch (JsonProcessingException e) {
             fail("Unable to parse " + pullEvent.toString());

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
@@ -5,6 +5,7 @@ import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.config.GitHubProperties;
 import com.checkmarx.flow.controller.ADOController;
 import com.checkmarx.flow.controller.GitHubController;
+import com.checkmarx.flow.dto.ControllerRequest;
 import com.checkmarx.flow.dto.RepoComment;
 import com.checkmarx.flow.dto.azure.Project;
 import com.checkmarx.flow.dto.azure.Resource;
@@ -32,6 +33,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -166,7 +168,7 @@ public class UpdatePullRequestCommentsSteps {
         }
     }
 
-    private void validateCommentsUpdated(List<RepoComment> comments) throws IOException {
+    private void validateCommentsUpdated(List<RepoComment> comments) {
         for (RepoComment comment: comments) {
             Assert.assertTrue("Comment was not updated", isCommentUpdated(comment));
         }
@@ -181,7 +183,7 @@ public class UpdatePullRequestCommentsSteps {
     public void verify2NewComments() throws IOException {
         List<RepoComment> comments = getRepoComments();
         Assert.assertEquals("Wrong number of comments", 2, comments.size());
-        comments.stream().forEach(c -> Assert.assertTrue("Comment is not new (probably updated", isCommentNew(c)));
+        comments.forEach(c -> Assert.assertTrue("Comment is not new (probably updated", isCommentNew(c)));
 
     }
 
@@ -259,11 +261,17 @@ public class UpdatePullRequestCommentsSteps {
         try {
             String pullEventStr = mapper.writeValueAsString(pullEvent);
 
+            ControllerRequest request = ControllerRequest.builder()
+                    .branch(Collections.singletonList(branch))
+                    .application("VB")
+                    .build();
+
             gitHubControllerSpy.pullRequest(
                     pullEventStr,
                     "SIGNATURE",
-                    "CX", "VB",
-                    Arrays.asList(branch), null,
+                    "CX",
+                    request,
+                    null,
                     null,
                     null,
                     "VB",

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
@@ -303,7 +303,11 @@ public class UpdatePullRequestCommentsSteps {
 
         pullEvent.setResource(resource);
 
-        adoControllerSpy.pullRequest(pullEvent,"Basic Y3hmbG93OjEyMzQ=", null, null,null,null,null,null,"AdoPullRequestTests-master", "\\CxServer\\SP",null,null,null,null,null,null,null,null,null,null,null,null, null);
+        ControllerRequest request = ControllerRequest.builder()
+                .project("AdoPullRequestTests-master")
+                .team("\\CxServer\\SP")
+                .build();
+        adoControllerSpy.pullRequest(pullEvent,"Basic Y3hmbG93OjEyMzQ=", null, request, null);
     }
 
     private class ScanResultsAnswerer implements Answer<ScanResults> {

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
@@ -84,7 +84,7 @@ public class UpdatePullRequestCommentsSteps {
     @Before
     public void initMocks() {
         flowProperties.getBranches().add("udi-tests-2");
-        flowProperties.setEnabledVulnerabilityScanners(Arrays.asList("sast"));
+        flowProperties.setEnabledVulnerabilityScanners(Collections.singletonList("sast"));
         initGitHubControllerSpy();
         initHelperServiceMock();
     }
@@ -264,27 +264,12 @@ public class UpdatePullRequestCommentsSteps {
             ControllerRequest request = ControllerRequest.builder()
                     .branch(Collections.singletonList(branch))
                     .application("VB")
+                    .team("\\CxServer\\SP")
+                    .assignee("")
+                    .preset("default")
                     .build();
 
-            gitHubControllerSpy.pullRequest(
-                    pullEventStr,
-                    "SIGNATURE",
-                    "CX",
-                    request,
-                    null,
-                    null,
-                    null,
-                    "VB",
-                    "\\CxServer\\SP",
-                    null,
-                    "",
-                    "default",
-                    false,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null);
+            gitHubControllerSpy.pullRequest(pullEventStr, "SIGNATURE", "CX", request);
 
         } catch (JsonProcessingException e) {
             fail("Unable to parse " + pullEvent.toString());
@@ -330,6 +315,6 @@ public class UpdatePullRequestCommentsSteps {
 
     enum SourceControlType {
         GITHUB,
-        ADO;
+        ADO
     }
 }

--- a/src/test/java/com/checkmarx/flow/utils/github/GitHubTestUtils.java
+++ b/src/test/java/com/checkmarx/flow/utils/github/GitHubTestUtils.java
@@ -5,6 +5,7 @@ import com.checkmarx.flow.controller.GitHubController;
 import com.checkmarx.flow.cucumber.common.Constants;
 import com.checkmarx.flow.cucumber.common.utils.TestUtils;
 import com.checkmarx.flow.custom.GitHubIssueTracker;
+import com.checkmarx.flow.dto.ControllerRequest;
 import com.checkmarx.flow.dto.Issue;
 import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.exception.MachinaException;
@@ -137,16 +138,14 @@ public class GitHubTestUtils implements GitHubTestUtilsImpl {
 
     /**
      * Executes a controller method that corresponds to eventType.
-     * No parameter overrides are passed to the call.
+     * No parameter overrides are passed to the call besides project name.
      */
     public void callController(GitHubController controller, EventType eventType, @Nullable String projectNameOverride) {
         String body = loadWebhookRequestBody(eventType);
         String signature = createSignature(body);
         if (eventType == EventType.PULL_REQUEST) {
             controller.pullRequest(body, signature,
-                    null, null, null, null, null, projectNameOverride,
-                    null, null, null, null, null, null,
-                    null, null, null, null);
+                    null, ControllerRequest.builder().project(projectNameOverride).build());
         } else {
             controller.pushRequest(body, signature,
                     null, null, null, null, null, null, projectNameOverride,

--- a/src/test/java/com/checkmarx/flow/utils/github/GitHubTestUtils.java
+++ b/src/test/java/com/checkmarx/flow/utils/github/GitHubTestUtils.java
@@ -144,7 +144,7 @@ public class GitHubTestUtils implements GitHubTestUtilsImpl {
         String signature = createSignature(body);
         if (eventType == EventType.PULL_REQUEST) {
             controller.pullRequest(body, signature,
-                    null, null, null, null, null, null, projectNameOverride,
+                    null, null, null, null, null, projectNameOverride,
                     null, null, null, null, null, null,
                     null, null, null, null);
         } else {

--- a/src/test/java/com/checkmarx/flow/utils/github/GitHubTestUtils.java
+++ b/src/test/java/com/checkmarx/flow/utils/github/GitHubTestUtils.java
@@ -143,14 +143,11 @@ public class GitHubTestUtils implements GitHubTestUtilsImpl {
     public void callController(GitHubController controller, EventType eventType, @Nullable String projectNameOverride) {
         String body = loadWebhookRequestBody(eventType);
         String signature = createSignature(body);
+        ControllerRequest request = ControllerRequest.builder().project(projectNameOverride).build();
         if (eventType == EventType.PULL_REQUEST) {
-            controller.pullRequest(body, signature,
-                    null, ControllerRequest.builder().project(projectNameOverride).build());
+            controller.pullRequest(body, signature, null, request);
         } else {
-            controller.pushRequest(body, signature,
-                    null, null, null, null, null, null, projectNameOverride,
-                    null, null, null, null, null, null,
-                    null, null, null, null);
+            controller.pushRequest(body, signature, null, request);
         }
     }
 


### PR DESCRIPTION
### Description

Returning technical debt: webhook handler methods had lots of arguments. These arguments are bound to request query string. This made the controller code difficult to maintain and read. 

The main changes:
- extract arguments that are common for the controllers into a separate class (ControllerRequest)
- extract the common arguments of ADO/TFS controllers into the AdoDetailsRequest class
- extract duplicate code into base classes: WebhookController and AdoControllerBase

Some query string parameters are defined using kebab case, e.g. `exclude-files`. Spring Boot doesn't support binding such parameters to class fields out of the box. To fix this, CaseTransformingFilter was added.

### References
[Work item 154](https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/154/).

### Testing

The changes are covered by existing tests that involve calls to webhook controllers.

