### PR TITLE
Added support for multiple optional SCM's instances

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -197,6 +197,7 @@ task integrationTest(type: Test) {
         include 'com/checkmarx/flow/cucumber/integration/azure/publishing/github2ado/*'
         include 'com/checkmarx/flow/cucumber/integration/cxconfig/*'
         include 'com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/**'
+        include 'com/checkmarx/flow/cucumber/integration/multiScmInstances/**'
 
         testLogging {
             events "passed", "skipped", "failed"

--- a/src/main/java/com/checkmarx/flow/config/OptionalScmInstanceProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/OptionalScmInstanceProperties.java
@@ -1,41 +1,14 @@
 package com.checkmarx.flow.config;
 
-public class OptionalScmInstanceProperties {
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+class OptionalScmInstanceProperties {
 
     private String webhookToken;
     private String token;
     private String url;
     private String apiUrl;
-
-    public String getWebhookToken() {
-        return webhookToken;
-    }
-
-    public void setWebhookToken(String webhookToken) {
-        this.webhookToken = webhookToken;
-    }
-
-    public String getToken() {
-        return token;
-    }
-
-    public void setToken(String token) {
-        this.token = token;
-    }
-
-    public String getUrl() {
-        return url;
-    }
-
-    public void setUrl(String url) {
-        this.url = url;
-    }
-
-    public String getApiUrl() {
-        return apiUrl;
-    }
-
-    public void setApiUrl(String apiUrl) {
-        this.apiUrl = apiUrl;
-    }
 }

--- a/src/main/java/com/checkmarx/flow/config/OptionalScmInstanceProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/OptionalScmInstanceProperties.java
@@ -5,7 +5,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-class OptionalScmInstanceProperties {
+public class OptionalScmInstanceProperties {
 
     private String webhookToken;
     private String token;

--- a/src/main/java/com/checkmarx/flow/config/OptionalScmInstanceProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/OptionalScmInstanceProperties.java
@@ -1,0 +1,41 @@
+package com.checkmarx.flow.config;
+
+public class OptionalScmInstanceProperties {
+
+    private String webhookToken;
+    private String token;
+    private String url;
+    private String apiUrl;
+
+    public String getWebhookToken() {
+        return webhookToken;
+    }
+
+    public void setWebhookToken(String webhookToken) {
+        this.webhookToken = webhookToken;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getApiUrl() {
+        return apiUrl;
+    }
+
+    public void setApiUrl(String apiUrl) {
+        this.apiUrl = apiUrl;
+    }
+}

--- a/src/main/java/com/checkmarx/flow/config/RepoProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/RepoProperties.java
@@ -1,10 +1,9 @@
 package com.checkmarx.flow.config;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.PostConstruct;
+import java.util.Map;
 
 public class RepoProperties {
     private boolean enabled;
@@ -26,6 +25,15 @@ public class RepoProperties {
     private String flowSummaryHeader = "Violation Summary";
     private boolean cxSummary = false;
     private String cxSummaryHeader = "Checkmarx Scan Summary";
+    private Map<String, OptionalScmInstanceProperties> optionalInstances;
+
+    public Map<String, OptionalScmInstanceProperties> getOptionalInstances() {
+        return optionalInstances;
+    }
+
+    public void setOptionalInstances(Map<String, OptionalScmInstanceProperties> optionalInstances) {
+        this.optionalInstances = optionalInstances;
+    }
 
     public boolean isEnabled() {
         return enabled;

--- a/src/main/java/com/checkmarx/flow/config/ScmConfigOverrider.java
+++ b/src/main/java/com/checkmarx/flow/config/ScmConfigOverrider.java
@@ -18,6 +18,13 @@ public class ScmConfigOverrider {
                 .orElse(properties.getToken());
     }
 
+    public String determineConfigToken(RepoProperties properties, ControllerRequest controllerRequest) {
+        return Optional.ofNullable(controllerRequest)
+                .map(ControllerRequest::getScmInstance)
+                .map(key -> getScmOverriddenConfig(properties, ScmConfigParams.TOKEN, key))
+                .orElse(properties.getToken());
+    }
+
     public String determineConfigApiUrl(RepoProperties properties, ScanRequest scanRequest) {
         return Optional.ofNullable(scanRequest.getScmInstance())
                 .map(key -> getScmOverriddenConfig(properties, ScmConfigParams.API_URL, key))

--- a/src/main/java/com/checkmarx/flow/config/ScmConfigOverrider.java
+++ b/src/main/java/com/checkmarx/flow/config/ScmConfigOverrider.java
@@ -1,0 +1,45 @@
+package com.checkmarx.flow.config;
+
+import com.checkmarx.flow.dto.ScanRequest;
+import com.checkmarx.flow.exception.MachinaRuntimeException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@Slf4j
+public class ScmConfigOverrider {
+
+    public String determineConfigToken(RepoProperties properties, ScanRequest scanRequest) {
+        return Optional.ofNullable(scanRequest.getScmInstance())
+                .map(key -> getScmOverriddenConfig(properties, ScmConfigParams.TOKEN, key))
+                .orElse(properties.getToken());
+    }
+
+    public String determineConfigApiUrl(RepoProperties properties, ScanRequest scanRequest) {
+        return Optional.ofNullable(scanRequest.getScmInstance())
+                .map(key -> getScmOverriddenConfig(properties, ScmConfigParams.API_URI, key))
+                .orElse(properties.getApiUrl());
+    }
+
+    private String getScmOverriddenConfig(RepoProperties properties, ScmConfigParams configParams, String key) {
+        String value = null;
+        OptionalScmInstanceProperties optionalInstanceKey = properties.getOptionalInstances().get(key);
+        if (optionalInstanceKey == null) {
+            log.warn("scm-instance key: {} does not exists on configuration file. Using default configuration", key);
+        } else {
+            switch (configParams) {
+                case TOKEN:
+                    value = optionalInstanceKey.getToken();
+                    break;
+                case API_URI:
+                    value = optionalInstanceKey.getApiUrl();
+                    break;
+                default:
+                    throw new MachinaRuntimeException("Scm key: " + key + "is not supported");
+            }
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/checkmarx/flow/config/ScmConfigOverrider.java
+++ b/src/main/java/com/checkmarx/flow/config/ScmConfigOverrider.java
@@ -20,7 +20,7 @@ public class ScmConfigOverrider {
 
     public String determineConfigApiUrl(RepoProperties properties, ScanRequest scanRequest) {
         return Optional.ofNullable(scanRequest.getScmInstance())
-                .map(key -> getScmOverriddenConfig(properties, ScmConfigParams.API_URI, key))
+                .map(key -> getScmOverriddenConfig(properties, ScmConfigParams.API_URL, key))
                 .orElse(properties.getApiUrl());
     }
 
@@ -42,11 +42,11 @@ public class ScmConfigOverrider {
                 case TOKEN:
                     value = optionalInstanceKey.getToken();
                     break;
-                case API_URI:
-                    value = optionalInstanceKey.getApiUrl();
-                    break;
                 case WEBHOOK_TOKEN:
                     value = optionalInstanceKey.getWebhookToken();
+                    break;
+                case API_URL:
+                    value = optionalInstanceKey.getApiUrl();
                     break;
                 default:
                     throw new MachinaRuntimeException("Scm key: " + key + "is not supported");

--- a/src/main/java/com/checkmarx/flow/config/ScmConfigOverrider.java
+++ b/src/main/java/com/checkmarx/flow/config/ScmConfigOverrider.java
@@ -1,5 +1,6 @@
 package com.checkmarx.flow.config;
 
+import com.checkmarx.flow.dto.ControllerRequest;
 import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.exception.MachinaRuntimeException;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +24,13 @@ public class ScmConfigOverrider {
                 .orElse(properties.getApiUrl());
     }
 
+    public String determineConfigWebhookToken(RepoProperties properties, ControllerRequest controllerRequest) {
+        return Optional.ofNullable(controllerRequest)
+                .map(ControllerRequest::getScmInstance)
+                .map(key -> getScmOverriddenConfig(properties, ScmConfigParams.WEBHOOK_TOKEN, key))
+                .orElse(properties.getWebhookToken());
+    }
+
     private String getScmOverriddenConfig(RepoProperties properties, ScmConfigParams configParams, String key) {
         String value = null;
         OptionalScmInstanceProperties optionalInstanceKey = properties.getOptionalInstances().get(key);
@@ -35,6 +43,9 @@ public class ScmConfigOverrider {
                     break;
                 case API_URI:
                     value = optionalInstanceKey.getApiUrl();
+                    break;
+                case WEBHOOK_TOKEN:
+                    value = optionalInstanceKey.getWebhookToken();
                     break;
                 default:
                     throw new MachinaRuntimeException("Scm key: " + key + "is not supported");

--- a/src/main/java/com/checkmarx/flow/config/ScmConfigOverrider.java
+++ b/src/main/java/com/checkmarx/flow/config/ScmConfigOverrider.java
@@ -32,10 +32,11 @@ public class ScmConfigOverrider {
     }
 
     private String getScmOverriddenConfig(RepoProperties properties, ScmConfigParams configParams, String key) {
-        String value = null;
+        String value;
         OptionalScmInstanceProperties optionalInstanceKey = properties.getOptionalInstances().get(key);
         if (optionalInstanceKey == null) {
-            log.warn("scm-instance key: {} does not exists on configuration file. Using default configuration", key);
+            log.error("scm-instance key: {} does not exists on configuration file.", key);
+            throw new MachinaRuntimeException();
         } else {
             switch (configParams) {
                 case TOKEN:

--- a/src/main/java/com/checkmarx/flow/config/ScmConfigOverrider.java
+++ b/src/main/java/com/checkmarx/flow/config/ScmConfigOverrider.java
@@ -12,15 +12,8 @@ import java.util.Optional;
 @Slf4j
 public class ScmConfigOverrider {
 
-    public String determineConfigToken(RepoProperties properties, ScanRequest scanRequest) {
-        return Optional.ofNullable(scanRequest.getScmInstance())
-                .map(key -> getScmOverriddenConfig(properties, ScmConfigParams.TOKEN, key))
-                .orElse(properties.getToken());
-    }
-
-    public String determineConfigToken(RepoProperties properties, ControllerRequest controllerRequest) {
-        return Optional.ofNullable(controllerRequest)
-                .map(ControllerRequest::getScmInstance)
+    public String determineConfigToken(RepoProperties properties, String scmInstance) {
+        return Optional.ofNullable(scmInstance)
                 .map(key -> getScmOverriddenConfig(properties, ScmConfigParams.TOKEN, key))
                 .orElse(properties.getToken());
     }

--- a/src/main/java/com/checkmarx/flow/config/ScmConfigOverrider.java
+++ b/src/main/java/com/checkmarx/flow/config/ScmConfigOverrider.java
@@ -47,12 +47,15 @@ public class ScmConfigOverrider {
         } else {
             switch (configParams) {
                 case TOKEN:
+                    log.info("Overriding token for SCM instance key: {}", key);
                     value = optionalInstanceKey.getToken();
                     break;
                 case WEBHOOK_TOKEN:
+                    log.info("Overriding webhook-token for SCM instance key: {}", key);
                     value = optionalInstanceKey.getWebhookToken();
                     break;
                 case API_URL:
+                    log.info("Overriding api-url for SCM instance key: {}", key);
                     value = optionalInstanceKey.getApiUrl();
                     break;
                 default:

--- a/src/main/java/com/checkmarx/flow/config/ScmConfigParams.java
+++ b/src/main/java/com/checkmarx/flow/config/ScmConfigParams.java
@@ -1,0 +1,5 @@
+package com.checkmarx.flow.config;
+
+public enum ScmConfigParams {
+    TOKEN, API_URI
+}

--- a/src/main/java/com/checkmarx/flow/config/ScmConfigParams.java
+++ b/src/main/java/com/checkmarx/flow/config/ScmConfigParams.java
@@ -1,5 +1,5 @@
 package com.checkmarx.flow.config;
 
 public enum ScmConfigParams {
-    TOKEN, API_URI, WEBHOOK_TOKEN
+    TOKEN, WEBHOOK_TOKEN, API_URL
 }

--- a/src/main/java/com/checkmarx/flow/config/ScmConfigParams.java
+++ b/src/main/java/com/checkmarx/flow/config/ScmConfigParams.java
@@ -1,5 +1,5 @@
 package com.checkmarx.flow.config;
 
 public enum ScmConfigParams {
-    TOKEN, API_URI
+    TOKEN, API_URI, WEBHOOK_TOKEN
 }

--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -194,6 +194,7 @@ public class GitHubController extends WebhookController {
                     .build();
 
             overrideScanPreset(controllerRequest, request);
+            setScmInstance(controllerRequest, request);
 
             /*Check for Config as code (cx.config) and override*/
             CxConfig cxConfig =  gitHubService.getCxConfigOverride(request);

--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -38,6 +38,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 /**
  * Class used to manage Controller for GitHub WebHooks
@@ -311,6 +312,7 @@ public class GitHubController extends WebhookController {
                     .build();
 
             overrideScanPreset(controllerRequest, request);
+            setScmInstance(controllerRequest, request);
 
             /*Check for Config as code (cx.config) and override*/
             CxConfig cxConfig =  gitHubService.getCxConfigOverride(request);
@@ -330,6 +332,10 @@ public class GitHubController extends WebhookController {
         }
         
         return getSuccessMessage();
+    }
+
+    private void setScmInstance(ControllerRequest controllerRequest, ScanRequest request) {
+        Optional.ofNullable(controllerRequest.getScmInstance()).ifPresent(request::setScmInstance);
     }
 
     private List<String> determineEmails(PushEvent event) {

--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -162,7 +162,7 @@ public class GitHubController extends WebhookController {
             setExclusionProperties(cxProperties, controllerRequest);
             //build request object
             String gitUrl = repository.getCloneUrl();
-            String token = properties.getToken();
+            String token = scmConfigOverrider.determineConfigToken(properties, controllerRequest);
             log.info("Using url: {}", gitUrl);
             String gitAuthUrl = gitUrl.replace(Constants.HTTPS, Constants.HTTPS.concat(token).concat("@"));
             gitAuthUrl = gitAuthUrl.replace(Constants.HTTP, Constants.HTTP.concat(token).concat("@"));
@@ -277,7 +277,7 @@ public class GitHubController extends WebhookController {
             Repository repository = event.getRepository();
             String gitUrl = repository.getCloneUrl();
             log.debug("Using url: {}", gitUrl);
-            String token = properties.getToken();
+            String token = scmConfigOverrider.determineConfigToken(properties, controllerRequest);
             if(ScanUtils.empty(token)){
                 log.error("No token was provided for Github");
                 throw new MachinaRuntimeException();

--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -162,7 +162,7 @@ public class GitHubController extends WebhookController {
             setExclusionProperties(cxProperties, controllerRequest);
             //build request object
             String gitUrl = repository.getCloneUrl();
-            String token = scmConfigOverrider.determineConfigToken(properties, controllerRequest);
+            String token = scmConfigOverrider.determineConfigToken(properties, controllerRequest.getScmInstance());
             log.info("Using url: {}", gitUrl);
             String gitAuthUrl = gitUrl.replace(Constants.HTTPS, Constants.HTTPS.concat(token).concat("@"));
             gitAuthUrl = gitAuthUrl.replace(Constants.HTTP, Constants.HTTP.concat(token).concat("@"));
@@ -278,7 +278,7 @@ public class GitHubController extends WebhookController {
             Repository repository = event.getRepository();
             String gitUrl = repository.getCloneUrl();
             log.debug("Using url: {}", gitUrl);
-            String token = scmConfigOverrider.determineConfigToken(properties, controllerRequest);
+            String token = scmConfigOverrider.determineConfigToken(properties, controllerRequest.getScmInstance());
             if(ScanUtils.empty(token)){
                 log.error("No token was provided for Github");
                 throw new MachinaRuntimeException();

--- a/src/main/java/com/checkmarx/flow/custom/GitHubIssueTracker.java
+++ b/src/main/java/com/checkmarx/flow/custom/GitHubIssueTracker.java
@@ -56,7 +56,7 @@ public class GitHubIssueTracker implements IssueTracker {
                 ScanUtils.empty(request.getBranch())){
             throw new MachinaException("Namespace / RepoName / Branch are required");
         }
-        if(ScanUtils.empty(properties.getApiUrl())){
+        if((ScanUtils.empty(properties.getApiUrl()) && ScanUtils.empty(request.getScmInstance()))){
             throw new MachinaException("GitHub API Url must be provided in property config");
         }
     }

--- a/src/main/java/com/checkmarx/flow/custom/GitHubIssueTracker.java
+++ b/src/main/java/com/checkmarx/flow/custom/GitHubIssueTracker.java
@@ -140,7 +140,7 @@ public class GitHubIssueTracker implements IssueTracker {
      */
     private Issue getIssue(String issueUrl, ScanRequest scanRequest) {
         log.info("Executing getIssue GitHub API call");
-        HttpEntity httpEntity = new HttpEntity<>(createAuthHeaders(scanRequest));
+        HttpEntity<Object> httpEntity = new HttpEntity<>(createAuthHeaders(scanRequest));
         ResponseEntity<com.checkmarx.flow.dto.github.Issue> response =
                 restTemplate.exchange(issueUrl, HttpMethod.GET, httpEntity, com.checkmarx.flow.dto.github.Issue.class);
 
@@ -190,7 +190,7 @@ public class GitHubIssueTracker implements IssueTracker {
     @Override
     public Issue updateIssue(Issue issue, ScanResults.XIssue resultIssue, ScanRequest request) throws MachinaException {
         log.info("Executing updateIssue GitHub API call");
-        HttpEntity httpEntity = new HttpEntity<>(getJSONUpdateIssue(resultIssue, request).toString(), createAuthHeaders(request));
+        HttpEntity<String> httpEntity = new HttpEntity<>(getJSONUpdateIssue(resultIssue, request).toString(), createAuthHeaders(request));
         ResponseEntity<com.checkmarx.flow.dto.github.Issue> response;
         try {
             response = restTemplate.exchange(issue.getUrl(), HttpMethod.POST, httpEntity, com.checkmarx.flow.dto.github.Issue.class);

--- a/src/main/java/com/checkmarx/flow/custom/GitHubIssueTracker.java
+++ b/src/main/java/com/checkmarx/flow/custom/GitHubIssueTracker.java
@@ -347,7 +347,7 @@ public class GitHubIssueTracker implements IssueTracker {
      */
     private HttpHeaders createAuthHeaders(ScanRequest scanRequest) {
         HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.set(HttpHeaders.AUTHORIZATION, "token ".concat(scmConfigOverrider.determineConfigToken(properties, scanRequest)));
+        httpHeaders.set(HttpHeaders.AUTHORIZATION, "token ".concat(scmConfigOverrider.determineConfigToken(properties, scanRequest.getScmInstance())));
         return httpHeaders;
     }
 

--- a/src/main/java/com/checkmarx/flow/dto/ControllerRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/ControllerRequest.java
@@ -33,6 +33,7 @@ public class ControllerRequest {
     private List<String> excludeFiles;
     private List<String> excludeFolders;
     private String override;
+    private String scmInstance;
 
     // Bug tracker.
     private String bug;

--- a/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
@@ -50,6 +50,13 @@ public class ScanRequest {
     private String scanPreset;
 
     /**
+     * Getting populated from the ControllerRequest.
+     * Indicates whether we got a scm-instance parameter from a webhook event.
+     * In case not null it will override the configuration default scm credentials
+     */
+    private String scmInstance;
+
+    /**
      * Indicates whether scan preset has been overridden.
      * Overrides may come from a webhook parameter or config-as-code.
      */

--- a/src/main/java/com/checkmarx/flow/service/GitHubService.java
+++ b/src/main/java/com/checkmarx/flow/service/GitHubService.java
@@ -323,7 +323,7 @@ public class GitHubService extends RepoService {
     }
 
     private String getGitHubEndPoint(ScanRequest request) {
-        String endpoint = properties.getApiUrl().concat(REPO_CONTENT);
+        String endpoint = scmConfigOverrider.determineConfigApiUrl(properties, request).concat(REPO_CONTENT);
         endpoint = endpoint.replace("{namespace}", request.getNamespace());
         endpoint = endpoint.replace("{repo}", request.getRepoName());
         endpoint = endpoint.replace("{branch}", request.getBranch());
@@ -337,7 +337,7 @@ public class GitHubService extends RepoService {
         Map<String, Integer> langsPercent = new HashMap<>();
         HttpHeaders headers = createAuthHeaders(request);
 
-        String urlTemplate = properties.getApiUrl().concat(LANGUAGE_TYPES);
+        String urlTemplate = scmConfigOverrider.determineConfigApiUrl(properties, request).concat(LANGUAGE_TYPES);
         String url = new DefaultUriBuilderFactory()
                 .expand(urlTemplate, request.getNamespace(), request.getRepoName())
                 .toString();

--- a/src/main/java/com/checkmarx/flow/service/GitHubService.java
+++ b/src/main/java/com/checkmarx/flow/service/GitHubService.java
@@ -77,7 +77,7 @@ public class GitHubService extends RepoService {
 
     private HttpHeaders createAuthHeaders(ScanRequest scanRequest){
         HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.set(HttpHeaders.AUTHORIZATION, "token ".concat(scmConfigOverrider.determineConfigToken(properties, scanRequest)));
+        httpHeaders.set(HttpHeaders.AUTHORIZATION, "token ".concat(scmConfigOverrider.determineConfigToken(properties, scanRequest.getScmInstance())));
         return httpHeaders;
     }
 

--- a/src/main/java/com/checkmarx/flow/service/GitHubService.java
+++ b/src/main/java/com/checkmarx/flow/service/GitHubService.java
@@ -18,9 +18,14 @@ import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.*;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 
 import java.io.IOException;
@@ -45,6 +50,7 @@ public class GitHubService extends RepoService {
     private final GitHubProperties properties;
     private final FlowProperties flowProperties;
     private final ThresholdValidator thresholdValidator;
+    private final ScmConfigOverrider scmConfigOverrider;
 
     private static final String FILE_CONTENT = "/{namespace}/{repo}/contents/{config}?ref={branch}";
     private static final String LANGUAGE_TYPES = "/{namespace}/{repo}/languages";
@@ -60,16 +66,18 @@ public class GitHubService extends RepoService {
     public GitHubService(@Qualifier("flowRestTemplate") RestTemplate restTemplate,
                          GitHubProperties properties,
                          FlowProperties flowProperties,
-                         ThresholdValidator thresholdValidator) {
+                         ThresholdValidator thresholdValidator,
+                         ScmConfigOverrider scmConfigOverrider) {
         this.restTemplate = restTemplate;
         this.properties = properties;
         this.flowProperties = flowProperties;
         this.thresholdValidator = thresholdValidator;
+        this.scmConfigOverrider = scmConfigOverrider;
     }
 
-    private HttpHeaders createAuthHeaders(){
+    private HttpHeaders createAuthHeaders(ScanRequest scanRequest){
         HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.set(HttpHeaders.AUTHORIZATION, "token ".concat(properties.getToken()));
+        httpHeaders.set(HttpHeaders.AUTHORIZATION, "token ".concat(scmConfigOverrider.determineConfigToken(properties, scanRequest)));
         return httpHeaders;
     }
 
@@ -79,16 +87,16 @@ public class GitHubService extends RepoService {
             sendMergeComment(request, comment);
     }
 
-    private void updateComment(String baseUrl, String comment) {
+    private void updateComment(String baseUrl, String comment, ScanRequest scanRequest) {
         log.debug("Updating exisiting comment. url: {}", baseUrl);
         log.debug("Updated comment: {}" , comment);
-        HttpEntity<?> httpEntity = new HttpEntity<>(RepoIssue.getJSONComment("body",comment).toString(), createAuthHeaders());
+        HttpEntity<?> httpEntity = new HttpEntity<>(RepoIssue.getJSONComment("body",comment).toString(), createAuthHeaders(scanRequest));
         restTemplate.exchange(baseUrl, HttpMethod.PATCH, httpEntity, String.class);
     }
 
-    public List<RepoComment> getComments(String url) throws IOException  {
-        HttpEntity<?> httpEntity = new HttpEntity<>(createAuthHeaders());
-        ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, httpEntity , String.class);
+    public List<RepoComment> getComments(ScanRequest scanRequest) throws IOException  {
+        HttpEntity<?> httpEntity = new HttpEntity<>(createAuthHeaders(scanRequest));
+        ResponseEntity<String> response = restTemplate.exchange(scanRequest.getMergeNoteUri(), HttpMethod.GET, httpEntity , String.class);
         List<RepoComment> result = new ArrayList<>();
         ObjectMapper objMapper = new ObjectMapper();
         JsonNode root = objMapper.readTree(response.getBody());
@@ -103,8 +111,8 @@ public class GitHubService extends RepoService {
         return result;
     }
 
-    public void deleteComment(String url) {
-        HttpEntity<?> httpEntity = new HttpEntity<>(createAuthHeaders());
+    public void deleteComment(String url, ScanRequest scanRequest) {
+        HttpEntity<?> httpEntity = new HttpEntity<>(createAuthHeaders(scanRequest));
         restTemplate.exchange(url, HttpMethod.DELETE, httpEntity, String.class);
     }
 
@@ -127,7 +135,7 @@ public class GitHubService extends RepoService {
 
     public void sendMergeComment(ScanRequest request, String comment) {
         try {
-            RepoComment commentToUpdate = PullRequestCommentsHelper.getCommentToUpdate(getComments(request.getMergeNoteUri()), comment);
+            RepoComment commentToUpdate = PullRequestCommentsHelper.getCommentToUpdate(getComments(request), comment);
             if (commentToUpdate !=  null) {
                 log.debug("Got candidate comment to update. comment: {}", commentToUpdate.getComment());
                 if (!PullRequestCommentsHelper.shouldUpdateComment(comment, commentToUpdate.getComment())) {
@@ -135,7 +143,7 @@ public class GitHubService extends RepoService {
                     return;
                 }
                 log.debug("sendMergeComment: Going to update GitHub pull request comment");
-                updateComment(commentToUpdate.getCommentUrl(), comment);
+                updateComment(commentToUpdate.getCommentUrl(), comment, request);
             } else {
                 log.debug("sendMergeComment: Going to create a new GitHub pull request comment");
                 addComment(request, comment);
@@ -149,7 +157,7 @@ public class GitHubService extends RepoService {
 
     private void addComment(ScanRequest request, String comment) {
         log.debug("Adding a new comment");
-        HttpEntity<?> httpEntity = new HttpEntity<>(RepoIssue.getJSONComment("body",comment).toString(), createAuthHeaders());
+        HttpEntity<?> httpEntity = new HttpEntity<>(RepoIssue.getJSONComment("body",comment).toString(), createAuthHeaders(request));
         restTemplate.exchange(request.getMergeNoteUri(), HttpMethod.POST, httpEntity, String.class);
     }
 
@@ -158,7 +166,7 @@ public class GitHubService extends RepoService {
             final String PULL_REQUEST_STATUS = "pending";
             HttpEntity<?> httpEntity = new HttpEntity<>(
                     getJSONStatus(PULL_REQUEST_STATUS, url, "Checkmarx Scan Initiated").toString(),
-                    createAuthHeaders()
+                    createAuthHeaders(request)
             );
             String statusApiUrl = request.getAdditionalMetadata(STATUSES_URL_KEY);
             if (ScanUtils.empty(statusApiUrl)) {
@@ -199,7 +207,7 @@ public class GitHubService extends RepoService {
 
             PullRequestReport report = new PullRequestReport(scanDetails, request);
 
-            HttpEntity<String> httpEntity = getStatusRequestEntity(results, report);
+            HttpEntity<String> httpEntity = getStatusRequestEntity(results, report, request);
 
             logPullRequestWithSastOsa(results, report);
 
@@ -246,7 +254,7 @@ public class GitHubService extends RepoService {
         }
     }
 
-    private HttpEntity<String> getStatusRequestEntity(ScanResults results, PullRequestReport pullRequestReport) {
+    private HttpEntity<String> getStatusRequestEntity(ScanResults results, PullRequestReport pullRequestReport, ScanRequest scanRequest) {
         String statusForApi = MERGE_SUCCESS;
 
         if (!thresholdValidator.isMergeAllowed(results, properties, pullRequestReport)) {
@@ -255,14 +263,14 @@ public class GitHubService extends RepoService {
 
         log.debug("Setting pull request status to '{}'.", statusForApi);
         JSONObject requestBody = getJSONStatus(statusForApi, results.getLink(), pullRequestReport.getPullRequestResult().getMessage());
-        return new HttpEntity<>(requestBody.toString(), createAuthHeaders());
+        return new HttpEntity<>(requestBody.toString(), createAuthHeaders(scanRequest));
     }
 
     void failBlockMerge(ScanRequest request, String url){
         if(properties.isBlockMerge()) {
             HttpEntity<?> httpEntity = new HttpEntity<>(
                     getJSONStatus(MERGE_FAILURE, url, "Checkmarx Issue Threshold Met").toString(),
-                    createAuthHeaders()
+                    createAuthHeaders(request)
             );
             String statusApiUrl = request.getAdditionalMetadata(STATUSES_URL_KEY);
             if (ScanUtils.empty(statusApiUrl)) {
@@ -291,7 +299,7 @@ public class GitHubService extends RepoService {
     void errorBlockMerge(ScanRequest request, String targetURL, String description){
         if(properties.isBlockMerge()) {
             JSONObject jsonRequestBody = getJSONStatus(MERGE_ERROR, targetURL, description);
-            HttpEntity<?> httpEntity = new HttpEntity<>(jsonRequestBody.toString(), createAuthHeaders());
+            HttpEntity<?> httpEntity = new HttpEntity<>(jsonRequestBody.toString(), createAuthHeaders(request));
             String statusApiUrl = request.getAdditionalMetadata(STATUSES_URL_KEY);
             if (ScanUtils.empty(statusApiUrl)) {
                 log.error(STATUSES_URL_NOT_PROVIDED);
@@ -310,7 +318,7 @@ public class GitHubService extends RepoService {
         }
         Sources sources = getRepoLanguagePercentages(request);
         String endpoint = getGitHubEndPoint(request);
-        scanGitContent(0, endpoint, sources);
+        scanGitContent(0, endpoint, sources, request);
         return sources;
     }
 
@@ -327,7 +335,7 @@ public class GitHubService extends RepoService {
         Sources sources = new Sources();
         Map<String, Long> langs = new HashMap<>();
         Map<String, Integer> langsPercent = new HashMap<>();
-        HttpHeaders headers = createAuthHeaders();
+        HttpHeaders headers = createAuthHeaders(request);
 
         String urlTemplate = properties.getApiUrl().concat(LANGUAGE_TYPES);
         String url = new DefaultUriBuilderFactory()
@@ -373,10 +381,10 @@ public class GitHubService extends RepoService {
         return sources;
     }
 
-    private List<Content> getRepoContent(String endpoint) {
+    private List<Content> getRepoContent(String endpoint, ScanRequest scanRequest) {
         log.info("Getting repo content from {}", endpoint);
         //"/{namespace}/{repo}/languages"
-        HttpHeaders headers = createAuthHeaders();
+        HttpHeaders headers = createAuthHeaders(scanRequest);
         try {
             ResponseEntity<Content[]> response = restTemplate.exchange(
                     endpoint,
@@ -397,14 +405,14 @@ public class GitHubService extends RepoService {
     }
 
 
-    private void scanGitContent(int depth, String endpoint, Sources sources){
+    private void scanGitContent(int depth, String endpoint, Sources sources, ScanRequest scanRequest){
         if(depth >= flowProperties.getProfilingDepth()){
             return;
         }
-        List<Content> contents = getRepoContent(endpoint);
+        List<Content> contents = getRepoContent(endpoint, scanRequest);
         for(Content content: contents){
             if(content.getType().equals("dir")){
-                scanGitContent(depth + 1, content.getUrl(), sources);
+                scanGitContent(depth + 1, content.getUrl(), sources, scanRequest);
             }
             else if (content.getType().equals("file")){
                 sources.addSource(content.getPath(), content.getName());
@@ -454,8 +462,8 @@ public class GitHubService extends RepoService {
         ResponseEntity<String> response = null;
 
         if (StringUtils.isNotEmpty(branch)) {
-            HttpHeaders headers = createAuthHeaders();
-            String urlTemplate = properties.getApiUrl().concat(FILE_CONTENT);
+            HttpHeaders headers = createAuthHeaders(request);
+            String urlTemplate = scmConfigOverrider.determineConfigApiUrl(properties, request).concat(FILE_CONTENT);
 
             response = restTemplate.exchange(
                     urlTemplate,

--- a/src/test/java/com/checkmarx/flow/controller/GitHubControllerTest.java
+++ b/src/test/java/com/checkmarx/flow/controller/GitHubControllerTest.java
@@ -47,20 +47,20 @@ public class GitHubControllerTest {
     private static final String validWebhookToken = "adsfdsfddsfsadaf";
     @Test
     public void initNullController() throws InvalidKeyException, NoSuchAlgorithmException {
-        GitHubController gitHubControllerNull = new GitHubController(null, null, null, null, null, helperService, null, null, null, null);
+        GitHubController gitHubControllerNull = new GitHubController(null, null, null, null, null, helperService, null, null, null, null, null);
         gitHubControllerNull.init();
     }
 
     @Test
     public void initNullWebHookToken() throws InvalidKeyException, NoSuchAlgorithmException {
         properties.setWebhookToken(null);
-        GitHubController gitHubControllerNull = new GitHubController(properties, null, null, null, null, helperService, null, null, null, null);
+        GitHubController gitHubControllerNull = new GitHubController(properties, null, null, null, null, helperService, null, null, null, null, null);
         gitHubControllerNull.init();
     }
 
     @Test
     public void pingRequestNullController() {
-        GitHubController gitHubControllerNull = new GitHubController(null, null, null, null, null, helperService, null, null, null, null);
+        GitHubController gitHubControllerNull = new GitHubController(null, null, null, null, null, helperService, null, null, null, null, null);
         try {
             gitHubControllerNull.pingRequest("body", "product", "signature");
             assert false;
@@ -71,7 +71,7 @@ public class GitHubControllerTest {
 
     @Test
     public void pingRequestNullControllerWithNullParameters() {
-        GitHubController gitHubControllerNull = new GitHubController(null, null, null, null, null, helperService, null, null, null, null);
+        GitHubController gitHubControllerNull = new GitHubController(null, null, null, null, null, helperService, null, null, null, null, null);
         try {
             gitHubControllerNull.pingRequest(null, null, null);
             assert false;
@@ -82,7 +82,7 @@ public class GitHubControllerTest {
 
     @Test
     public void pingRequestWithNullParametersNullWebHookToken() {
-        GitHubController gitHubController = new GitHubController(properties, null, null, null, null, helperService, null, null, null, null);
+        GitHubController gitHubController = new GitHubController(properties, null, null, null, null, helperService, null, null, null, null, null);
         try {
             gitHubController.pingRequest(null, null, null);
             assert false;
@@ -94,7 +94,7 @@ public class GitHubControllerTest {
     @Test
     public void pingRequestWithNullParametersWithWebHookTokenNullMessage() {
         properties.setWebhookToken("token");
-        GitHubController gitHubController = new GitHubController(properties, null, null, null, null, helperService, null, null, null, null);
+        GitHubController gitHubController = new GitHubController(properties, null, null, null, null, helperService, null, null, null, null, null);
         try {
             gitHubController.pingRequest(null, null, null);
             assert false;
@@ -106,7 +106,7 @@ public class GitHubControllerTest {
     @Test
     public void pingRequestWithWebHookTokenInvalidSignature() {
         properties.setWebhookToken(invalidWebhookToken);
-        GitHubController gitHubController = new GitHubController(properties, null, null, null, null, helperService, null, null, null, null);
+        GitHubController gitHubController = new GitHubController(properties, null, null, null, null, helperService, null, null, null, null, null);
         try {
             gitHubController.pingRequest("test", null, null);
             assert false;
@@ -118,7 +118,7 @@ public class GitHubControllerTest {
     @Test
     public void pingRequestWithWebHookTokenInvalidMessage() {
         properties.setWebhookToken(invalidWebhookToken);
-        GitHubController gitHubController = new GitHubController(properties, null, null, null, null, helperService, null, null, null, null);
+        GitHubController gitHubController = new GitHubController(properties, null, null, null, null, helperService, null, null, null, null, null);
         try {
             gitHubController.pingRequest(null, null, validSignature);
             assert true;
@@ -130,7 +130,7 @@ public class GitHubControllerTest {
     @Test
     public void pingRequestWithWebHookTokenValidSignature() {
         properties.setWebhookToken(invalidWebhookToken);
-        GitHubController gitHubController = new GitHubController(properties, null, null, null, null, helperService, null, null, null, null);
+        GitHubController gitHubController = new GitHubController(properties, null, null, null, null, helperService, null, null, null, null, null);
         try {
             gitHubController.pingRequest(invalidWebhookToken, null, validSignature);
             assert false;
@@ -141,7 +141,7 @@ public class GitHubControllerTest {
 
     @Test
     public void pushRequestNullControllerNullParameters() {
-        GitHubController gitHubController = new GitHubController(null, null, null, null, null, helperService, null, null, null, null);
+        GitHubController gitHubController = new GitHubController(null, null, null, null, null, helperService, null, null, null, null, null);
         try {
             gitHubController.pushRequest(null, null, null, null);
             assert false;
@@ -152,7 +152,7 @@ public class GitHubControllerTest {
 
     @Test
     public void pushRequestNullControllerNullParametersWithBody() {
-        GitHubController gitHubController = new GitHubController(null, null, null, null, null, helperService, null, null, null, null);
+        GitHubController gitHubController = new GitHubController(null, null, null, null, null, helperService, null, null, null, null, null);
         try {
             gitHubController.pushRequest(validBody, null, null, null);
             assert false;
@@ -164,7 +164,7 @@ public class GitHubControllerTest {
     @Test
     public void pushRequestNullParametersWithBodyInvalidWebHook() {
         properties.setWebhookToken(invalidWebhookToken);
-        GitHubController gitHubController = new GitHubController(properties, null, null, null, null, helperService, null, null, null, null);
+        GitHubController gitHubController = new GitHubController(properties, null, null, null, null, helperService, null, null, null, null, null);
         try {
             gitHubController.pushRequest(validBody, null, null, null);
             assert false;
@@ -177,7 +177,7 @@ public class GitHubControllerTest {
     @Test
     public void pushRequestNullParametersWithBodyValidWebHookInvalidSignature() {
         properties.setWebhookToken(validWebhookToken);
-        GitHubController gitHubController = new GitHubController(properties, null, null, null, null, helperService,null, null, null, null);
+        GitHubController gitHubController = new GitHubController(properties, null, null, null, null, helperService,null, null, null, null, null);
         try {
             gitHubController.pushRequest(validBody, null, null, null);
             assert false;
@@ -189,7 +189,7 @@ public class GitHubControllerTest {
     @Test
     public void pushRequestInvalidFlowPropertiesWithBodyValidWebHookValidSignature() {
         properties.setWebhookToken(validWebhookToken);
-        GitHubController gitHubController = new GitHubController(properties, null, null, null, null, helperService, null, null, null, null);
+        GitHubController gitHubController = new GitHubController(properties, null, null, null, null, helperService, null, null, null, null, null);
         try {
             gitHubController.pushRequest(validBody,validSignature2, null, null);
             assert false;
@@ -201,7 +201,7 @@ public class GitHubControllerTest {
     @Test
     public void pushRequestValidFlowPropertiesWithBodyValidWebHookValidSignature() {
         properties.setWebhookToken(validWebhookToken);
-        GitHubController gitHubController = new GitHubController(properties, flowProperties, null, null, null, helperService, null, null, null, null);
+        GitHubController gitHubController = new GitHubController(properties, flowProperties, null, null, null, helperService, null, null, null, null, null);
         try {
             gitHubController.pushRequest(validBody, validSignature2, null, null);
             assert false;
@@ -215,7 +215,7 @@ public class GitHubControllerTest {
     public void pushRequestValidFlowPropertiesWithBodyValidWebHookValidSignatureWithValidToken() {
         properties.setWebhookToken(validWebhookToken);
         properties.setToken(invalidWebhookToken);
-        GitHubController gitHubController = new GitHubController(properties, flowProperties, null, null, null, helperService, null, null, filterFactory, null);
+        GitHubController gitHubController = new GitHubController(properties, flowProperties, null, null, null, helperService, null, null, filterFactory, null, null);
         try {
             gitHubController.pushRequest(validBody, validSignature2, null, null);
             assert false;
@@ -244,7 +244,7 @@ public class GitHubControllerTest {
     public void pushRequestValidCxPropertiesWithBodyValidWebHookValidSignatureWithValidTokenFlowService() {
         properties.setWebhookToken(validWebhookToken);
         properties.setToken(invalidWebhookToken);
-        GitHubController gitHubController = new GitHubController(properties, flowProperties, cxProperties, null, flowService, helperService, null, null, filterFactory, null);
+        GitHubController gitHubController = new GitHubController(properties, flowProperties, cxProperties, null, flowService, helperService, null, null, filterFactory, null, null);
         try {
             gitHubController.pushRequest(validBody, validSignature2, null, null);
             assert false;

--- a/src/test/java/com/checkmarx/flow/cucumber/component/analytics/pullrequest/AnalyticsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/analytics/pullrequest/AnalyticsSteps.java
@@ -231,7 +231,8 @@ public class AnalyticsSteps {
         GitHubService gitService = new GitHubService(restTemplateMock,
                 gitHubProperties,
                 flowProperties,
-                thresholdValidator);
+                thresholdValidator,
+                null);
 
         return new ResultsService(
                 cxClientMock,

--- a/src/test/java/com/checkmarx/flow/cucumber/component/deletebranch/DeleteBranchSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/deletebranch/DeleteBranchSteps.java
@@ -214,7 +214,7 @@ public class DeleteBranchSteps {
     }
 
     private void initMockGitHubController() {
-        doNothing().when(gitHubControllerSpy).verifyHmacSignature(any(), any());
+        doNothing().when(gitHubControllerSpy).verifyHmacSignature(any(), any(), any());
     }
     
     private void initServices() {
@@ -240,7 +240,8 @@ public class DeleteBranchSteps {
                 gitHubService,
                 sastScanner,
                 filterFactory,
-                configOverrider));
+                configOverrider,
+                null));
         
     }
 

--- a/src/test/java/com/checkmarx/flow/cucumber/component/thresholds/sastPR/ThresholdsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/thresholds/sastPR/ThresholdsSteps.java
@@ -261,7 +261,8 @@ public class ThresholdsSteps {
         GitHubService gitService = new GitHubService(restTemplateMock,
                 gitHubProperties,
                 flowProperties,
-                thresholdValidator);
+                thresholdValidator,
+                null);
 
         ADOService adoService = new ADOService(restTemplateMock,
                 adoProperties,

--- a/src/test/java/com/checkmarx/flow/cucumber/component/thresholds/sastPR/ThresholdsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/thresholds/sastPR/ThresholdsSteps.java
@@ -1,10 +1,7 @@
 package com.checkmarx.flow.cucumber.component.thresholds.sastPR;
 
 import com.checkmarx.flow.CxFlowApplication;
-import com.checkmarx.flow.config.ADOProperties;
-import com.checkmarx.flow.config.FindingSeverity;
-import com.checkmarx.flow.config.FlowProperties;
-import com.checkmarx.flow.config.GitHubProperties;
+import com.checkmarx.flow.config.*;
 import com.checkmarx.flow.dto.BugTracker;
 import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.exception.MachinaException;
@@ -71,6 +68,7 @@ public class ThresholdsSteps {
     private final SastScanner sastScanner;
     private final SCAScanner scaScanner;
     private final EmailService emailService;
+    private final ScmConfigOverrider scmConfigOverrider;
 
     private ScanResults scanResultsToInject;
     private ResultsService resultsService;
@@ -79,7 +77,8 @@ public class ThresholdsSteps {
 
     public ThresholdsSteps(CxClient cxClientMock, RestTemplate restTemplateMock, FlowProperties flowProperties, ADOProperties adoProperties,
                            CxProperties cxProperties, GitHubProperties gitHubProperties, ThresholdValidator thresholdValidator,
-                           ScaProperties scaProperties, SastScanner sastScanner, SCAScanner scaScanner, EmailService emailService) {
+                           ScaProperties scaProperties, SastScanner sastScanner, SCAScanner scaScanner, EmailService emailService,
+                           ScmConfigOverrider scmConfigOverrider) {
 
         this.cxClientMock = cxClientMock;
         this.restTemplateMock = restTemplateMock;
@@ -101,6 +100,7 @@ public class ThresholdsSteps {
         this.scaScanner = scaScanner;
 
         this.emailService = emailService;
+        this.scmConfigOverrider = scmConfigOverrider;
     }
 
     @Before("@ThresholdsFeature")
@@ -262,7 +262,7 @@ public class ThresholdsSteps {
                 gitHubProperties,
                 flowProperties,
                 thresholdValidator,
-                null);
+                scmConfigOverrider);
 
         ADOService adoService = new ADOService(restTemplateMock,
                 adoProperties,

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/azure/publishing/github2ado/Github2AdoSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/azure/publishing/github2ado/Github2AdoSteps.java
@@ -263,7 +263,7 @@ public class Github2AdoSteps {
     }
 
     private void initMockGitHubController() {
-        doNothing().when(gitHubControllerSpy).verifyHmacSignature(any(), any());
+        doNothing().when(gitHubControllerSpy).verifyHmacSignature(any(), any(), any());
     }
     
     private void initServices() {
@@ -280,7 +280,8 @@ public class Github2AdoSteps {
                 gitHubService,
                 null,
                 filterFactory,
-                configOverrider));
+                configOverrider,
+                null));
         
         //results service will be a Mock and will work with gitHubService Mock
         //and will not not connect to any external 

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/azure/publishing/github2ado/Github2AdoSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/azure/publishing/github2ado/Github2AdoSteps.java
@@ -4,6 +4,7 @@ import com.checkmarx.flow.CxFlowApplication;
 import com.checkmarx.flow.config.ADOProperties;
 import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.config.GitHubProperties;
+import com.checkmarx.flow.config.ScmConfigOverrider;
 import com.checkmarx.flow.controller.GitHubController;
 import com.checkmarx.flow.cucumber.integration.azure.publishing.AzureDevopsClient;
 import com.checkmarx.flow.cucumber.integration.azure.publishing.githubflow.ScanResultsBuilder;
@@ -64,6 +65,7 @@ public class Github2AdoSteps {
     private final EmailService emailService;
     private final FilterFactory filterFactory;
     private final ConfigurationOverrider configOverrider;
+    private ScmConfigOverrider scmConfigOverrider;
 
     private ScanResults scanResultsToInject;
     
@@ -81,7 +83,10 @@ public class Github2AdoSteps {
     
     public Github2AdoSteps(FlowProperties flowProperties, GitHubService gitHubService,
                            CxProperties cxProperties, GitHubProperties gitHubProperties,
-                           ConfigurationOverrider configOverrider, FlowService flowService, ADOProperties adoProperties, FilterFactory filterFactory, AzureDevopsClient azureDevopsClient, EmailService emailService) {
+                           ConfigurationOverrider configOverrider, FlowService flowService,
+                           ADOProperties adoProperties, FilterFactory filterFactory,
+                           AzureDevopsClient azureDevopsClient, EmailService emailService,
+                           ScmConfigOverrider scmConfigOverrider) {
         this.filterFactory = filterFactory;
 
         this.cxClientMock = mock(CxClient.class);
@@ -98,6 +103,7 @@ public class Github2AdoSteps {
         this.adoProperties = adoProperties;
         this.configOverrider = configOverrider;
         this.emailService = emailService;
+        this.scmConfigOverrider = scmConfigOverrider;
         initGitHubProperties();
     }
 
@@ -281,7 +287,7 @@ public class Github2AdoSteps {
                 null,
                 filterFactory,
                 configOverrider,
-                null));
+                scmConfigOverrider));
         
         //results service will be a Mock and will work with gitHubService Mock
         //and will not not connect to any external 

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/azure/publishing/githubflow/PublishingSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/azure/publishing/githubflow/PublishingSteps.java
@@ -142,7 +142,7 @@ public class PublishingSteps extends PublishingStepsBase {
         FlowService flowService = new FlowService(vulnerabilityScannerList, projectNameGenerator, resultsService);
 
         return new GitHubController(gitHubProperties, flowProperties, cxProperties,
-                null, flowService, helperService, gitHubService, null, filterFactory, configOverrider);
+                null, flowService, helperService, gitHubService, null, filterFactory, configOverrider, null);
     }
 
     private static GitHubTestUtils.EventType determineEventType(String eventName) {

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/azure/publishing/githubflow/PublishingSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/azure/publishing/githubflow/PublishingSteps.java
@@ -3,6 +3,7 @@ package com.checkmarx.flow.cucumber.integration.azure.publishing.githubflow;
 import com.checkmarx.flow.CxFlowApplication;
 import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.config.GitHubProperties;
+import com.checkmarx.flow.config.ScmConfigOverrider;
 import com.checkmarx.flow.controller.GitHubController;
 import com.checkmarx.flow.cucumber.integration.azure.publishing.AzureDevopsClient;
 import com.checkmarx.flow.cucumber.integration.azure.publishing.PublishingStepsBase;
@@ -57,6 +58,7 @@ public class PublishingSteps extends PublishingStepsBase {
     private final VulnerabilityScanner sastScanner;
     private final FilterFactory filterFactory;
     private final ConfigurationOverrider configOverrider;
+    private final ScmConfigOverrider scmConfigOverrider;
 
 
     @MockBean
@@ -142,7 +144,7 @@ public class PublishingSteps extends PublishingStepsBase {
         FlowService flowService = new FlowService(vulnerabilityScannerList, projectNameGenerator, resultsService);
 
         return new GitHubController(gitHubProperties, flowProperties, cxProperties,
-                null, flowService, helperService, gitHubService, null, filterFactory, configOverrider, null);
+                null, flowService, helperService, gitHubService, null, filterFactory, configOverrider, scmConfigOverrider);
     }
 
     private static GitHubTestUtils.EventType determineEventType(String eventName) {

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/ConfigAsCodeBranchSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/ConfigAsCodeBranchSteps.java
@@ -65,7 +65,7 @@ public class ConfigAsCodeBranchSteps {
         // Don't start automation.
         FlowService flowServiceMock = mock(FlowService.class);
 
-        GitHubService gitHubService = new GitHubService(restTemplateMock, gitHubProperties, flowProperties, null, null);
+        GitHubService gitHubService = new GitHubService(restTemplateMock, gitHubProperties, flowProperties, null, scmConfigOverrider);
 
         GitHubController gitHubControllerSpy = Mockito.spy(new GitHubController(gitHubProperties,
                 flowProperties,

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/ConfigAsCodeBranchSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/ConfigAsCodeBranchSteps.java
@@ -74,8 +74,9 @@ public class ConfigAsCodeBranchSteps {
                 gitHubService,
                 null,
                 filterFactory,
-                configOverrider));
-        doNothing().when(gitHubControllerSpy).verifyHmacSignature(any(), any());
+                configOverrider,
+                null));
+        doNothing().when(gitHubControllerSpy).verifyHmacSignature(any(), any(), any());
 
         return gitHubControllerSpy;
     }

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/ConfigAsCodeBranchSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/ConfigAsCodeBranchSteps.java
@@ -2,6 +2,7 @@ package com.checkmarx.flow.cucumber.integration.cxconfig;
 
 import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.config.GitHubProperties;
+import com.checkmarx.flow.config.ScmConfigOverrider;
 import com.checkmarx.flow.controller.GitHubController;
 import com.checkmarx.flow.dto.github.PullEvent;
 import com.checkmarx.flow.service.*;
@@ -30,6 +31,7 @@ public class ConfigAsCodeBranchSteps {
     private final HelperService helperService;
     private final FilterFactory filterFactory;
     private final ConfigurationOverrider configOverrider;
+    private final ScmConfigOverrider scmConfigOverrider;
 
     private String defaultBranch;
     private String actualBranch;
@@ -75,7 +77,7 @@ public class ConfigAsCodeBranchSteps {
                 null,
                 filterFactory,
                 configOverrider,
-                null));
+                scmConfigOverrider));
         doNothing().when(gitHubControllerSpy).verifyHmacSignature(any(), any(), any());
 
         return gitHubControllerSpy;

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/ConfigAsCodeBranchSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/ConfigAsCodeBranchSteps.java
@@ -63,7 +63,7 @@ public class ConfigAsCodeBranchSteps {
         // Don't start automation.
         FlowService flowServiceMock = mock(FlowService.class);
 
-        GitHubService gitHubService = new GitHubService(restTemplateMock, gitHubProperties, flowProperties, null);
+        GitHubService gitHubService = new GitHubService(restTemplateMock, gitHubProperties, flowProperties, null, null);
 
         GitHubController gitHubControllerSpy = Mockito.spy(new GitHubController(gitHubProperties,
                 flowProperties,

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
@@ -514,7 +514,7 @@ public class CxConfigSteps {
     }
 
     private void initMockGitHubController() {
-        doNothing().when(gitHubControllerSpy).verifyHmacSignature(any(), any());
+        doNothing().when(gitHubControllerSpy).verifyHmacSignature(any(), any(), any());
     }
 
     private void initServices() {
@@ -531,7 +531,8 @@ public class CxConfigSteps {
                 gitHubService,
                 null,
                 filterFactory,
-                configOverrider));
+                configOverrider,
+                null));
 
         // results service will be a Mock and will work with gitHubService Mock
         // and will not connect to any external service.

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
@@ -1,10 +1,7 @@
 package com.checkmarx.flow.cucumber.integration.cxconfig;
 
 import com.checkmarx.flow.CxFlowApplication;
-import com.checkmarx.flow.config.FindingSeverity;
-import com.checkmarx.flow.config.FlowProperties;
-import com.checkmarx.flow.config.GitHubProperties;
-import com.checkmarx.flow.config.JiraProperties;
+import com.checkmarx.flow.config.*;
 import com.checkmarx.flow.controller.GitHubController;
 import com.checkmarx.flow.dto.BugTracker;
 import com.checkmarx.flow.dto.ControllerRequest;
@@ -80,10 +77,12 @@ public class CxConfigSteps {
 
     private ScanRequest request;
     private final JiraProperties jiraProperties;
+    private final ScmConfigOverrider scmConfigOverrider;
 
     public CxConfigSteps(FlowProperties flowProperties, GitHubService gitHubService,
                          CxProperties cxProperties, GitHubProperties gitHubProperties, ConfigurationOverrider configOverrider, JiraProperties jiraProperties,
-                         ThresholdValidator thresholdValidator, FilterFactory filterFactory, FlowService flowService, EmailService emailService) {
+                         ThresholdValidator thresholdValidator, FilterFactory filterFactory, FlowService flowService, EmailService emailService,
+                         ScmConfigOverrider scmConfigOverrider) {
 
         this.cxClientMock = mock(CxClient.class);
 
@@ -100,6 +99,7 @@ public class CxConfigSteps {
         this.gitHubProperties = gitHubProperties;
         this.filterFactory = filterFactory;
         this.configOverrider = configOverrider;
+        this.scmConfigOverrider = scmConfigOverrider;
         initGitHubProperties();
     }
 
@@ -548,7 +548,7 @@ public class CxConfigSteps {
                 gitHubProperties,
                 flowProperties,
                 thresholdValidator,
-                null);
+                scmConfigOverrider);
 
         this.resultsService = new ResultsService(
                 cxClientMock,

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
@@ -532,7 +532,7 @@ public class CxConfigSteps {
                 null,
                 filterFactory,
                 configOverrider,
-                null));
+                scmConfigOverrider));
 
         // results service will be a Mock and will work with gitHubService Mock
         // and will not connect to any external service.

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
@@ -546,7 +546,8 @@ public class CxConfigSteps {
         GitHubService gitHubServiceMock = new GitHubService(restTemplateMock,
                 gitHubProperties,
                 flowProperties,
-                thresholdValidator);
+                thresholdValidator,
+                null);
 
         this.resultsService = new ResultsService(
                 cxClientMock,

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/CxConfigBugTrackerSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/CxConfigBugTrackerSteps.java
@@ -106,7 +106,7 @@ public class CxConfigBugTrackerSteps {
     }
 
     private void initGitHubControllerSpy() {
-        doNothing().when(gitHubControllerSpy).verifyHmacSignature(any(), any());
+        doNothing().when(gitHubControllerSpy).verifyHmacSignature(any(), any(), any());
     }
 
     private void fixBranch() {
@@ -155,7 +155,7 @@ public class CxConfigBugTrackerSteps {
         assertFlowPropertiesBugTracker("Json");
         ArgumentCaptor<ScanRequest> ac = ArgumentCaptor.forClass(ScanRequest.class);
         FlowService flowServiceMock = Mockito.mock(FlowService.class);
-        gitHubControllerSpy = new GitHubController(gitHubProperties,flowProperties, cxProperties, jiraProperties, flowServiceMock,helperService, gitHubService, null, filterFactory, configOverrider);
+        gitHubControllerSpy = new GitHubController(gitHubProperties,flowProperties, cxProperties, jiraProperties, flowServiceMock,helperService, gitHubService, null, filterFactory, configOverrider, null);
         gitHubControllerSpy = spy(gitHubControllerSpy);
         initGitHubControllerSpy();
         buildPullRequest();
@@ -168,7 +168,7 @@ public class CxConfigBugTrackerSteps {
         assertFlowPropertiesBugTracker("Json");
         ArgumentCaptor<ScanRequest> ac = ArgumentCaptor.forClass(ScanRequest.class);
         FlowService flowServiceMock = Mockito.mock(FlowService.class);
-        gitHubControllerSpy = new GitHubController(gitHubProperties,flowProperties, cxProperties, jiraProperties, flowServiceMock,helperService, gitHubService, null, filterFactory, configOverrider);
+        gitHubControllerSpy = new GitHubController(gitHubProperties,flowProperties, cxProperties, jiraProperties, flowServiceMock,helperService, gitHubService, null, filterFactory, configOverrider, null);
         gitHubControllerSpy = spy(gitHubControllerSpy);
         initGitHubControllerSpy();
         buildPushRequest();

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/CxConfigBugTrackerSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/CxConfigBugTrackerSteps.java
@@ -172,7 +172,7 @@ public class CxConfigBugTrackerSteps {
         assertFlowPropertiesBugTracker("Json");
         ArgumentCaptor<ScanRequest> ac = ArgumentCaptor.forClass(ScanRequest.class);
         FlowService flowServiceMock = Mockito.mock(FlowService.class);
-        gitHubControllerSpy = new GitHubController(gitHubProperties,flowProperties, cxProperties, jiraProperties, flowServiceMock,helperService, gitHubService, null, filterFactory, configOverrider, null);
+        gitHubControllerSpy = new GitHubController(gitHubProperties,flowProperties, cxProperties, jiraProperties, flowServiceMock,helperService, gitHubService, null, filterFactory, configOverrider, scmConfigOverrider);
         gitHubControllerSpy = spy(gitHubControllerSpy);
         initGitHubControllerSpy();
         buildPushRequest();

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/CxConfigBugTrackerSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/CxConfigBugTrackerSteps.java
@@ -4,6 +4,7 @@ import com.checkmarx.flow.CxFlowApplication;
 import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.config.GitHubProperties;
 import com.checkmarx.flow.config.JiraProperties;
+import com.checkmarx.flow.config.ScmConfigOverrider;
 import com.checkmarx.flow.controller.GitHubController;
 import com.checkmarx.flow.dto.BugTracker;
 import com.checkmarx.flow.dto.ControllerRequest;
@@ -58,6 +59,7 @@ public class CxConfigBugTrackerSteps {
     private final HelperService helperService;
     private final FilterFactory filterFactory;
     private final ConfigurationOverrider configOverrider;
+    private final ScmConfigOverrider scmConfigOverrider;
 
     private ScanResults scanResultsToInject;
 
@@ -69,7 +71,8 @@ public class CxConfigBugTrackerSteps {
     public CxConfigBugTrackerSteps(FlowProperties flowProperties, GitHubService gitHubService,
                                    CxProperties cxProperties, GitHubProperties gitHubProperties,
                                    JiraProperties jiraProperties, GitHubController gitHubController,
-                                   FilterFactory filterFactory, ConfigurationOverrider configOverrider) {
+                                   FilterFactory filterFactory, ConfigurationOverrider configOverrider,
+                                   ScmConfigOverrider scmConfigOverrider) {
 
 
         this.flowProperties = flowProperties;
@@ -83,6 +86,7 @@ public class CxConfigBugTrackerSteps {
         this.gitHubProperties = gitHubProperties;
         this.gitHubControllerSpy = gitHubController;
         this.configOverrider = configOverrider;
+        this.scmConfigOverrider = scmConfigOverrider;
         initGitHubProperties();
     }
 
@@ -155,7 +159,7 @@ public class CxConfigBugTrackerSteps {
         assertFlowPropertiesBugTracker("Json");
         ArgumentCaptor<ScanRequest> ac = ArgumentCaptor.forClass(ScanRequest.class);
         FlowService flowServiceMock = Mockito.mock(FlowService.class);
-        gitHubControllerSpy = new GitHubController(gitHubProperties,flowProperties, cxProperties, jiraProperties, flowServiceMock,helperService, gitHubService, null, filterFactory, configOverrider, null);
+        gitHubControllerSpy = new GitHubController(gitHubProperties,flowProperties, cxProperties, jiraProperties, flowServiceMock,helperService, gitHubService, null, filterFactory, configOverrider, scmConfigOverrider);
         gitHubControllerSpy = spy(gitHubControllerSpy);
         initGitHubControllerSpy();
         buildPullRequest();

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/multiScmInstances/PublishTicketsWithOptionalScmConfSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/multiScmInstances/PublishTicketsWithOptionalScmConfSteps.java
@@ -1,0 +1,141 @@
+package com.checkmarx.flow.cucumber.integration.multiScmInstances;
+
+import com.checkmarx.flow.CxFlowApplication;
+import com.checkmarx.flow.config.FlowProperties;
+import com.checkmarx.flow.config.GitHubProperties;
+import com.checkmarx.flow.config.OptionalScmInstanceProperties;
+import com.checkmarx.flow.cucumber.common.utils.JsonUtils;
+import com.checkmarx.flow.cucumber.common.utils.TestUtils;
+import com.checkmarx.flow.dto.BugTracker;
+import com.checkmarx.flow.dto.Issue;
+import com.checkmarx.flow.dto.ScanRequest;
+import com.checkmarx.flow.exception.MachinaException;
+import com.checkmarx.flow.service.ResultsService;
+import com.checkmarx.flow.utils.github.GitHubTestUtils;
+import com.checkmarx.flow.utils.github.GitHubTestUtilsImpl;
+import com.checkmarx.sdk.config.Constants;
+import com.checkmarx.sdk.dto.Filter;
+import com.checkmarx.sdk.dto.ScanResults;
+import com.checkmarx.sdk.dto.filtering.FilterConfiguration;
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import lombok.RequiredArgsConstructor;
+import org.junit.Assert;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.checkmarx.flow.cucumber.common.Constants.CUCUMBER_DATA_DIR;
+
+@SpringBootTest(classes = {CxFlowApplication.class, GitHubTestUtils.class})
+@RequiredArgsConstructor
+public class PublishTicketsWithOptionalScmConfSteps {
+
+    private static final String INPUT_BASE_PATH = CUCUMBER_DATA_DIR + "/sample-ast-results/";
+    private static final String INPUT_FILE = "5-findings-2-high-3-medium.json";
+    private static final String REPO_NAME = "VB_3845";
+    private static final String SCM_INSTANCE_NAME = "instance1";
+
+    private final GitHubTestUtilsImpl gitHubTestUtils;
+    private final GitHubProperties gitHubProperties;
+    private final ResultsService resultsService;
+    private final FlowProperties flowProperties;
+
+    private List<Filter> filters;
+    private BugTracker bugTracker;
+    private ScanRequest scanRequest;
+
+    @Before("@Scm_Optional_Instance")
+    public void init() {
+        filters = createFiltersFromString();
+    }
+
+    @After("@Scm_Optional_Instance")
+    public void closeIssues() throws MachinaException {
+        List<Issue> openIssues = gitHubTestUtils.filterIssuesByState(gitHubTestUtils.getIssues(scanRequest), "open");
+        gitHubTestUtils.closeAllIssues(openIssues, scanRequest);
+    }
+
+    @Given("bug tracker is GitHub")
+    public void setBugTracker() {
+        bugTracker = getBasicBugTrackerToJira();
+        flowProperties.setBugTracker(bugTracker.getType().name());
+    }
+
+    @And("GitHub optional instance configuration is defined")
+    public void defineOptionalScmInstance() {
+        setGitHubProperties();
+    }
+
+    @When("processing the results")
+    public void resultsProcessing() throws IOException, MachinaException {
+        scanRequest = getBasicScanRequest();
+        ScanResults scanResults = JsonUtils.json2Object(TestUtils.getFileFromRelativeResourcePath(INPUT_BASE_PATH + INPUT_FILE), ScanResults.class);
+        resultsService.processResults(scanRequest, scanResults, null);
+    }
+
+    @Then("new GitHub Issues should be open respectively")
+    public void validateGitHubIssues() {
+        List<Issue> actualOpenIssues = gitHubTestUtils.filterIssuesByState(gitHubTestUtils.getIssues(scanRequest), "open");
+
+        Assert.assertEquals("Expected GitHub issues for optional SCM instance are not as expected",
+                3, actualOpenIssues.size());
+    }
+
+    private void setGitHubProperties() {
+        OptionalScmInstanceProperties instanceProperties = new OptionalScmInstanceProperties();
+        instanceProperties.setWebhookToken("1234");
+        instanceProperties.setToken(gitHubProperties.getToken());
+        instanceProperties.setApiUrl("https://api.github.com/repos/");
+        instanceProperties.setUrl("https://github.com");
+
+        Map<String, OptionalScmInstanceProperties> instancePropertiesMap = new LinkedHashMap<>();
+        instancePropertiesMap.put(SCM_INSTANCE_NAME, instanceProperties);
+        gitHubProperties.setOptionalInstances(instancePropertiesMap);
+
+        // Comment-out default configuration
+        gitHubProperties.setWebhookToken(null);
+        gitHubProperties.setToken(null);
+        gitHubProperties.setUrl(null);
+        gitHubProperties.setApiUrl(null);
+    }
+
+    private ScanRequest getBasicScanRequest() {
+        return ScanRequest.builder()
+                .product(ScanRequest.Product.CX)
+                .project("VB_3845-master")
+                .namespace("cxflowtestuser")
+                .repoName(REPO_NAME)
+                .repoType(ScanRequest.Repository.GITHUB)
+                .branch("master")
+                .bugTracker(bugTracker)
+                .refs(Constants.CX_BRANCH_PREFIX.concat("master"))
+                .filter(FilterConfiguration.fromSimpleFilters(filters))
+                .scmInstance(SCM_INSTANCE_NAME)
+                .build();
+    }
+
+    private List<Filter> createFiltersFromString() {
+        String[] filterValArr = "High, Medium, Low".split(",");
+        return Arrays.stream(filterValArr)
+                .map(filterVal -> new Filter(Filter.Type.SEVERITY, filterVal))
+                .collect(Collectors.toList());
+    }
+
+    private BugTracker getBasicBugTrackerToJira() {
+        return BugTracker.builder()
+                .type(BugTracker.Type.CUSTOM)
+                .customBean("GitHub")
+                .build();
+    }
+
+}

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/multiScmInstances/RunPublishTicketsWithOptionalScmConfSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/multiScmInstances/RunPublishTicketsWithOptionalScmConfSteps.java
@@ -1,0 +1,12 @@
+package com.checkmarx.flow.cucumber.integration.multiScmInstances;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        features = "src/test/resources/cucumber/features/integrationTests/jira/publish-processing.feature",
+        tags = "@Scm_Optional_Instance and not @Skip")
+public class RunPublishTicketsWithOptionalScmConfSteps {
+}

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
@@ -296,7 +296,7 @@ public class UpdatePullRequestCommentsSteps {
     }
 
     private void initGitHubControllerSpy() {
-        doNothing().when(gitHubControllerSpy).verifyHmacSignature(any(), any());
+        doNothing().when(gitHubControllerSpy).verifyHmacSignature(any(), any(), any());
     }
 
     private void initHelperServiceMock() {

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
@@ -7,6 +7,7 @@ import com.checkmarx.flow.controller.ADOController;
 import com.checkmarx.flow.controller.GitHubController;
 import com.checkmarx.flow.dto.ControllerRequest;
 import com.checkmarx.flow.dto.RepoComment;
+import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.dto.azure.AdoDetailsRequest;
 import com.checkmarx.flow.dto.azure.Project;
 import com.checkmarx.flow.dto.azure.Resource;
@@ -170,13 +171,13 @@ public class UpdatePullRequestCommentsSteps {
     private void deleteGitHubComments() throws IOException {
         List<RepoComment> comments = getRepoComments();
         for (RepoComment comment: comments) {
-            gitHubService.deleteComment(comment.getCommentUrl());
+            gitHubService.deleteComment(comment.getCommentUrl(), getBasicRequest());
         }
     }
 
     private List<RepoComment> getRepoComments() throws IOException {
         if (sourceControl.equals(SourceControlType.GITHUB)) {
-            return gitHubService.getComments(PULL_REQUEST_COMMENTS_URL);
+            return gitHubService.getComments(getBasicRequest());
         }
         else if (sourceControl.equals(SourceControlType.ADO)){
             return adoService.getComments(ADO_PR_COMMENTS_URL);
@@ -303,6 +304,11 @@ public class UpdatePullRequestCommentsSteps {
         when(helperService.getShortUid()).thenReturn("123456");
     }
 
+    private ScanRequest getBasicRequest() {
+        return ScanRequest.builder()
+                .mergeNoteUri(PULL_REQUEST_COMMENTS_URL)
+                .build();
+    }
 
     private void initGitHubProperties() {
         this.gitHubProperties.setCxSummary(false);

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/sast/config/OverwritingProjectConfigSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/sast/config/OverwritingProjectConfigSteps.java
@@ -124,7 +124,7 @@ public class OverwritingProjectConfigSteps {
     public void githubNotifiesCxFlowAboutAPullRequest(String projectName) {
 
         GitHubController gitHubController = new GitHubController(gitHubProperties, flowProperties, cxProperties,
-                null, flowService, helperService, gitHubService, sastScanner, filterFactory, configOverrider);
+                null, flowService, helperService, gitHubService, sastScanner, filterFactory, configOverrider, null);
 
         gitHubTestUtils.callController(gitHubController, GitHubTestUtils.EventType.PULL_REQUEST, projectName);
     }

--- a/src/test/resources/cucumber/features/integrationTests/jira/publish-processing.feature
+++ b/src/test/resources/cucumber/features/integrationTests/jira/publish-processing.feature
@@ -144,5 +144,10 @@ Feature: parse, and then publish processing given SAST XML results, findings sho
     When updating a new Jira issue via the command line
     Then a matching ticket updating data should be recorded in the analytics json file
 
-
+  @Scm_Optional_Instance
+  Scenario: Open new GitHub tickets while GitHub default configuration is in comment-out and an optional scm-instance is defined
+    Given bug tracker is GitHub
+    And GitHub optional instance configuration is defined
+    When processing the results
+    Then new GitHub Issues should be open respectively
 


### PR DESCRIPTION
### Description

> Enable multiple optional SCM's instances on Cx-Flow configuration

### References

> https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/231

### Testing
Integration test with optional instance was created, while default configuration is on comment-out

>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
