### PR TITLE
fix #363 - github PR from forked repo handling #364 (clone of other PR with same nme)

### DIFF
--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -161,7 +161,7 @@ public class GitHubController extends WebhookController {
 
             setExclusionProperties(cxProperties, controllerRequest);
             //build request object
-            String gitUrl = pullRequest.getHead().getRepo().getCloneUrl()
+            String gitUrl = pullRequest.getHead().getRepo().getCloneUrl();
             String token = scmConfigOverrider.determineConfigToken(properties, controllerRequest.getScmInstance());
             log.info("Using url: {}", gitUrl);
             String gitAuthUrl = gitUrl.replace(Constants.HTTPS, Constants.HTTPS.concat(token).concat("@"));

--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -161,7 +161,7 @@ public class GitHubController extends WebhookController {
 
             setExclusionProperties(cxProperties, controllerRequest);
             //build request object
-            String gitUrl = repository.getCloneUrl();
+            String gitUrl = pullRequest.getHead().getRepo().getCloneUrl()
             String token = scmConfigOverrider.determineConfigToken(properties, controllerRequest.getScmInstance());
             log.info("Using url: {}", gitUrl);
             String gitAuthUrl = gitUrl.replace(Constants.HTTPS, Constants.HTTPS.concat(token).concat("@"));

--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -161,7 +161,9 @@ public class GitHubController extends WebhookController {
 
             setExclusionProperties(cxProperties, controllerRequest);
             //build request object
-            String gitUrl = pullRequest.getHead().getRepo().getCloneUrl();
+            String gitUrl = Optional.ofNullable(pullRequest.getHead().getRepo())
+                    .map(Repo::getCloneUrl)
+                    .orElse(repository.getCloneUrl());
             String token = scmConfigOverrider.determineConfigToken(properties, controllerRequest.getScmInstance());
             log.info("Using url: {}", gitUrl);
             String gitAuthUrl = gitUrl.replace(Constants.HTTPS, Constants.HTTPS.concat(token).concat("@"));


### PR DESCRIPTION
This PR is a clone of the PR #364 

Description
Previously, the GitHubController would set the clone URL to the repository's clone URL (equivalent to the PR base branch clone URL); this commit instead sets the clone URL to the clone URL of the pull request HEAD, so that scanned code changes are pulled from the correct repository, whether the PR was from a branch in the same repo or from a branch in a forked repository.

References
#363

Testing
To demonstrate failure case:

Fork a repo that is configured with CxFlow webhook
Create a branch name that does not exist on the source repository
Make a commit on that forked branch
open a PR from the forked repo, asking to merge your forked branch onto the default branch of the source repo
observe that CxFlow fails to process the event since it cannot find the ref name on the source repo
To test this PR, repeat the steps 1-4 above after this change, and note that all use cases now work as expected

Checklist
 I have added documentation for new/changed functionality in this PR (if applicable). If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment
 All active GitHub checks for tests, formatting, and security are passing
 The correct base branch is being used