### PR TITLE
set default branch in GitGubController PR handler

### DIFF
--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -180,6 +180,7 @@ public class GitHubController extends WebhookController {
                     .repoUrlWithAuth(gitAuthUrl)
                     .repoType(ScanRequest.Repository.GITHUB)
                     .branch(currentBranch)
+                    .defaultBranch(repository.getDefaultBranch())
                     .refs(Constants.CX_BRANCH_PREFIX.concat(currentBranch))
                     .mergeNoteUri(event.getPullRequest().getIssueUrl().concat("/comments"))
                     .mergeTargetBranch(targetBranch)


### PR DESCRIPTION
### Description
Set the default branch in GitHubController's PR handler (like it is set in the push handler), so that PRs are processed against the default branch when no branches are listed in the Flow properties.

### References

### Testing

### Checklist

- [X] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
