### PR TITLE
Fix CLI Execution from processing results twice

### DIFF
--- a/src/main/java/com/checkmarx/flow/service/SCAScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/SCAScanner.java
@@ -55,8 +55,8 @@ public class SCAScanner implements VulnerabilityScanner {
         return result;
     }
 
-    public ScanResults cxFullScan(ScanRequest scanRequest, String path) throws ExitThrowable {
-        ScanResults result = null;
+    public ScanResults scan(ScanRequest scanRequest, String path) throws ExitThrowable {
+        ScanResults result;
         log.info("--------------------- Initiating new {} scan ---------------------", SCAN_TYPE);
         SCAResults internalResults = new SCAResults();
 
@@ -73,6 +73,7 @@ public class SCAScanner implements VulnerabilityScanner {
             internalResults = scaClient.scanLocalSource(internalScaParams);
             logRequest(scanRequest, internalResults.getScanId(),  OperationResult.successful());
             result = toScanResults(internalResults);
+
             log.debug("Deleting temp file {}", f.getPath());
             Files.deleteIfExists(Paths.get(cxZipFile));
 
@@ -85,7 +86,6 @@ public class SCAScanner implements VulnerabilityScanner {
         }
         return result;
     }
-
 
     private void logRequest(ScanRequest request, String scanId, OperationResult scanCreationResult) {
         ScanReport report = new ScanReport(scanId, request,request.getRepoUrl(), scanCreationResult, ScanReport.SCA);


### PR DESCRIPTION
… for both/all scanners will need future consideration

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ts/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

CLI Execution was processing results twice.  This change will resolve this.

Logic was removed related to Future processing as the scans were not properly Async compatible.   This should be handle in the future.

### Testing

Manual testing against GitLab and GitHub were conducted to validate the fix.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
