### PR TITLE
Fixed: config as code parameters overrides scan-request object instead of properties files

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.4.34"
+        CxSBSDK = "0.4.35"
         //cxVersion = "8.90.5"
         springBootVersion = '2.2.6.RELEASE'
         sonarqubeVersion = '2.8'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.4.34"
+        CxSBSDK = "0.4.35"
         //cxVersion = "8.90.5"
         springBootVersion = '2.2.6.RELEASE'
         sonarqubeVersion = '2.8'

--- a/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
@@ -1,5 +1,6 @@
 package com.checkmarx.flow.dto;
 
+import com.checkmarx.flow.config.FindingSeverity;
 import com.checkmarx.flow.service.VulnerabilityScanner;
 import com.checkmarx.sdk.config.ScaConfig;
 import com.checkmarx.sdk.dto.filtering.FilterConfiguration;
@@ -68,6 +69,7 @@ public class ScanRequest {
     private Type type;
     private List<String> activeBranches;
     private FilterConfiguration filter;
+    private Map<FindingSeverity, Integer> thresholds;
     private Map<String, String> additionalMetadata;
     private List<VulnerabilityScanner> vulnerabilityScanners;
     private ScaConfig scaConfig;
@@ -106,6 +108,7 @@ public class ScanRequest {
         this.forceScan = other.forceScan;
         this.vulnerabilityScanners = other.vulnerabilityScanners;
         this.scaConfig = other.scaConfig;
+        this.thresholds = other.thresholds;
     }
 
     public Map<String,String> getAltFields() {

--- a/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
@@ -1,6 +1,7 @@
 package com.checkmarx.flow.dto;
 
 import com.checkmarx.flow.service.VulnerabilityScanner;
+import com.checkmarx.sdk.config.ScaConfig;
 import com.checkmarx.sdk.dto.filtering.FilterConfiguration;
 import lombok.*;
 
@@ -69,6 +70,7 @@ public class ScanRequest {
     private FilterConfiguration filter;
     private Map<String, String> additionalMetadata;
     private List<VulnerabilityScanner> vulnerabilityScanners;
+    private ScaConfig scaConfig;
 
     public ScanRequest(ScanRequest other) {
         this.namespace = other.namespace;
@@ -103,6 +105,7 @@ public class ScanRequest {
         this.filter = other.filter;
         this.forceScan = other.forceScan;
         this.vulnerabilityScanners = other.vulnerabilityScanners;
+        this.scaConfig = other.scaConfig;
     }
 
     public Map<String,String> getAltFields() {

--- a/src/main/java/com/checkmarx/flow/dto/report/PullRequestReport.java
+++ b/src/main/java/com/checkmarx/flow/dto/report/PullRequestReport.java
@@ -36,9 +36,11 @@ public class PullRequestReport extends AnalyticsReport {
     private Double scaThresholdsScore = null;
 
     private OperationResult pullRequestResult;
+    private ScanRequest scanRequest;
 
     public PullRequestReport(ScanDetails scanDetails, ScanRequest request) {
         super(scanDetails.getScanId(), request);
+        this.scanRequest = request;
 
         setEncryptedRepoUrl(request.getRepoUrl());
         if(scanDetails.isOsaScan()){
@@ -66,7 +68,11 @@ public class PullRequestReport extends AnalyticsReport {
         findingMapReport.put(FindingSeverity.INFO, findingsMap.get(Filter.Severity.INFO));
         setFindingsPerSeverity(findingMapReport);
     }
-    
+
+    public ScanRequest getScanRequest() {
+        return scanRequest;
+    }
+
     @Override
     protected String _getOperation() {
         return OPERATION;

--- a/src/main/java/com/checkmarx/flow/service/AbstractASTScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/AbstractASTScanner.java
@@ -139,6 +139,7 @@ public abstract class AbstractASTScanner  implements VulnerabilityScanner{
         return ScanParams.builder()
                 .projectName(scanRequest.getProject())
                 .remoteRepoUrl(parsedUrl)
+                .scaConfig(scanRequest.getScaConfig())
                 .build();
     }
 

--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -8,6 +8,7 @@ import com.checkmarx.flow.dto.FlowOverride;
 import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.utils.ScanUtils;
 import com.checkmarx.sdk.config.CxProperties;
+import com.checkmarx.sdk.config.ScaConfig;
 import com.checkmarx.sdk.config.ScaProperties;
 import com.checkmarx.sdk.dto.CxConfig;
 import com.checkmarx.sdk.dto.Sca;
@@ -195,31 +196,34 @@ public class ConfigurationOverrider {
                 overrideReport.put("exclude files", sf);
             });
         });
-        overridePropertiesSca(Optional.ofNullable(override.getSca()), overrideReport);
+        overridePropertiesSca(Optional.ofNullable(override.getSca()), overrideReport, request);
     }
 
-    private void overridePropertiesSca(Optional<Sca> sca, Map<String, String> overrideReport) {
+    private void overridePropertiesSca(Optional<Sca> sca, Map<String, String> overrideReport, ScanRequest request) {
         if (!sca.isPresent()) {
           return;
         }
 
+        ScaConfig scaConfig = ScaConfig.builder()
+                .build();
+
         sca.map(Sca::getAccessControlUrl).ifPresent(accessControlUrl -> {
-            scaProperties.setAccessControlUrl(accessControlUrl);
+            scaConfig.setAccessControlUrl(accessControlUrl);
             overrideReport.put("accessControlUrl", accessControlUrl);
         });
 
         sca.map(Sca::getApiUrl).ifPresent(apiUrl -> {
-            scaProperties.setApiUrl(apiUrl);
+            scaConfig.setApiUrl(apiUrl);
             overrideReport.put("apiUrl", apiUrl);
         });
 
         sca.map(Sca::getAppUrl).ifPresent(appUrl -> {
-            scaProperties.setAppUrl(appUrl);
+            scaConfig.setAppUrl(appUrl);
             overrideReport.put("appUrl", appUrl);
         });
 
         sca.map(Sca::getTenant).ifPresent(tenant -> {
-            scaProperties.setTenant(tenant);
+            scaConfig.setTenant(tenant);
             overrideReport.put("tenant", tenant);
         });
 
@@ -234,15 +238,16 @@ public class ConfigurationOverrider {
         });
 
         sca.map(Sca::getFilterSeverity).ifPresent(filterSeverity -> {
-            scaProperties.setFilterSeverity(filterSeverity);
+            scaConfig.setFilterSeverity(filterSeverity);
             overrideReport.put("filterSeverity", filterSeverity.toString());
         });
 
         sca.map(Sca::getFilterScore).ifPresent(filterScore -> {
-            scaProperties.setFilterScore(filterScore);
+            scaConfig.setFilterScore(filterScore);
             overrideReport.put("filterScore", String.valueOf(filterScore));
         });
 
+        request.setScaConfig(scaConfig);
     }
 
     /**

--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -228,12 +228,12 @@ public class ConfigurationOverrider {
         });
 
         sca.map(Sca::getThresholdsSeverity).ifPresent(thresholdsSeverity -> {
-            scaProperties.setThresholdsSeverity(thresholdsSeverity);
+            scaConfig.setThresholdsSeverity(thresholdsSeverity);
             overrideReport.put("thresholdsSeverity", convertMapToString(thresholdsSeverity));
         });
 
         sca.map(Sca::getThresholdsScore).ifPresent(thresholdsScore -> {
-            scaProperties.setThresholdsScore(thresholdsScore);
+            scaConfig.setThresholdsScore(thresholdsScore);
             overrideReport.put("thresholdsScore", String.valueOf(thresholdsScore));
         });
 

--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -94,7 +94,7 @@ public class ConfigurationOverrider {
 
         overrideFilters(fo, request, overrideReport);
 
-        overrideThresholds(fo, overrideReport);
+        overrideThresholds(fo, overrideReport, request);
 
         Optional.ofNullable(fo.getVulnerabilityScanners()).ifPresent(vulnerabilityScanners -> {
             List<VulnerabilityScanner> scanRequestVulnerabilityScanner = new ArrayList<>();
@@ -113,19 +113,11 @@ public class ConfigurationOverrider {
 
     }
 
-    private void overrideThresholds(FlowOverride flowOverride, Map<String, String> overrideReport) {
+    private void overrideThresholds(FlowOverride flowOverride, Map<String, String> overrideReport, ScanRequest request) {
         Optional.ofNullable(flowOverride.getThresholds()).ifPresent(thresholds -> {
-            if (!(
-                    thresholds.getHigh() == null &&
-                            thresholds.getMedium() == null &&
-                            thresholds.getLow() == null &&
-                            thresholds.getInfo() == null
-            )) {
-                Map<FindingSeverity, Integer> thresholdsMap = getThresholdsMap(thresholds);
-                if (!thresholdsMap.isEmpty()) {
-                    flowProperties.setThresholds(thresholdsMap);
-                }
-
+            Map<FindingSeverity, Integer> thresholdsMap = getThresholdsMap(thresholds);
+            if (!thresholdsMap.isEmpty()) {
+                request.setThresholds(thresholdsMap);
                 overrideReport.put("thresholds", convertMapToString(thresholdsMap));
             }
         });

--- a/src/main/java/com/checkmarx/flow/service/ThresholdValidatorImpl.java
+++ b/src/main/java/com/checkmarx/flow/service/ThresholdValidatorImpl.java
@@ -134,7 +134,8 @@ public class ThresholdValidatorImpl implements ThresholdValidator {
     }
 
     private boolean areSastThresholdsFromRequestDefined(ScanRequest scanRequest) {
-        return Optional.ofNullable(scanRequest.getThresholds())
+        return Optional.ofNullable(scanRequest)
+                .map(ScanRequest::getThresholds)
                 .map(map -> !map.isEmpty())
                 .orElse(false);
     }
@@ -155,7 +156,8 @@ public class ThresholdValidatorImpl implements ThresholdValidator {
     }
 
     private boolean areScaThresholdsSeverityFromRequestDefined(ScanRequest scanRequest) {
-        return Optional.ofNullable(scanRequest.getScaConfig())
+        return Optional.ofNullable(scanRequest)
+                .map(ScanRequest::getScaConfig)
                 .map(ScaConfig::getThresholdsSeverity)
                 .map(map -> !map.isEmpty())
                 .orElse(false);
@@ -178,7 +180,8 @@ public class ThresholdValidatorImpl implements ThresholdValidator {
     }
 
     private boolean areScaThresholdScoreFromRequestDefined(ScanRequest scanRequest) {
-        return Optional.ofNullable(scanRequest.getScaConfig())
+        return Optional.ofNullable(scanRequest)
+                .map(ScanRequest::getScaConfig)
                 .map(ScaConfig::getThresholdsScore).isPresent();
     }
 
@@ -190,14 +193,16 @@ public class ThresholdValidatorImpl implements ThresholdValidator {
     }
 
     private boolean isScaThresholdsScoreDefined(ScanRequest scanRequest) {
-        return Optional.ofNullable(scanRequest.getScaConfig())
+        return Optional.ofNullable(scanRequest)
+                .map(ScanRequest::getScaConfig)
                 .map(ScaConfig::getThresholdsScore)
                 .map(any -> true)
                 .orElse(scaProperties.getThresholdsScore() != null);
     }
 
     private boolean areScaThresholdsSeverityDefined(ScanRequest scanRequest) {
-        return Optional.ofNullable(scanRequest.getScaConfig())
+        return Optional.ofNullable(scanRequest)
+                .map(ScanRequest::getScaConfig)
                 .map(ScaConfig::getThresholdsSeverity)
                 .map(map -> !map.isEmpty())
                 .orElse(areScaThresholdsSeverityDefinedFromProperties());

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
@@ -368,7 +368,7 @@ public class CxConfigSteps {
         }
 
         if (!asExpected) {
-            fail("Invalid Filter for branch " + branch + ": " + flowProperties.getThresholds().toString());
+            fail("Invalid Filter for branch " + branch + ": " + request.getThresholds().toString());
         }
 
     }
@@ -390,21 +390,21 @@ public class CxConfigSteps {
         switch (branch) {
             case "test1":
                 //High: 3  Medium: 8  Low: 15
-                asExpected = flowProperties.getThresholds().get(FindingSeverity.HIGH) == 3 &&
-                        flowProperties.getThresholds().get(FindingSeverity.MEDIUM) == 8 &&
-                        flowProperties.getThresholds().get(FindingSeverity.LOW) == 15;
+                asExpected = request.getThresholds().get(FindingSeverity.HIGH) == 3 &&
+                        request.getThresholds().get(FindingSeverity.MEDIUM) == 8 &&
+                        request.getThresholds().get(FindingSeverity.LOW) == 15;
                 break;
             case "test2":
                 //High: not set  Medium: 8  Low: 15
-                asExpected = flowProperties.getThresholds().get(FindingSeverity.HIGH) == null &&
-                        flowProperties.getThresholds().get(FindingSeverity.MEDIUM) == 8 &&
-                        flowProperties.getThresholds().get(FindingSeverity.LOW) == 15;
+                asExpected = request.getThresholds().get(FindingSeverity.HIGH) == null &&
+                        request.getThresholds().get(FindingSeverity.MEDIUM) == 8 &&
+                        request.getThresholds().get(FindingSeverity.LOW) == 15;
                 break;
             case "test3":
                 //High: 3  Medium: 8  Low: 15
-                asExpected = flowProperties.getThresholds().get(FindingSeverity.HIGH) == 3 &&
-                        flowProperties.getThresholds().get(FindingSeverity.MEDIUM) == null &&
-                        flowProperties.getThresholds().get(FindingSeverity.LOW) == 15;
+                asExpected = request.getThresholds().get(FindingSeverity.HIGH) == 3 &&
+                        request.getThresholds().get(FindingSeverity.MEDIUM) == null &&
+                        request.getThresholds().get(FindingSeverity.LOW) == 15;
                 break;
             case "test4":
             case "test5":
@@ -422,7 +422,7 @@ public class CxConfigSteps {
         }
 
         if (!asExpected) {
-            fail("Invalid Threshods for branch " + branch + ": " + flowProperties.getThresholds().toString());
+            fail("Invalid Threshods for branch " + branch + ": " + request.getThresholds().toString());
         }
 
     }
@@ -464,6 +464,7 @@ public class CxConfigSteps {
         additionalMetdata.put("statuses_url", PULL_REQUEST_STATUSES_URL);
 
         scanRequest.setAdditionalMetadata(additionalMetdata);
+        scanRequest.setThresholds(request.getThresholds());
 
         return scanRequest;
     }

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigTestRunner.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigTestRunner.java
@@ -9,6 +9,6 @@ import org.junit.runner.RunWith;
         plugin = { "pretty", "summary", "html:build/cucumber/integration/cxconfig"},
         features = "src/test/resources/cucumber/features/integrationTests/cxconfig.feature",
         glue = { "com.checkmarx.flow.cucumber.integration.cxconfig" },
-        tags = "@CxConfigFeature and not @Skip")
+        tags = "@CxConfigFeature and not @Skip and not @Sca_cx_config")
 public class CxConfigTestRunner {
 }

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/sca_scanner/config_as_code/ScaConfigAsCodeSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/sca_scanner/config_as_code/ScaConfigAsCodeSteps.java
@@ -28,8 +28,6 @@ public class ScaConfigAsCodeSteps {
     private final GitHubProperties gitHubProperties;
     private final GitHubService gitHubService;
     private final ConfigurationOverrider configOverrider;
-    private final ScaProperties scaProperties;
-    private final FlowProperties flowProperties;
 
     private ScanRequest scanRequest;
 
@@ -64,25 +62,25 @@ public class ScaConfigAsCodeSteps {
                 case "thresholdsSeverity":
                     failMsg = "SCA thresholds severity from configuration as code is not as expected";
                     expected = "{HIGH=10, MEDIUM=6, LOW=3}";
-                    actual = StringUtils.join(scaProperties.getThresholdsSeverity());
+                    actual = StringUtils.join(scanRequest.getScaConfig().getThresholdsSeverity());
                     Assert.assertEquals(failMsg , expected , actual);
                     break;
                 case "thresholdsScore":
                     failMsg = "SCA thresholds score from configuration as code is not as expected";
                     expected = new Double(8.5);
-                    actual = scaProperties.getThresholdsScore();
+                    actual = scanRequest.getScaConfig().getThresholdsScore();
                     Assert.assertEquals(failMsg , expected , actual);
                     break;
                 case "filterSeverity":
                     failMsg = "SCA filter severity from configuration as code is not as expected";
                     expected = "[high, medium, low]";
-                    actual = scaProperties.getFilterSeverity().toString();
+                    actual = scanRequest.getScaConfig().getFilterSeverity().toString();
                     Assert.assertEquals(failMsg , expected , actual);
                     break;
                 case "filterScore":
                     failMsg = "SCA filter score from configuration as code is not as expected";
                     expected = new Double(7.5);
-                    actual = scaProperties.getFilterScore();
+                    actual = scanRequest.getScaConfig().getFilterScore();
                     Assert.assertEquals(failMsg , expected , actual);
                     break;
                 default:

--- a/src/test/resources/cucumber/data/input-files-toscan/cx.config.src
+++ b/src/test/resources/cucumber/data/input-files-toscan/cx.config.src
@@ -7,6 +7,7 @@
 	"sca": {
 		"appUrl": "https://sca.scacheckmarx.com",
 		"apiUrl": "https://api.scacheckmarx.com",
-		"accessControlUrl": "https://platform.checkmarx.net"
+		"accessControlUrl": "https://platform.checkmarx.net",
+		"tenant": "cxflow"
 	}
 }


### PR DESCRIPTION
### Description

> config as code parameters overrides scan-request object instead of properties files which have caused a bug in the main flow.

### References

https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/201

### Testing
Proper test are validates configuration properties are withing the scanRequest.

