### PR TITLE
Fixed: Normalize project name in CLI mode to prevent bad characters on project name

### DIFF
--- a/src/main/java/com/checkmarx/flow/service/SastScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/SastScanner.java
@@ -224,6 +224,8 @@ public class SastScanner implements VulnerabilityScanner {
     public void cxFullScan(ScanRequest request) throws ExitThrowable {
 
         try {
+            String effectiveProjectName = projectNameGenerator.determineProjectName(request);
+            request.setProject(effectiveProjectName);
             CompletableFuture<ScanResults> future = executeCxScanFlow(request, null);
 
             if (future.isCompletedExceptionally()) {


### PR DESCRIPTION
### Description

> When running Cx-Flow in CLI mode with project name which contains a '/', the following error will occur:
`HTTP error code 400 BAD_REQUEST while creating project with name dctrn_javaapp_test/k8sCheckmarx under owner id b2252452-0a5f-42a0-8a37-ab803e1a40ac`

Fixed #314 

### References

https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/190
