### PR TITLE
 fix #363 - github PR from forked repo handling

### DIFF
--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -161,7 +161,7 @@ public class GitHubController extends WebhookController {
 
             setExclusionProperties(cxProperties, controllerRequest);
             //build request object
-            String gitUrl = repository.getCloneUrl();
+            String gitUrl = pullRequest.getHead().getRepo().getCloneUrl();
             String token = properties.getToken();
             log.info("Using url: {}", gitUrl);
             String gitAuthUrl = gitUrl.replace(Constants.HTTPS, Constants.HTTPS.concat(token).concat("@"));


### PR DESCRIPTION
### Description

Previously, the GitHubController would set the clone URL to the repository's clone URL (equivalent to the PR base branch clone URL); this commit instead sets the clone URL to the clone URL of the pull request HEAD, so that scanned code changes are pulled from the correct repository, whether the PR was from a branch in the same repo or from a branch in a forked repository.

### References

#363 

### Testing
To demonstrate failure case:
1. Fork a repo that is configured with CxFlow webhook
2. Create a branch name that does not exist on the source repository
3. Make a commit on that forked branch
4. open a PR from the forked repo, asking to merge your forked branch onto the default branch of the source repo
5. observe that CxFlow fails to process the event since it cannot find the ref name on the source repo

To test this PR, repeat the steps 1-4 above after this change, and note that all use cases now work as expected

### Checklist

- [X] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
