### PR TITLE
Fixed: Remove hard coded auto profile setting to TRUE on GitHubController flow

### DIFF
--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -414,8 +414,6 @@ public class GitHubController extends WebhookController {
             namespace = repository.getOwner().getName().replace(" ", "_");
         }
 
-        flowProperties.setAutoProfile(true);
-
         ScanRequest request = ScanRequest.builder()
                 .application(app)
                 .product(p)


### PR DESCRIPTION
this is a clone  of PR #368 

### Description

> This fixes a breaking issue for our environment. We have the autoProfile property set to false in our environment, because when autoProfile is enabled, CxFlow hits an exception during commit & PR events when it calls the profile-related GitHub APIs (perhaps because the GitHub Enterprise service account we use does not have the needed scopes/permissions for those APIs) and so that exception causes processing of those event to fail and CxFlow doesn't create the project and/or kick off Checkmarx scans. I think it's apparent that the line this PR deletes was a typo anyway, because it globally overrides the autoProfile property on branch deletion events, so we would see things working as normal (autoProfile disabled) until a branch deletion event was processed, at which point all other events started failing since autoProfile was enabled.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X ] All active GitHub checks for tests, formatting, and security are passing
- [X ] The correct base branch is being used
