### PR TITLE
Fixed: CxFlow tries do delete a wrong SAST project when the project name was defined in config-as-code

### DIFF
--- a/src/main/java/com/checkmarx/flow/config/GitHubProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/GitHubProperties.java
@@ -1,5 +1,7 @@
 package com.checkmarx.flow.config;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
@@ -8,6 +10,9 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "github")
 @Validated
 public class GitHubProperties extends RepoProperties {
+    @Getter
+    @Setter
+    private boolean useConfigAsCodeFromDefaultBranch;
 
     public String getMergeNoteUri(String namespace, String repo, String mergeId){
         String format = "%s/%s/%s/issues/%s/comments";
@@ -20,5 +25,4 @@ public class GitHubProperties extends RepoProperties {
         return String.format(format, getUrl(), namespace, repo);
         //sample: https://github.com/namespace/repo.git
     }
-
 }

--- a/src/main/java/com/checkmarx/flow/config/RepoProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/RepoProperties.java
@@ -1,5 +1,7 @@
 package com.checkmarx.flow.config;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.PostConstruct;
@@ -12,7 +14,11 @@ public class RepoProperties {
     private String apiUrl;
     private String falsePositiveLabel = "false-positive";
     private String configAsCode = "cx.config";
+
+    @Getter
+    @Setter
     private boolean useConfigAsCodeFromDefaultBranch;
+
     private String openTransition = "open";
     private String closeTransition = "closed";
     private String filePath = ".";
@@ -170,14 +176,6 @@ public class RepoProperties {
 
     public void setCxSummaryHeader(String cxSummaryHeader) {
         this.cxSummaryHeader = cxSummaryHeader;
-    }
-
-    public boolean isUseConfigAsCodeFromDefaultBranch() {
-        return useConfigAsCodeFromDefaultBranch;
-    }
-
-    public void setUseConfigAsCodeFromDefaultBranch(boolean useConfigAsCodeFromDefaultBranch) {
-        this.useConfigAsCodeFromDefaultBranch = useConfigAsCodeFromDefaultBranch;
     }
 
     @PostConstruct

--- a/src/main/java/com/checkmarx/flow/config/RepoProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/RepoProperties.java
@@ -12,6 +12,7 @@ public class RepoProperties {
     private String apiUrl;
     private String falsePositiveLabel = "false-positive";
     private String configAsCode = "cx.config";
+    private boolean useConfigAsCodeFromDefaultBranch;
     private String openTransition = "open";
     private String closeTransition = "closed";
     private String filePath = ".";
@@ -171,12 +172,18 @@ public class RepoProperties {
         this.cxSummaryHeader = cxSummaryHeader;
     }
 
+    public boolean isUseConfigAsCodeFromDefaultBranch() {
+        return useConfigAsCodeFromDefaultBranch;
+    }
+
+    public void setUseConfigAsCodeFromDefaultBranch(boolean useConfigAsCodeFromDefaultBranch) {
+        this.useConfigAsCodeFromDefaultBranch = useConfigAsCodeFromDefaultBranch;
+    }
+
     @PostConstruct
     private void postConstruct() {
-        if(this.apiUrl != null){
-            if(this.apiUrl.endsWith("/")){
-                this.setApiUrl(StringUtils.chop(apiUrl));
-            }
+        if(apiUrl != null && apiUrl.endsWith("/")){
+            setApiUrl(StringUtils.chop(apiUrl));
         }
     }
 }

--- a/src/main/java/com/checkmarx/flow/config/RepoProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/RepoProperties.java
@@ -15,10 +15,6 @@ public class RepoProperties {
     private String falsePositiveLabel = "false-positive";
     private String configAsCode = "cx.config";
 
-    @Getter
-    @Setter
-    private boolean useConfigAsCodeFromDefaultBranch;
-
     private String openTransition = "open";
     private String closeTransition = "closed";
     private String filePath = ".";

--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -419,10 +419,14 @@ public class GitHubController extends WebhookController {
                 .repoUrl(repository.getCloneUrl())
                 .repoType(ScanRequest.Repository.NA)
                 .branch(currentBranch)
+                .defaultBranch(repository.getDefaultBranch())
                 .refs(event.getRef())
                 .build();
 
         request.setScanPresetOverride(false);
+
+        CxConfig cxConfig = gitHubService.getCxConfigOverride(request);
+        request = configOverrider.overrideScanRequestProperties(cxConfig, request);
 
         //deletes a project which is not in the middle of a scan, otherwise it will not be deleted
         sastScanner.deleteProject(request);

--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -431,13 +431,13 @@ public class GitHubController extends WebhookController {
         //deletes a project which is not in the middle of a scan, otherwise it will not be deleted
         sastScanner.deleteProject(request);
 
-        log.info("Process of delete branch has finished successfully");
+        final String MESSAGE = "Branch deletion event was handled successfully.";
+        log.info(MESSAGE);
 
         return ResponseEntity.status(HttpStatus.OK).body(EventResponse.builder()
-                .message("Delete Branch Successfully finished")
+                .message(MESSAGE)
                 .success(true)
                 .build());
-
     }
 
 

--- a/src/main/java/com/checkmarx/flow/service/GitHubService.java
+++ b/src/main/java/com/checkmarx/flow/service/GitHubService.java
@@ -1,8 +1,6 @@
 package com.checkmarx.flow.service;
 
-import com.checkmarx.flow.config.FindingSeverity;
-import com.checkmarx.flow.config.FlowProperties;
-import com.checkmarx.flow.config.GitHubProperties;
+import com.checkmarx.flow.config.*;
 import com.checkmarx.flow.dto.*;
 import com.checkmarx.flow.dto.github.Content;
 import com.checkmarx.flow.dto.report.AnalyticsReport;
@@ -12,23 +10,17 @@ import com.checkmarx.flow.utils.HTMLHelper;
 import com.checkmarx.flow.utils.ScanUtils;
 import com.checkmarx.sdk.dto.CxConfig;
 import com.checkmarx.sdk.dto.ScanResults;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.json.JSONObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.*;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 
 import java.io.IOException;
@@ -37,9 +29,8 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 
 @Service
+@Slf4j
 public class GitHubService extends RepoService {
-    private static final Logger log = LoggerFactory.getLogger(GitHubService.class);
-
     private static final String HTTP_BODY_IS_NULL = "HTTP Body is null for content api ";
     private static final String CONTENT_NOT_FOUND_IN_RESPONSE = "Content not found in JSON response";
     private static final String STATUSES_URL_KEY = "statuses_url";

--- a/src/main/java/com/checkmarx/flow/service/HelperService.java
+++ b/src/main/java/com/checkmarx/flow/service/HelperService.java
@@ -76,16 +76,23 @@ public class HelperService {
         }
 
         // If the script fails above, default to base property check functionality (regex list)
-        for (String aBranch : branches) {
-            if (strMatches(aBranch, branchToCheck)) return true;
-        }
-
-        if (branches.isEmpty() && branchToCheck.equalsIgnoreCase(request.getDefaultBranch())) {
-            log.info("Scanning default branch - {}", request.getDefaultBranch());
+        if (isBranchProtected(branchToCheck, branches, request)) {
             return true;
         }
+
         log.info("Branch {} did not meet the scanning criteria [{}]", branchToCheck, branches);
         return false;
+    }
+
+    public boolean isBranchProtected(String branchToCheck, List<String> protectedBranchPatterns, ScanRequest request) {
+        boolean result;
+        if (protectedBranchPatterns.isEmpty() && branchToCheck.equalsIgnoreCase(request.getDefaultBranch())) {
+            result = true;
+            log.info("Scanning default branch - {}", request.getDefaultBranch());
+        } else {
+            result = protectedBranchPatterns.stream().anyMatch(aBranch -> strMatches(aBranch, branchToCheck));
+        }
+        return result;
     }
 
     private Object executeBranchScript(String scriptFile, ScanRequest request, List<String> branches) {

--- a/src/main/java/com/checkmarx/flow/service/HelperService.java
+++ b/src/main/java/com/checkmarx/flow/service/HelperService.java
@@ -8,6 +8,7 @@ import com.checkmarx.flow.utils.ScanUtils;
 import com.checkmarx.sdk.config.Constants;
 import com.checkmarx.sdk.config.CxProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
@@ -56,15 +57,15 @@ public class HelperService {
         }
     }
 
-    public boolean isBranch2Scan(ScanRequest request, List<String> branches){
+    public boolean isBranch2Scan(ScanRequest request, List<String> branches) {
         String scriptFile = properties.getBranchScript();
         String branch = request.getBranch();
         String targetBranch = request.getMergeTargetBranch();
-        if(!ScanUtils.empty(targetBranch)){ //if targetBranch is set, it is a merge request
+        if (!ScanUtils.empty(targetBranch)) { //if targetBranch is set, it is a merge request
             branch = targetBranch;
         }
         //note:  if script is provided, it is highest priority
-        if(!ScanUtils.empty(scriptFile)){
+        if (!ScanUtils.empty(scriptFile)) {
             log.info("executing external script to determine if branch should be scanned ({})", scriptFile);
             try {
                 String script = getStringFromFile(scriptFile);
@@ -75,21 +76,20 @@ public class HelperService {
                 if (result instanceof Boolean) {
                     return ((boolean) result);
                 }
-            }catch (IOException e){
+            } catch (IOException e) {
                 log.error("Error reading script file {}", scriptFile, e);
             }
         }
         /*Override branches if provided in the request*/
-        if(request.getActiveBranches() != null && !request.getActiveBranches().isEmpty()){
+        if (CollectionUtils.isNotEmpty(request.getActiveBranches())) {
             branches = request.getActiveBranches();
         }
         //If the script fails above, default to base property check functionality (regex list)
-        for( String b: branches){
-            if(strMatches(b, branch)) return true;
+        for (String b : branches) {
+            if (strMatches(b, branch)) return true;
         }
 
-        if (branches.isEmpty() && branch.equalsIgnoreCase(request.getDefaultBranch()))
-        {
+        if (branches.isEmpty() && branch.equalsIgnoreCase(request.getDefaultBranch())) {
             log.info("Scanning default branch - {}", request.getDefaultBranch());
             return true;
         }

--- a/src/main/java/com/checkmarx/flow/service/RepoService.java
+++ b/src/main/java/com/checkmarx/flow/service/RepoService.java
@@ -3,15 +3,11 @@ package com.checkmarx.flow.service;
 import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.dto.Sources;
 import com.checkmarx.sdk.dto.CxConfig;
-import com.checkmarx.sdk.exception.CheckmarxException;
-import com.checkmarx.sdk.utils.ScanUtils;
 
 public abstract class RepoService {
-
     public abstract Sources getRepoContent(ScanRequest request);
 
     public CxConfig getCxConfigOverride(ScanRequest request) {
         return null;
     }
-    
 }

--- a/src/main/java/com/checkmarx/flow/service/SastScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/SastScanner.java
@@ -138,7 +138,7 @@ public class SastScanner implements VulnerabilityScanner {
                     cxBatch(request);
                     break;
                 default:
-                    log.warn("SastScanner does not support scanType of {}, ignoring.");
+                    log.warn("SastScanner does not support scanType of {}, ignoring.", scanType);
                     break;
             }
         } catch (ExitThrowable e) {
@@ -307,9 +307,7 @@ public class SastScanner implements VulnerabilityScanner {
     }
 
     public void deleteProject(ScanRequest request) {
-
         try {
-
             String ownerId = scanRequestConverter.determineTeamAndOwnerID(request);
 
             String projectName = projectNameGenerator.determineProjectName(request);
@@ -320,7 +318,6 @@ public class SastScanner implements VulnerabilityScanner {
             if (projectId != UNKNOWN_INT) {
                 cxService.deleteProject(projectId);
             }
-
         } catch (CheckmarxException e) {
             log.error("Error delete branch " + e.getMessage());
         }

--- a/src/main/java/com/checkmarx/flow/service/SastScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/SastScanner.java
@@ -326,11 +326,14 @@ public class SastScanner implements VulnerabilityScanner {
     private boolean canDeleteProject(Integer projectId, ScanRequest request) {
         boolean result = false;
         if (projectId == null || projectId == UNKNOWN_INT) {
-            log.warn("Project with the provided name is not found, nothing to delete.");
+            log.warn("{} project with the provided name is not found, nothing to delete.", SCAN_TYPE);
         } else {
-            boolean branchIsProtected = helperService.isBranch2Scan(request, flowProperties.getBranches());
+            boolean branchIsProtected = helperService.isBranchProtected(request.getBranch(),
+                    flowProperties.getBranches(),
+                    request);
+
             if (branchIsProtected) {
-                log.warn("Unable to delete project, because the corresponding repo branch is protected.");
+                log.info("Unable to delete {} project, because the corresponding repo branch is protected.", SCAN_TYPE);
             } else {
                 result = true;
             }

--- a/src/test/java/com/checkmarx/flow/cucumber/component/deletebranch/DeleteBranchRunner.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/deletebranch/DeleteBranchRunner.java
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-        features = "src/test/resources/cucumber/features/componentTests/deletBranch.feature",
+        features = "src/test/resources/cucumber/features/componentTests/delete-branch.feature",
         tags = "not @Skip")
 public class DeleteBranchRunner {
 }

--- a/src/test/java/com/checkmarx/flow/cucumber/component/deletebranch/DeleteBranchSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/deletebranch/DeleteBranchSteps.java
@@ -156,7 +156,7 @@ public class DeleteBranchSteps {
         }
     }
 
-    @When("GitHub notifies cxFlow that a {string} branch was deleted")
+    @When("GitHub notifies cxFlow that a {string} branch/ref was deleted")
     public void githubNotifiesCxFlowThatABranchWasDeleted(String deletedBranch) {
         branch = deletedBranch;
         sendDeleteEvent();

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/ConfigAsCodeBranchSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/ConfigAsCodeBranchSteps.java
@@ -1,0 +1,109 @@
+package com.checkmarx.flow.cucumber.integration.cxconfig;
+
+import com.checkmarx.flow.config.FlowProperties;
+import com.checkmarx.flow.config.GitHubProperties;
+import com.checkmarx.flow.controller.GitHubController;
+import com.checkmarx.flow.dto.github.PullEvent;
+import com.checkmarx.flow.service.*;
+import com.checkmarx.sdk.config.CxProperties;
+import io.cucumber.java.en.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.springframework.http.*;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ConfigAsCodeBranchSteps {
+    private static final int BRANCH_ARGUMENT_INDEX = 7;
+
+    private final GitHubProperties gitHubProperties;
+    private final FlowProperties flowProperties;
+    private final CxProperties cxProperties;
+    private final HelperService helperService;
+    private final FilterFactory filterFactory;
+    private final ConfigurationOverrider configOverrider;
+
+    private String defaultBranch;
+    private String actualBranch;
+
+    @Given("use-config-as-code-from-default-branch property in application.yml is set to {string}")
+    public void useConfigAsCodeFromDefaultBranch(String useDefaultBranch) {
+        boolean parsedPropValue = Boolean.parseBoolean(useDefaultBranch);
+        gitHubProperties.setUseConfigAsCodeFromDefaultBranch(parsedPropValue);
+    }
+
+    @And("GitHub repo default branch is {string}")
+    public void githubRepoDefaultBranchIs(String defaultBranch) {
+        this.defaultBranch = defaultBranch;
+    }
+
+    @When("GitHub notifies CxFlow that a pull request was created for the {string} branch")
+    public void githubNotifiesCxFlow(String srcBranch) {
+        log.info("Creating RestTemplate mock.");
+        RestTemplate restTemplateMock = mock(RestTemplate.class);
+        when(gettingFileFromRepo(restTemplateMock)).thenAnswer(this::interceptConfigAsCodeBranch);
+
+        PullEvent pullEvent = CxConfigSteps.createPullEventDto(srcBranch, defaultBranch, gitHubProperties);
+
+        GitHubController controllerSpy = getGitHubControllerSpy(restTemplateMock);
+        CxConfigSteps.sendPullRequest(pullEvent, controllerSpy, srcBranch);
+    }
+
+    private GitHubController getGitHubControllerSpy(RestTemplate restTemplateMock) {
+        log.info("Creating GitHub controller spy.");
+
+        // Don't start automation.
+        FlowService flowServiceMock = mock(FlowService.class);
+
+        GitHubService gitHubService = new GitHubService(restTemplateMock, gitHubProperties, flowProperties, null);
+
+        GitHubController gitHubControllerSpy = Mockito.spy(new GitHubController(gitHubProperties,
+                flowProperties,
+                cxProperties,
+                null,
+                flowServiceMock,
+                helperService,
+                gitHubService,
+                null,
+                filterFactory,
+                configOverrider));
+        doNothing().when(gitHubControllerSpy).verifyHmacSignature(any(), any());
+
+        return gitHubControllerSpy;
+    }
+
+    @Then("CxFlow should get config-as-code from the {string} branch")
+    public void cxflowShouldGetConfigAsCodeFromTheBranch(String expectedBranch) {
+        assertEquals(expectedBranch,
+                actualBranch,
+                "CxFlow has tried to get config-as-code file from an incorrect branch.");
+    }
+
+    private static ResponseEntity<String> gettingFileFromRepo(RestTemplate restTemplateMock) {
+        return restTemplateMock.exchange(anyString(),
+                eq(HttpMethod.GET),
+                any(HttpEntity.class),
+                ArgumentMatchers.<Class<String>>any(),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString());   // expecting branch name here
+    }
+
+    private Object interceptConfigAsCodeBranch(InvocationOnMock invocation) {
+        assertEquals(BRANCH_ARGUMENT_INDEX + 1,
+                invocation.getArguments().length,
+                "Unexpected argument count for the restTemplate call.");
+
+        actualBranch = invocation.getArgument(BRANCH_ARGUMENT_INDEX);
+        return null;
+    }
+}

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
@@ -132,22 +132,22 @@ public class CxConfigSteps {
         flowProperties.setFilterStatus(null);
     }
 
-    @Given("github branch is {string} and threshods section is not set application.yml")
-    public void setBranchAndCreatePullReqeust(String branch) {
+    @Given("github branch is {string} and thresholds section is not set application.yml")
+    public void setBranchAndCreatePullRequest(String branch) {
         this.branch = branch;
         buildPullRequest();
     }
 
     @And("github branch is {string} with cx.config")
     public void setBranchAppSet(String branch) {
-        setBranchAndCreatePullReqeust(branch);
+        setBranchAndCreatePullRequest(branch);
     }
 
     @Given("github branch is {string} with invalid cx.config")
     public void setBranchInvalid(String branch) {
         //set filter from application.yml
         setCurrentFilter("severity");
-        setBranchAndCreatePullReqeust(branch);
+        setBranchAndCreatePullRequest(branch);
     }
 
     public void buildPullRequest() {

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
@@ -23,9 +23,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.java.Before;
-import io.cucumber.java.en.And;
-import io.cucumber.java.en.Given;
-import io.cucumber.java.en.Then;
+import io.cucumber.java.en.*;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jgit.util.StringUtils;
 import org.junit.Assert;
@@ -58,11 +56,11 @@ public class CxConfigSteps {
     public static final String SQL_INJECTION = "SQL_INJECTION";
     public static final String CWE_79 = "79";
     public static final String CWE_89 = "89";
+    private static final ObjectMapper mapper = new ObjectMapper();
 
     private final CxClient cxClientMock;
     private final GitHubService gitHubService;
     private GitHubController gitHubControllerSpy;
-    private final ObjectMapper mapper = new ObjectMapper();
     private final ThresholdValidator thresholdValidator;
     private final FlowProperties flowProperties;
     private final CxProperties cxProperties;
@@ -79,6 +77,7 @@ public class CxConfigSteps {
 
     private final FlowService flowService;
     private String branch;
+
     private ScanRequest request;
     private final JiraProperties jiraProperties;
 
@@ -133,29 +132,52 @@ public class CxConfigSteps {
     }
 
     @Given("github branch is {string} and thresholds section is not set application.yml")
-    public void setBranchAndCreatePullRequest(String branch) {
+    public void setBranchAndSendPullRequest(String branch) {
         this.branch = branch;
-        buildPullRequest();
+        PullEvent pullEvent = createPullEventDto(branch, null, gitHubProperties);
+        sendPullRequest(pullEvent, gitHubControllerSpy, branch);
     }
 
     @And("github branch is {string} with cx.config")
     public void setBranchAppSet(String branch) {
-        setBranchAndCreatePullRequest(branch);
+        setBranchAndSendPullRequest(branch);
     }
 
     @Given("github branch is {string} with invalid cx.config")
     public void setBranchInvalid(String branch) {
         //set filter from application.yml
         setCurrentFilter("severity");
-        setBranchAndCreatePullRequest(branch);
+        setBranchAndSendPullRequest(branch);
     }
 
-    public void buildPullRequest() {
+    static void sendPullRequest(PullEvent pullEvent, GitHubController gitHubController, String sourceBranch) {
+        log.info("Sending pull request event to controller.");
+        try {
+            String pullEventStr = mapper.writeValueAsString(pullEvent);
+
+            ControllerRequest request = ControllerRequest.builder()
+                    .branch(Collections.singletonList(sourceBranch))
+                    .application("VB")
+                    .team("\\CxServer\\SP")
+                    .assignee("")
+                    .preset("default")
+                    .build();
+
+            gitHubController.pullRequest(pullEventStr, "SIGNATURE", "CX", request);
+
+        } catch (JsonProcessingException e) {
+            fail("Unable to parse " + pullEvent.toString());
+        }
+    }
+
+    static PullEvent createPullEventDto(String sourceBranch, String defaultBranch, GitHubProperties gitHubProperties) {
+        log.info("Creating pull event DTO.");
         PullEvent pullEvent = new PullEvent();
         Repository repo = new Repository();
         repo.setName("CxConfigTests");
-
         repo.setCloneUrl(gitHubProperties.getUrl());
+        repo.setDefaultBranch(defaultBranch);
+
         Owner owner = new Owner();
         owner.setName("");
         owner.setLogin("cxflowtestuser");
@@ -165,30 +187,14 @@ public class CxConfigSteps {
         PullRequest pullRequest = new PullRequest();
         pullRequest.setIssueUrl("");
         Head headBranch = new Head();
-        headBranch.setRef(branch);
+        headBranch.setRef(sourceBranch);
 
         pullRequest.setHead(headBranch);
         pullRequest.setBase(new Base());
         pullRequest.setStatusesUrl("");
 
         pullEvent.setPullRequest(pullRequest);
-
-        try {
-            String pullEventStr = mapper.writeValueAsString(pullEvent);
-
-            ControllerRequest request = ControllerRequest.builder()
-                    .branch(Collections.singletonList(branch))
-                    .application("VB")
-                    .team("\\CxServer\\SP")
-                    .assignee("")
-                    .preset("default")
-                    .build();
-
-            gitHubControllerSpy.pullRequest(pullEventStr, "SIGNATURE", "CX", request);
-
-        } catch (JsonProcessingException e) {
-            fail("Unable to parse " + pullEvent.toString());
-        }
+        return pullEvent;
     }
 
     @Given("application.xml contains high thresholds {string} medium thresholds {string} and low thresholds {string}")
@@ -482,7 +488,6 @@ public class CxConfigSteps {
         return new ResponseEntity<>("{}", HttpStatus.OK);
     }
 
-
     private void initCxClientMock() {
         try {
             ScanResultsAnswerer answerer = new ScanResultsAnswerer();
@@ -491,7 +496,6 @@ public class CxConfigSteps {
             Assert.fail("Error initializing mock." + e);
         }
     }
-
 
     /**
      * Returns scan results as if they were produced by SAST.
@@ -502,7 +506,6 @@ public class CxConfigSteps {
             return scanResultsToInject;
         }
     }
-
 
     private void initHelperServiceMock() {
         HelperServiceAnswerer answerer = new HelperServiceAnswerer();
@@ -516,9 +519,9 @@ public class CxConfigSteps {
 
     private void initServices() {
 
-        //gitHubControllerSpy is a spy which will run real methods.
-        //It will connect to a real github repository toread a real cx.config file
-        //And thus it will work with real gitHubService
+        // gitHubControllerSpy is a spy which will run real methods.
+        // It will connect to a real github repository to read a real cx.config file
+        // And thus it will work with real gitHubService
         this.gitHubControllerSpy = spy(new GitHubController(gitHubProperties,
                 flowProperties,
                 cxProperties,
@@ -530,8 +533,8 @@ public class CxConfigSteps {
                 filterFactory,
                 configOverrider));
 
-        //results service will be a Mock and will work with gitHubService Mock
-        //and will not not connect to any external 
+        // results service will be a Mock and will work with gitHubService Mock
+        // and will not connect to any external service.
         initResultsServiceMock();
     }
 

--- a/src/test/resources/cucumber/features/componentTests/delete-branch.feature
+++ b/src/test/resources/cucumber/features/componentTests/delete-branch.feature
@@ -1,7 +1,7 @@
 @DeleteBranchFeature @ComponentTest
 Feature: CxFlow should delete SAST project when corresponding GitHub branch is deleted
   
-  Scenario Outline: CxFlow SAST project when GitHub branch is deleted
+  Scenario Outline: CxFlow deletes SAST project when GitHub branch is deleted
     Given GitHub repoName is "<repoName>"
     And GitHub webhook is configured for delete branch or tag
     And github branch is "<branch>" and it is set "<set_in_app>" application.yml
@@ -29,4 +29,13 @@ Feature: CxFlow should delete SAST project when corresponding GitHub branch is d
       | repoName | trigger | exists |
       | VB_3845  | branch  | true   |
       | VB_3845  | tag     | true   |
-  
+
+
+  @Skip
+  Scenario: CxFlow should not allow automatic deletion of a SAST project when it corresponds
+  to a protected branch
+    Given GitHub repoName is "VB_3845"
+    And a project "VB_3845-test1" exists in SAST
+    And the "test1" branch is specified as protected in application.yml
+    When GitHub notifies cxFlow that a "test1" branch was deleted
+    Then CxFlow will not call the SAST delete API

--- a/src/test/resources/cucumber/features/componentTests/delete-branch.feature
+++ b/src/test/resources/cucumber/features/componentTests/delete-branch.feature
@@ -1,7 +1,7 @@
 @DeleteBranchFeature @ComponentTest
 Feature: CxFlow should delete SAST project when corresponding GitHub branch is deleted
 
-  Scenario Outline: CxFlow deletes SAST project when GitHub branch is deleted
+  Scenario Outline: CxFlow deletes SAST project when a non-protected GitHub branch is deleted
     Given GitHub repo name is "VB_3845"
     And GitHub branch is "test1"
     And the "test1" branch is "<protected>" as determined by application.yml
@@ -23,7 +23,7 @@ Feature: CxFlow should delete SAST project when corresponding GitHub branch is d
     And GitHub trigger is "<trigger>"
     And the "test2" branch is "not protected" as determined by application.yml
     And a project "VB_3845-test2" "exists" in SAST
-    When GitHub notifies cxFlow that a "test2" branch was deleted
+    When GitHub notifies cxFlow that a "test2" ref was deleted
     Then CxFlow will "<call>" the SAST delete API for the "VB_3845-test2" project
     And no exception will be thrown
 

--- a/src/test/resources/cucumber/features/componentTests/delete-branch.feature
+++ b/src/test/resources/cucumber/features/componentTests/delete-branch.feature
@@ -1,41 +1,33 @@
 @DeleteBranchFeature @ComponentTest
 Feature: CxFlow should delete SAST project when corresponding GitHub branch is deleted
-  
+
   Scenario Outline: CxFlow deletes SAST project when GitHub branch is deleted
-    Given GitHub repoName is "<repoName>"
-    And GitHub webhook is configured for delete branch or tag
-    And github branch is "<branch>" and it is set "<set_in_app>" application.yml
-    And a project "<projectName>" "<exists>" in SAST
-    Then CxFlow will call or not call the SAST delete API based on the fact whether the project "<exists>" or not in SAST
-    And SAST delete API will be called for project "<projectName>"
-    And no exception will be thrown
-
-    Examples:
-      | repoName | branch | projectName   | exists | set_in_app |
-      | VB_3845  | test1  | VB_3845-test1 | true   | false      |
-      | VB_3845  | test1  | VB_3845-test1 | true   | true       |
-      | VB_3845  | test1  | VB_3845-test1 | false  | false      |
-    
-  Scenario Outline: Github triggers delete event both when branch and tag are deleted,
-                    but CxFlow will call SAST delete API only when branch is deleted
-    Given GitHub repoName is "<repoName>"
-    And GitHub webhook is configured for delete branch or tag
-    And github trigger can be branch or tag "<trigger>" 
-    And a project "<projectName>" "<exists>" in SAST
-    Then CxFlow will call the SAST delete API only if trigger is branch
-    And no exception will be thrown
-
-    Examples:
-      | repoName | trigger | exists |
-      | VB_3845  | branch  | true   |
-      | VB_3845  | tag     | true   |
-
-
-  @Skip
-  Scenario: CxFlow should not allow automatic deletion of a SAST project when it corresponds
-  to a protected branch
-    Given GitHub repoName is "VB_3845"
-    And a project "VB_3845-test1" exists in SAST
-    And the "test1" branch is specified as protected in application.yml
+    Given GitHub repo name is "VB_3845"
+    And GitHub branch is "test1"
+    And the "test1" branch is "<protected>" as determined by application.yml
+    And a project "VB_3845-test1" "<exists>" in SAST
     When GitHub notifies cxFlow that a "test1" branch was deleted
-    Then CxFlow will not call the SAST delete API
+    Then CxFlow will "<call>" the SAST delete API for the "VB_3845-test1" project
+    And no exception will be thrown
+
+    Examples:
+      | exists | protected | call  |
+      | true   | true      | false |
+      | true   | false     | true  |
+      | false  | true      | false |
+      | false  | false     | false |
+
+  Scenario Outline: Github triggers delete event both when branch and tag are deleted,
+  but CxFlow will call SAST delete API only when branch is deleted
+    Given GitHub repo name is "VB_3845"
+    And GitHub trigger is "<trigger>"
+    And the "test2" branch is "not protected" as determined by application.yml
+    And a project "VB_3845-test2" "exists" in SAST
+    When GitHub notifies cxFlow that a "test2" branch was deleted
+    Then CxFlow will "<call>" the SAST delete API for the "VB_3845-test2" project
+    And no exception will be thrown
+
+    Examples:
+      | trigger | call  |
+      | branch  | true  |
+      | tag     | false |

--- a/src/test/resources/cucumber/features/integrationTests/cxconfig.feature
+++ b/src/test/resources/cucumber/features/integrationTests/cxconfig.feature
@@ -4,7 +4,7 @@ Feature: CxFlow should read configuration from cx.config file in the root of rep
   @Thresholds
   Scenario Outline: CxFlow should approve or fail GitHub pull request, depending on whether threshold is exceeded in cx.config
   GitHub notifies CxFlow that a pull request was created. CxFlow then executes a SAST scan.
-    Given github branch is "<branch>" and threshods section is not set application.yml
+    Given github branch is "<branch>" and thresholds section is not set application.yml
     And SAST detects <high count> findings of "High" severity
     And <medium count> findings of "Medium" severity
     And <low count> findings of "Low" severity
@@ -104,3 +104,13 @@ Feature: CxFlow should read configuration from cx.config file in the root of rep
       | filterSeverity        |
       | filterScore           |
 
+  @Skip
+  Scenario Outline: CxFlow should use config-as-code from a correct branch
+    Given use-config-as-code-from-default-branch property in application.yml is set to "<use default>"
+    And GitHub repo default branch is "master"
+    When GitHub notifies CxFlow that a pull request was created for the "test1" branch
+    Then CxFlow should get config-as-code from the "<branch>" branch
+    Examples:
+      | use default | branch |
+      | true        | master |
+      | false       | test1  |

--- a/src/test/resources/cucumber/features/integrationTests/cxconfig.feature
+++ b/src/test/resources/cucumber/features/integrationTests/cxconfig.feature
@@ -104,7 +104,6 @@ Feature: CxFlow should read configuration from cx.config file in the root of rep
       | filterSeverity        |
       | filterScore           |
 
-  @Skip
   Scenario Outline: CxFlow should use config-as-code from a correct branch
     Given use-config-as-code-from-default-branch property in application.yml is set to "<use default>"
     And GitHub repo default branch is "master"


### PR DESCRIPTION

## Description

This is what happened before the fix:

Suppose user has a 'MyRepo' repository with 'featureBranch' that contains config-as-code. The config-as-code contains
```
"project": "foo-${branch}"
```
no Groovy script for project name generation is present, and 'multi-tenant' is set to 'true' in application.yml.

1. User scans featureBranch with CxFlow => CxFlow creates a SAST project with the name: **foo-featureBranch** (see ConfigurationOverrider#overrideMainProperties).
1.   User deletes 'featureBranch' => 'Branch deleted' event arrives to CxFlow.
1. CxFlow determines corresponding SAST project name as **MyRepo-featureBranch** (see ProjectNameGenerator.determineProjectName()). This happens because CxFlow no longer has access to config-as-code (it was deleted together with the branch).
1. CxFlow tries to delete a SAST project with the 'MyRepo-featureBranch' name. Such project doesn't exist in SAST => an error is thrown.

\* If for some reason a 'MyRepo-featureBranch' project does exist in SAST, then we get a situation when a wrong project is deleted.

### The fix

1. Add support for a new application.yml property:
```use-config-as-code-from-default-branch: true/false```
If true: config-as-code is always loaded from the default repo branch.
If false: config-as-code is loaded from the current branch (this is the default value).
The new property has effect in all the flows (pull, push, delete). The new property is currently supported for GitHub only.

2. Change in deletion flow: if the deleted branch is protected (is within the cx-flow/branches list):
    - Don't delete the corresponding SAST project. This is to prevent accidental errors. E.g. if for some reason config-as-code in 'develop' indicates that SAST project corresponding to 'master' must be deleted.
    - Log a corresponding message.

## References

GitHub issue: #345 
Work item: [202](https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/202/)

## Testing

Added tests for the 2 parts of the fix. See delete-branch.feature and cxconfig.feature.

