### PR TITLE
Fixed: SAST threshold tests sometimes failed after SCA threshold tests were added

### DIFF
--- a/src/main/java/com/checkmarx/flow/service/ThresholdValidatorImpl.java
+++ b/src/main/java/com/checkmarx/flow/service/ThresholdValidatorImpl.java
@@ -46,8 +46,6 @@ public class ThresholdValidatorImpl implements ThresholdValidator {
 
     @Override
     public boolean isMergeAllowed(ScanResults scanResults, RepoProperties repoProperties, PullRequestReport pullRequestReport) {
-        log.info("getEnabledVulnerabilityScanners: {}", flowProperties.getEnabledVulnerabilityScanners());
-        log.info("flowProperties {}", flowProperties);
         OperationResult requestResult = new OperationResult(OperationStatus.SUCCESS, MERGE_SUCCESS_DESCRIPTION);
         boolean isMergeAllowed = isAllowed(scanResults, repoProperties, pullRequestReport);
 

--- a/src/main/java/com/checkmarx/flow/service/ThresholdValidatorImpl.java
+++ b/src/main/java/com/checkmarx/flow/service/ThresholdValidatorImpl.java
@@ -19,7 +19,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
+import java.util.EnumMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -166,12 +170,13 @@ public class ThresholdValidatorImpl implements ThresholdValidator {
         Map<Severity, Integer> scaFindingsCountsPerSeverity = getScaFindingsCountsPerSeverity(scanResults);
         pullRequestReport.setScaFindingsSeverityCount(scaFindingsCountsPerSeverity);
 
-        for (Severity severity : scaFindingsCountsPerSeverity.keySet()) {
+        for (Map.Entry<Severity, Integer> entry : scaFindingsCountsPerSeverity.entrySet()) {
+            Severity severity = entry.getKey();
             Integer thresholdCount = scaThresholds.get(severity);
             if (thresholdCount == null) {
                 continue;
             }
-            Integer findingsCount = scaFindingsCountsPerSeverity.get(severity);
+            Integer findingsCount = entry.getValue();
             if (findingsCount > thresholdCount) {
                 isExceeded = true;
                 logScaThresholdExceedsCounts(true, severity, thresholdCount, findingsCount);
@@ -186,12 +191,6 @@ public class ThresholdValidatorImpl implements ThresholdValidator {
 
 
     private static boolean isExceedsScaThresholdsScore(ScanResults scanResults, Double scaThresholdsScore) {
-        if (scanResults == null
-                || scanResults.getScaResults() == null
-                || scanResults.getScaResults().getSummary() == null) {
-            throw new IllegalStateException("Unable to check SCA thresholds: CxSCA scan results are missing.");
-        }
-
         double summaryRiskScore = scanResults.getScaResults().getSummary().getRiskScore();
 
         boolean isExceeded = scaThresholdsScore != null && (summaryRiskScore > scaThresholdsScore);

--- a/src/main/java/com/checkmarx/flow/service/ThresholdValidatorImpl.java
+++ b/src/main/java/com/checkmarx/flow/service/ThresholdValidatorImpl.java
@@ -29,7 +29,7 @@ public class ThresholdValidatorImpl implements ThresholdValidator {
 
     private static final String MERGE_SUCCESS_DESCRIPTION = "Checkmarx Scan Completed";
     private static final String MERGE_FAILURE_DESCRIPTION = "Checkmarx Scan completed. Vulnerability scan failed";
-    
+
     private final FlowProperties flowProperties;
     private final ScaProperties scaProperties;
     private final SastScanner sastScanner;
@@ -46,19 +46,20 @@ public class ThresholdValidatorImpl implements ThresholdValidator {
 
     @Override
     public boolean isMergeAllowed(ScanResults scanResults, RepoProperties repoProperties, PullRequestReport pullRequestReport) {
+        log.info("getEnabledVulnerabilityScanners: {}", flowProperties.getEnabledVulnerabilityScanners());
 
         OperationResult requestResult = new OperationResult(OperationStatus.SUCCESS, MERGE_SUCCESS_DESCRIPTION);
         boolean isMergeAllowed = isAllowed(scanResults, repoProperties, pullRequestReport);
-        
+
         if (!isMergeAllowed) {
             requestResult = new OperationResult(OperationStatus.FAILURE, MERGE_FAILURE_DESCRIPTION);
         }
 
         pullRequestReport.setPullRequestResult(requestResult);
-        
+
         return isMergeAllowed;
     }
-    
+
     private boolean isAllowed(ScanResults scanResults, RepoProperties repoProperties, PullRequestReport pullRequestReport) {
         if (!repoProperties.isErrorMerge()) {
             log.info("Merge is allowed, because error-merge is set to false.");
@@ -185,6 +186,14 @@ public class ThresholdValidatorImpl implements ThresholdValidator {
 
 
     private static boolean isExceedsScaThresholdsScore(ScanResults scanResults, Double scaThresholdsScore) {
+        if (scanResults == null) {
+            log.info("scanResults is null");
+        } else if (scanResults.getScaResults() == null) {
+            log.info("getScaResults is null");
+        } else if (scanResults.getScaResults().getSummary() == null) {
+            log.info("getSummary is null");
+        }
+
         double summaryRiskScore = scanResults.getScaResults().getSummary().getRiskScore();
 
         boolean isExceeded = scaThresholdsScore != null && (summaryRiskScore > scaThresholdsScore);

--- a/src/test/java/com/checkmarx/flow/cucumber/component/thresholds/sastPR/ThresholdsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/thresholds/sastPR/ThresholdsSteps.java
@@ -103,6 +103,9 @@ public class ThresholdsSteps {
 
     @Before("@ThresholdsFeature")
     public void prepareServices() {
+        log.info("setting scan engine to CxSAST");
+        flowProperties.setEnabledVulnerabilityScanners(Collections.singletonList(CxProperties.CONFIG_PREFIX));
+
         initMock(cxClientMock);
         initMock(restTemplateMock);
         scanResultsToInject = createFakeScanResults();

--- a/src/test/java/com/checkmarx/flow/cucumber/component/thresholds/sastPR/ThresholdsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/thresholds/sastPR/ThresholdsSteps.java
@@ -10,10 +10,10 @@ import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.exception.MachinaException;
 import com.checkmarx.flow.service.ADOService;
 import com.checkmarx.flow.service.GitHubService;
-import com.checkmarx.flow.service.ThresholdValidator;
 import com.checkmarx.flow.service.ResultsService;
 import com.checkmarx.flow.service.SCAScanner;
 import com.checkmarx.flow.service.SastScanner;
+import com.checkmarx.flow.service.ThresholdValidator;
 import com.checkmarx.sdk.config.Constants;
 import com.checkmarx.sdk.config.CxProperties;
 import com.checkmarx.sdk.config.ScaProperties;
@@ -42,7 +42,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -243,7 +247,7 @@ public class ThresholdsSteps {
   
         when(sendingPostRequest).thenAnswer(interceptor);
         when(restTemplateMock.exchange(anyString(),eq(HttpMethod.GET),any(), any(Class.class) ))
-                .thenReturn(new ResponseEntity<>("{}", HttpStatus.OK));
+                .thenReturn(ResponseEntity.ok("{}"));
     }
 
     private void initMock(CxClient cxClientMock) {

--- a/src/test/java/com/checkmarx/flow/cucumber/component/thresholds/sastPR/ThresholdsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/thresholds/sastPR/ThresholdsSteps.java
@@ -42,10 +42,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -214,7 +211,7 @@ public class ThresholdsSteps {
         ScanRequest scanRequest = new ScanRequest();
         BugTracker.Type issueTruckerType;
 
-        Map<String, String> additionalMetadata = new HashMap<String, String>();
+        Map<String, String> additionalMetadata = new HashMap<>();
         additionalMetadata.put(STATUSES_URL_KEY, PULL_REQUEST_STATUSES_URL);
         
         if(isGitHub) {
@@ -242,14 +239,9 @@ public class ThresholdsSteps {
                 anyString(), eq(HttpMethod.POST), any(HttpEntity.class), ArgumentMatchers.<Class<String>>any());
   
         when(sendingPostRequest).thenAnswer(interceptor);
-        when(restTemplateMock.exchange(anyString(),eq(HttpMethod.GET),any(), any(Class.class) )).thenReturn(createResponseForGetComments());
+        when(restTemplateMock.exchange(anyString(),eq(HttpMethod.GET),any(), any(Class.class) ))
+                .thenReturn(new ResponseEntity<>("{}", HttpStatus.OK));
     }
-
-    private ResponseEntity<String> createResponseForGetComments() {
-        ResponseEntity<String> result = new ResponseEntity<>("{}", HttpStatus.OK);
-        return result;
-    }
-
 
     private void initMock(CxClient cxClientMock) {
         try {

--- a/src/test/java/com/checkmarx/flow/cucumber/component/thresholds/scaPR/ScaThresholdsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/thresholds/scaPR/ScaThresholdsSteps.java
@@ -1,5 +1,6 @@
 package com.checkmarx.flow.cucumber.component.thresholds.scaPR;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -77,7 +78,7 @@ public class ScaThresholdsSteps {
 
     @Before("@ThresholdsFeature")
     public void prepareServices() {
-        log.info("setting scan engine to CxSca");
+        log.info("setting scan engine to CxSCA");
         flowProperties.setEnabledVulnerabilityScanners(Collections.singletonList(ScaProperties.CONFIG_PREFIX));
     }
 
@@ -85,13 +86,12 @@ public class ScaThresholdsSteps {
     public void the_following_thresholds_severitys(List<Map<String, String>> thresholds) {
         log.info("found {} threshold-severitys definitions", thresholds.size());
         if (log.isDebugEnabled()) {
-            thresholds.forEach(threshold -> {
-                log.debug("{} --> high: {}, medium: {}, low: {}",
-                        threshold.get(ThresholdFeatureKeys.THRESHOLD_NAME.toKey()),
-                        threshold.get(ThresholdFeatureKeys.THRESHOLD_FOR_HIGH.toKey()),
-                        threshold.get(ThresholdFeatureKeys.THRESHOLD_FOR_MEDIUM.toKey()),
-                        threshold.get(ThresholdFeatureKeys.THRESHOLD_FOR_LOW.toKey()));
-            });
+            thresholds.forEach(threshold ->
+                    log.debug("{} --> high: {}, medium: {}, low: {}",
+                            threshold.get(ThresholdFeatureKeys.THRESHOLD_NAME.toKey()),
+                            threshold.get(ThresholdFeatureKeys.THRESHOLD_FOR_HIGH.toKey()),
+                            threshold.get(ThresholdFeatureKeys.THRESHOLD_FOR_MEDIUM.toKey()),
+                            threshold.get(ThresholdFeatureKeys.THRESHOLD_FOR_LOW.toKey())));
         }
         thresholdDefs = thresholds;
     }
@@ -100,10 +100,8 @@ public class ScaThresholdsSteps {
     public void the_following_scan_findings(List<Map<String, String>> findings) {
         log.info("found {} findings definitions", findings.size());
         if (log.isDebugEnabled()) {
-            findings.forEach(finding -> {
-                log.debug("{} --> high: {}, medium: {}, low: {}", finding.get("name"), finding.get("high"),
-                        finding.get("medium"), finding.get("low"));
-            });
+            findings.forEach(finding -> log.debug("{} --> high: {}, medium: {}, low: {}", finding.get("name"), finding.get("high"),
+                    finding.get("medium"), finding.get("low")));
         }
         findingsDefs = findings;
     }
@@ -141,7 +139,7 @@ public class ScaThresholdsSteps {
         PullRequestReport pullRequestReport = new PullRequestReport();
         boolean actual = thresholdValidatorImpl.isMergeAllowed(scanResults, repoProperties, pullRequestReport);
         log.info("is merged allowed = {} (expecting: {})", actual, expected);
-        assertTrue(expected.equals("pass") ? actual : !actual, "is merged allowed = " + actual + ", but was expecting: " + expected);
+        assertEquals(expected.equals("pass"), actual, "is merged allowed = " + actual + ", but was expecting: " + expected);
     }
 
     @When("max findings score is {word} threshold-score")
@@ -178,10 +176,10 @@ public class ScaThresholdsSteps {
         boolean isPassSeverity = Arrays.asList("score", "none").contains(failType);
         boolean isPassScore = Arrays.asList("count", "none").contains(failType);
     
-        thresholdDefs = Arrays.asList(Arrays.stream(ThresholdFeatureKeys.values())
-        .collect(Collectors.toMap(
-            key -> key.name().toLowerCase().replace('_','-'), 
-            key -> key == ThresholdFeatureKeys.THRESHOLD_NAME ? "spec" : "10")));
+        thresholdDefs = Collections.singletonList(Arrays.stream(ThresholdFeatureKeys.values())
+                .collect(Collectors.toMap(
+                        key -> key.name().toLowerCase().replace('_', '-'),
+                        key -> key == ThresholdFeatureKeys.THRESHOLD_NAME ? "spec" : "10")));
 
         findingsDefs = new ArrayList<>();
 
@@ -203,7 +201,7 @@ public class ScaThresholdsSteps {
         scaResults.setScanId("1");
         Summary summary = new Summary();
         Map<Filter.Severity, Integer> summaryMap = new EnumMap<>(Filter.Severity.class);
-        List<Finding> findings = new LinkedList<Finding>();
+        List<Finding> findings = new LinkedList<>();
         Map<String, String> specMap = findingsDefs.stream()
                 .filter(findingsDef -> findingsDef.get("name").equals(findingsName)).findAny().get();
 
@@ -212,8 +210,8 @@ public class ScaThresholdsSteps {
             log.info("{}-spec: {}", severity, spec);
 
             /* create findings */
-            Integer count = Arrays.asList(spec.split("-than-")).stream()
-                    .mapToInt(v -> "more".equals(v) ? 3 : "less".equals(v) ? -3 : Integer.valueOf((String) v))
+            Integer count = Arrays.stream(spec.split("-than-"))
+                    .mapToInt(v -> "more".equals(v) ? 3 : "less".equals(v) ? -3 : Integer.parseInt(v))
                     .reduce(0, Integer::sum);
             log.info("going to generate {} issues with {} severity", count, severity);
             summaryMap.put(Filter.Severity.valueOf(severity.name()), count);

--- a/src/test/resources/cucumber/features/componentTests/thresholds.feature
+++ b/src/test/resources/cucumber/features/componentTests/thresholds.feature
@@ -1,5 +1,4 @@
 @ThresholdsFeature
-@Skip
 Feature: CxFlow should fail builds and pull requests if the number of findings with certain severity is above threshold
   
   Scenario Outline: CxFlow should approve or fail GitHub pull request, depending on whether threshold is exceeded


### PR DESCRIPTION
### Description

thresholds.feature tests failed with NullPointerException if sca-thresholds.feature tests were executed first.

Caused by the same instance of CxProperties that is shared across component tests. 

The issue only reproduced sometimes, because test execution order is not fixed and may change from build to build.

The SCA test overrides enabled vulnerability scanners list in FlowProperties with [sca]. When the SAST test was executed after the SCA tests, it used the scanner list from FlowProperties as is (which is incorrect).

Fixed by explicitly setting enabledVulnerabilityScanners to [sast] at the beginning of the SAST test.

