### PR TITLE
Implemented getting and publishing latest SCA scan results in CLI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,8 @@ When providing --config override file you can override many elements associated 
 "severity": ["High", "Medium"],
  "cwe": ["79", "89"],
  "category": ["XSS_Reflected", "SQL_Injection"],
- "status": ["Confirmed", "New"]
+ "status": ["New", "Reoccured"],
+ "state": ["Urgent", "Confirmed"]
 }
 }
 ```

--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.4.36"
+        CxSBSDK = "0.4.37"
         //cxVersion = "8.90.5"
         springBootVersion = '2.2.6.RELEASE'
         sonarqubeVersion = '2.8'

--- a/build-cxgo.gradle
+++ b/build-cxgo.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.1.30"
+        CxSBSDK = "0.1.31"
         //cxVersion = "8.90.5"
         springBootVersion = '2.2.6.RELEASE'
         sonarqubeVersion = '2.8'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.4.36"
+        CxSBSDK = "0.4.37"
         //cxVersion = "8.90.5"
         springBootVersion = '2.2.6.RELEASE'
         sonarqubeVersion = '2.8'

--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -397,7 +397,7 @@ public class CxFlowRunner implements ApplicationRunner {
                     log.error("cx-project must be provided when --project option is used");
                     exit(2);
                 }
-                cxResults(request);
+                publishLatestScanResults(request);
             }
             else if(args.containsOption("scan")){
                 log.info("Executing scan process");
@@ -432,7 +432,7 @@ public class CxFlowRunner implements ApplicationRunner {
             }
         }catch (Exception e){
             log.error("An error occurred while processing request", e);
-            exit(10);
+            exit(ExitCode.BUILD_INTERRUPTED);
         }
         log.info("Completed Successfully");
         exit(ExitCode.SUCCESS);
@@ -499,11 +499,11 @@ public class CxFlowRunner implements ApplicationRunner {
         runOnActiveScanners(scanner -> scanner.scanCli(request , "cxBatch"));
     }
 
-    private void cxResults(ScanRequest request) throws ExitThrowable {
+    private void publishLatestScanResults(ScanRequest request) throws ExitThrowable {
         ScanResults results = resultsService.cxGetResults(request, null).join();
         if(flowProperties.isBreakBuild() && resultsService.filteredIssuesPresent(results)){
             log.error(ERROR_BREAK_MSG);
-            exit(10);
+            exit(ExitCode.BUILD_INTERRUPTED);
         }
     }
 
@@ -512,7 +512,7 @@ public class CxFlowRunner implements ApplicationRunner {
             resultsService.processResults(request, results, null);
             if (flowProperties.isBreakBuild() && resultsService.filteredIssuesPresent(results)) {
                 log.error(ERROR_BREAK_MSG);
-                exit(10);
+                exit(ExitCode.BUILD_INTERRUPTED);
             }
 
         } catch (MachinaException e) {

--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -484,7 +484,7 @@ public class CxFlowRunner implements ApplicationRunner {
             log.error("Please provide --cx-project to define the project in Checkmarx");
             exit(2);
         }
-        processResults(request, runOnActiveScanners(scanner -> scanner.scanCli(request , "cxFullScan", new File(path))));
+        processResults(request, runOnActiveScanners(scanner -> scanner.scanCli(request, "cxFullScan", new File(path))));
     }
 
     private void cxOsaParse(ScanRequest request, File file, File libs) throws ExitThrowable {
@@ -492,19 +492,16 @@ public class CxFlowRunner implements ApplicationRunner {
     }
 
     private void cxParse(ScanRequest request, File file) throws ExitThrowable {
-        runOnActiveScanners(scanner -> scanner.scanCli(request , "cxParse", file));
+        runOnActiveScanners(scanner -> scanner.scanCli(request, "cxParse", file));
     }
 
     private void cxBatch(ScanRequest request) throws ExitThrowable {
-        runOnActiveScanners(scanner -> scanner.scanCli(request , "cxBatch"));
+        runOnActiveScanners(scanner -> scanner.scanCli(request, "cxBatch"));
     }
 
     private void publishLatestScanResults(ScanRequest request) throws ExitThrowable {
-        ScanResults results = resultsService.cxGetResults(request, null).join();
-        if(flowProperties.isBreakBuild() && resultsService.filteredIssuesPresent(results)){
-            log.error(ERROR_BREAK_MSG);
-            exit(ExitCode.BUILD_INTERRUPTED);
-        }
+        ScanResults results = runOnActiveScanners(scanner -> scanner.getLatestScanResults(request));
+        processResults(request, results);
     }
 
     private void processResults(ScanRequest request, ScanResults results) throws ExitThrowable {

--- a/src/main/java/com/checkmarx/flow/controller/FlowController.java
+++ b/src/main/java/com/checkmarx/flow/controller/FlowController.java
@@ -103,7 +103,7 @@ public class FlowController {
         // Fetch the Checkmarx Scan Results based on given ScanRequest.
         // The cxProject parameter is null because the required project metadata
         // is already contained in the scanRequest parameter.
-        ScanResults scanResults = sastScanner.cxGetResults(scanRequest, null).join();
+        ScanResults scanResults = sastScanner.getLatestScanResults(scanRequest);
         log.debug("ScanResults {}", scanResults);
 
         return scanResults;

--- a/src/main/java/com/checkmarx/flow/controller/FlowController.java
+++ b/src/main/java/com/checkmarx/flow/controller/FlowController.java
@@ -51,9 +51,9 @@ public class FlowController {
     private final FlowService scanService;
     private final HelperService helperService;
     private final JiraProperties jiraProperties;
-    private final ResultsService resultsService;
     private final FilterFactory filterFactory;
     private final ConfigurationOverrider configOverrider;
+    private final SastScanner sastScanner;
 
     @GetMapping(value = "/scanresults", produces = "application/json")
     public ScanResults latestScanResults(
@@ -103,7 +103,7 @@ public class FlowController {
         // Fetch the Checkmarx Scan Results based on given ScanRequest.
         // The cxProject parameter is null because the required project metadata
         // is already contained in the scanRequest parameter.
-        ScanResults scanResults = resultsService.cxGetResults(scanRequest, null).join();
+        ScanResults scanResults = sastScanner.cxGetResults(scanRequest, null).join();
         log.debug("ScanResults {}", scanResults);
 
         return scanResults;

--- a/src/main/java/com/checkmarx/flow/dto/ExitCode.java
+++ b/src/main/java/com/checkmarx/flow/dto/ExitCode.java
@@ -10,7 +10,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ExitCode {
-    SUCCESS(0);
+    SUCCESS(0),
+    BUILD_INTERRUPTED(10);
 
     private final int value;
 }

--- a/src/main/java/com/checkmarx/flow/service/AbstractASTScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/AbstractASTScanner.java
@@ -1,21 +1,28 @@
 package com.checkmarx.flow.service;
 
 import com.checkmarx.flow.config.FlowProperties;
-import com.checkmarx.flow.dto.*;
+import com.checkmarx.flow.dto.OperationResult;
+import com.checkmarx.flow.dto.OperationStatus;
+import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.dto.report.AnalyticsReport;
 import com.checkmarx.flow.dto.report.ScanReport;
 import com.checkmarx.flow.exception.ExitThrowable;
 import com.checkmarx.flow.exception.MachinaRuntimeException;
 import com.checkmarx.flow.utils.ZipUtils;
 import com.checkmarx.sdk.dto.ScanResults;
-import com.checkmarx.sdk.dto.ast.*;
+import com.checkmarx.sdk.dto.ast.ASTResults;
+import com.checkmarx.sdk.dto.ast.ASTResultsWrapper;
+import com.checkmarx.sdk.dto.ast.SCAResults;
+import com.checkmarx.sdk.dto.ast.ScanParams;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.file.*;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.UUID;
 

--- a/src/main/java/com/checkmarx/flow/service/AbstractASTScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/AbstractASTScanner.java
@@ -71,8 +71,11 @@ public abstract class AbstractASTScanner implements VulnerabilityScanner {
 
     @Override
     public ScanResults getLatestScanResults(ScanRequest request) {
-        // stub
-        return new ScanResults();
+        ScanParams internalScanParams = ScanParams.builder()
+                .projectName(request.getProject())
+                .build();
+        ASTResultsWrapper internalResults = client.getLatestScanResults(internalScanParams);
+        return toScanResults(internalResults);
     }
 
     private void treatError(ScanRequest scanRequest, ASTResultsWrapper internalResults, Exception e) {
@@ -96,9 +99,9 @@ public abstract class AbstractASTScanner implements VulnerabilityScanner {
             log.debug("free space {}", f.getFreeSpace());
             log.debug("total space {}", f.getTotalSpace());
             log.debug(f.getAbsolutePath());
-            ScanParams internalScaParams = toParams(scanRequest, cxZipFile);
+            ScanParams internalScanParams = toParams(scanRequest, cxZipFile);
 
-            internalResults = client.scanLocalSource(internalScaParams);
+            internalResults = client.scanLocalSource(internalScanParams);
             logRequest(scanRequest, getScanId(internalResults), OperationResult.successful());
             result = toScanResults(internalResults);
 

--- a/src/main/java/com/checkmarx/flow/service/OsaScannerService.java
+++ b/src/main/java/com/checkmarx/flow/service/OsaScannerService.java
@@ -1,7 +1,9 @@
 package com.checkmarx.flow.service;
 
 import com.checkmarx.flow.config.FlowProperties;
-import com.checkmarx.flow.dto.*;
+import com.checkmarx.flow.dto.ExitCode;
+import com.checkmarx.flow.dto.ScanDetails;
+import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.exception.ExitThrowable;
 import com.checkmarx.flow.exception.MachinaException;
 import com.checkmarx.sdk.dto.ScanResults;

--- a/src/main/java/com/checkmarx/flow/service/OsaScannerService.java
+++ b/src/main/java/com/checkmarx/flow/service/OsaScannerService.java
@@ -1,8 +1,7 @@
 package com.checkmarx.flow.service;
 
 import com.checkmarx.flow.config.FlowProperties;
-import com.checkmarx.flow.dto.ScanDetails;
-import com.checkmarx.flow.dto.ScanRequest;
+import com.checkmarx.flow.dto.*;
 import com.checkmarx.flow.exception.ExitThrowable;
 import com.checkmarx.flow.exception.MachinaException;
 import com.checkmarx.sdk.dto.ScanResults;
@@ -20,8 +19,8 @@ import static com.checkmarx.flow.exception.ExitThrowable.exit;
 @Slf4j
 @RequiredArgsConstructor
 public class OsaScannerService {
-
-    private static final String ERROR_BREAK_MSG = "Exiting with Error code 10 due to issues present";
+    private static final String ERROR_BREAK_MSG = String.format("Exiting with Error code %d due to issues present",
+            ExitCode.BUILD_INTERRUPTED.getValue());
 
     private final CxClient cxService;
     private final ResultsService resultsService;
@@ -35,7 +34,7 @@ public class OsaScannerService {
             resultsService.processResults(request, results, scanDetails);
             if(flowProperties.isBreakBuild() && results !=null && results.getXIssues()!=null && !results.getXIssues().isEmpty()){
                 log.error(ERROR_BREAK_MSG);
-                exit(10);
+                exit(ExitCode.BUILD_INTERRUPTED);
             }
         } catch (MachinaException | CheckmarxException e) {
             log.error("Error occurred while processing results file(s)", e);

--- a/src/main/java/com/checkmarx/flow/service/ResultsService.java
+++ b/src/main/java/com/checkmarx/flow/service/ResultsService.java
@@ -1,10 +1,16 @@
 package com.checkmarx.flow.service;
 
 import com.atlassian.jira.rest.client.api.RestClientException;
-import com.checkmarx.flow.dto.*;
+import com.checkmarx.flow.dto.Field;
+import com.checkmarx.flow.dto.ScanDetails;
+import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.dto.report.AnalyticsReport;
 import com.checkmarx.flow.dto.report.ScanResultsReport;
-import com.checkmarx.flow.exception.*;
+import com.checkmarx.flow.exception.InvalidCredentialsException;
+import com.checkmarx.flow.exception.JiraClientException;
+import com.checkmarx.flow.exception.JiraClientRunTimeException;
+import com.checkmarx.flow.exception.MachinaException;
+import com.checkmarx.flow.exception.MachinaRuntimeException;
 import com.checkmarx.flow.utils.ScanUtils;
 import com.checkmarx.sdk.config.Constants;
 import com.checkmarx.sdk.config.CxProperties;
@@ -21,7 +27,10 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static com.checkmarx.sdk.config.Constants.UNKNOWN_INT;

--- a/src/main/java/com/checkmarx/flow/service/SCAScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/SCAScanner.java
@@ -4,9 +4,7 @@ import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.sdk.config.ScaProperties;
 import com.checkmarx.sdk.dto.ScanResults;
 import com.checkmarx.sdk.dto.ast.ASTResultsWrapper;
-import com.checkmarx.sdk.service.AstClient;
 import com.cx.restclient.ScaClientImpl;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -15,12 +13,10 @@ import java.util.Optional;
 
 @Service
 @Slf4j
-public class SCAScanner extends  AbstractASTScanner{
-
+public class SCAScanner extends AbstractASTScanner {
     public SCAScanner(ScaClientImpl astClient, FlowProperties flowProperties) {
         super(astClient, flowProperties, ScaProperties.CONFIG_PREFIX);
     }
-
 
     @Override
     protected ScanResults toScanResults(ASTResultsWrapper internalResults) {
@@ -29,13 +25,8 @@ public class SCAScanner extends  AbstractASTScanner{
                 .build();
     }
 
-
     @Override
     protected String getScanId(ASTResultsWrapper internalResults) {
-
         return Optional.ofNullable(internalResults.getScaResults().getScanId()).orElse("");
     }
-
-
-
 }

--- a/src/main/java/com/checkmarx/flow/service/SastScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/SastScanner.java
@@ -149,7 +149,7 @@ public class SastScanner implements VulnerabilityScanner {
 
     @Override
     public ScanResults getLatestScanResults(ScanRequest request) {
-        return cxGetResults(request, null).join();
+        return getLatestScanResultsAsync(request, null).join();
     }
 
     private ScanResults getEmptyScanResults() {
@@ -300,7 +300,7 @@ public class SastScanner implements VulnerabilityScanner {
                 helperService.getShortUid(request); //update new request object with a unique id for thread log monitoring
                 request.setProject(name);
                 request.setApplication(name);
-                processes.add(cxGetResults(request, project));
+                processes.add(getLatestScanResultsAsync(request, project));
             }
             log.info("Waiting for processing to complete");
             processes.forEach(CompletableFuture::join);
@@ -419,7 +419,7 @@ public class SastScanner implements VulnerabilityScanner {
         return osaScanId;
     }
 
-    public CompletableFuture<ScanResults> cxGetResults(ScanRequest request, CxProject cxProject) {
+    public CompletableFuture<ScanResults> getLatestScanResultsAsync(ScanRequest request, CxProject cxProject) {
         try {
             CxProject project;
 

--- a/src/main/java/com/checkmarx/flow/service/SastScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/SastScanner.java
@@ -262,7 +262,7 @@ public class SastScanner implements VulnerabilityScanner {
             resultsService.processResults(request, results, scanDetails);
             if (flowProperties.isBreakBuild() && results != null && results.getXIssues() != null && !results.getXIssues().isEmpty()) {
                 log.error(ERROR_BREAK_MSG);
-                exit(10);
+                exit(ExitCode.BUILD_INTERRUPTED);
             }
         } catch (MachinaException | CheckmarxException e) {
             log.error("Error occurred while processing results file", e);

--- a/src/main/java/com/checkmarx/flow/service/SastScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/SastScanner.java
@@ -146,7 +146,12 @@ public class SastScanner implements VulnerabilityScanner {
         }
         return scanResults;
     }
-    
+
+    @Override
+    public ScanResults getLatestScanResults(ScanRequest request) {
+        return cxGetResults(request, null).join();
+    }
+
     private ScanResults getEmptyScanResults() {
         ScanResults scanResults;
         scanResults = new ScanResults();
@@ -199,10 +204,10 @@ public class SastScanner implements VulnerabilityScanner {
                 }
             }
         } catch (GitHubRepoUnavailableException e) {
-            //the error message is printed when the exception is thrown
-            //usually should occur during push event occuring on delete branch
-            //therefore need to eliminate the scan process but do not want to create
-            //an error stuck trace in the log
+            // The error message is printed when the exception is thrown.
+            // Usually should occur during push event occurring on delete branch.
+            // Therefore need to eliminate the scan process but do not want to create
+            // an error stack trace in the log.
             return new ScanDetails(UNKNOWN_INT, UNKNOWN_INT, new CompletableFuture<>(), false);
         } catch (CheckmarxException | GitAPIException e) {
             String extendedMessage = treatFailure(request, cxFile, scanId, e);
@@ -295,7 +300,7 @@ public class SastScanner implements VulnerabilityScanner {
                 helperService.getShortUid(request); //update new request object with a unique id for thread log monitoring
                 request.setProject(name);
                 request.setApplication(name);
-                processes.add(resultsService.cxGetResults(request, project));
+                processes.add(cxGetResults(request, project));
             }
             log.info("Waiting for processing to complete");
             processes.forEach(CompletableFuture::join);
@@ -412,5 +417,92 @@ public class SastScanner implements VulnerabilityScanner {
             osaScanId = osaService.createScan(projectId, path);
         }
         return osaScanId;
+    }
+
+    public CompletableFuture<ScanResults> cxGetResults(ScanRequest request, CxProject cxProject) {
+        try {
+            CxProject project;
+
+            if (cxProject == null) {
+                String team = request.getTeam();
+                if (ScanUtils.empty(team)) {
+                    //if the team is not provided, use the default
+                    team = cxProperties.getTeam();
+                    request.setTeam(team);
+                }
+                if (!team.startsWith(cxProperties.getTeamPathSeparator())) {
+                    team = cxProperties.getTeamPathSeparator().concat(team);
+                }
+                String teamId = cxService.getTeamId(team);
+                Integer projectId = cxService.getProjectId(teamId, request.getProject());
+                if (projectId.equals(UNKNOWN_INT)) {
+                    log.warn("No project found for {}", request.getProject());
+                    CompletableFuture<ScanResults> x = new CompletableFuture<>();
+                    x.complete(null);
+                    return x;
+                }
+                project = cxService.getProject(projectId);
+
+            } else {
+                project = cxProject;
+            }
+            Integer scanId = cxService.getLastScanId(project.getId());
+            if (scanId.equals(UNKNOWN_INT)) {
+                log.warn("No Scan Results to process for project {}", project.getName());
+                CompletableFuture<ScanResults> x = new CompletableFuture<>();
+                x.complete(null);
+                return x;
+            } else {
+                getCxFields(project, request);
+                //null is passed for osaScanId as it is not applicable here and will be ignored
+                return resultsService.processScanResultsAsync(request, project.getId(), scanId, null, request.getFilter());
+            }
+
+        } catch (MachinaException | CheckmarxException e) {
+            log.error("Error occurred while processing results for {}{}", request.getTeam(), request.getProject(), e);
+            CompletableFuture<ScanResults> x = new CompletableFuture<>();
+            x.completeExceptionally(e);
+            return x;
+        }
+    }
+
+    private void getCxFields(CxProject project, ScanRequest request) {
+        if (project == null) {
+            return;
+        }
+
+        Map<String, String> fields = new HashMap<>();
+        for (CxProject.CustomField field : project.getCustomFields()) {
+            String name = field.getName();
+            String value = field.getValue();
+            if (!ScanUtils.empty(name) && !ScanUtils.empty(value)) {
+                fields.put(name, value);
+            }
+        }
+        if (!ScanUtils.empty(cxProperties.getJiraProjectField())) {
+            String jiraProject = fields.get(cxProperties.getJiraProjectField());
+            if (!ScanUtils.empty(jiraProject)) {
+                request.getBugTracker().setProjectKey(jiraProject);
+            }
+        }
+        if (!ScanUtils.empty(cxProperties.getJiraIssuetypeField())) {
+            String jiraIssuetype = fields.get(cxProperties.getJiraIssuetypeField());
+            if (!ScanUtils.empty(jiraIssuetype)) {
+                request.getBugTracker().setIssueType(jiraIssuetype);
+            }
+        }
+        if (!ScanUtils.empty(cxProperties.getJiraCustomField()) &&
+                (fields.get(cxProperties.getJiraCustomField()) != null) && !fields.get(cxProperties.getJiraCustomField()).isEmpty()) {
+            request.getBugTracker().setFields(ScanUtils.getCustomFieldsFromCx(fields.get(cxProperties.getJiraCustomField())));
+        }
+
+        if (!ScanUtils.empty(cxProperties.getJiraAssigneeField())) {
+            String assignee = fields.get(cxProperties.getJiraAssigneeField());
+            if (!ScanUtils.empty(assignee)) {
+                request.getBugTracker().setAssignee(assignee);
+            }
+        }
+
+        request.setCxFields(fields);
     }
 }

--- a/src/main/java/com/checkmarx/flow/service/VulnerabilityScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/VulnerabilityScanner.java
@@ -3,18 +3,17 @@ package com.checkmarx.flow.service;
 import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.sdk.dto.ScanResults;
 
+import javax.annotation.CheckForNull;
 import java.io.File;
 
-import javax.annotation.CheckForNull;
-
 public interface VulnerabilityScanner {
-
-    
     @CheckForNull
     ScanResults scan(ScanRequest scanRequest);
 
     @CheckForNull
-	ScanResults scanCli(ScanRequest request, String scanType, File... files);
+    ScanResults scanCli(ScanRequest request, String scanType, File... files);
+
+    ScanResults getLatestScanResults(ScanRequest request);
 
     boolean isEnabled();
 }

--- a/src/main/java/com/checkmarx/flow/utils/ZipUtils.java
+++ b/src/main/java/com/checkmarx/flow/utils/ZipUtils.java
@@ -1,24 +1,18 @@
 package com.checkmarx.flow.utils;
 
 import com.google.common.base.Strings;
-import org.slf4j.Logger;
+import lombok.extern.slf4j.Slf4j;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.nio.file.FileSystems;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+@Slf4j
 public class ZipUtils {
-    private static final Logger log = org.slf4j.LoggerFactory.getLogger(ZipUtils.class);
-
     private static final int DEFAULT_BUFFER_SIZE = 1024 * 4;
 
     private ZipUtils() {

--- a/src/test/java/com/checkmarx/flow/controller/FlowControllerTest.java
+++ b/src/test/java/com/checkmarx/flow/controller/FlowControllerTest.java
@@ -87,7 +87,7 @@ public class FlowControllerTest {
     public void testSSuccessfulScanResult(String severity, String cwe, String category, String status, String assignee, String override, String bug) {
         ScanResults results = new ScanResults();
         CompletableFuture<ScanResults> cf = CompletableFuture.completedFuture(results);
-        when(sastScanner.cxGetResults(any(ScanRequest.class), isNull())).thenReturn(cf);
+        when(sastScanner.getLatestScanResultsAsync(any(ScanRequest.class), isNull())).thenReturn(cf);
 
         ArgumentCaptor<ScanRequest> captor = ArgumentCaptor.forClass(ScanRequest.class);
         List<String> severityFilters = TestsParseUtils.parseCsvToList(severity);
@@ -96,7 +96,7 @@ public class FlowControllerTest {
         List<String> statusFilters = TestsParseUtils.parseCsvToList(status);
         ScanResults scanResults = flowController.latestScanResults(testProps.getProject(), flowProperties.getToken(), ScanFixture.TEAM_ID, testProps.getApplication(), severityFilters,
                 cweFilters, categoryFilters, statusFilters, assignee, override, bug);
-        verify(sastScanner, times(1)).cxGetResults(captor.capture(), isNull());
+        verify(sastScanner, times(1)).getLatestScanResultsAsync(captor.capture(), isNull());
         ScanRequest actual = captor.getValue();
         assertScanResultsRequest(actual, testProps.getApplication(), ScanFixture.TEAM_ID, severityFilters, cweFilters, categoryFilters, statusFilters);
     }
@@ -167,15 +167,15 @@ public class FlowControllerTest {
         assert400Response(response);
     }
 
-    private void assertOKResponse(ResponseEntity response) {
+    private void assertOKResponse(ResponseEntity<?> response) {
         assertHttpResponse(response, HttpStatus.OK);
     }
 
-    private void assert400Response(ResponseEntity response) {
+    private void assert400Response(ResponseEntity<?> response) {
         assertHttpResponse(response, HttpStatus.BAD_REQUEST);
     }
 
-    private void assertHttpResponse(ResponseEntity response, HttpStatus desiredStatus) {
+    private void assertHttpResponse(ResponseEntity<?> response, HttpStatus desiredStatus) {
         Assert.assertEquals("Received wrong HTTP status",desiredStatus, response.getStatusCode());
     }
 
@@ -224,7 +224,7 @@ public class FlowControllerTest {
                 .collect(Collectors.toList());
 
         for (String wantedStr : wanted) {
-            boolean found = !(filtersForType.stream().filter(f -> f.getValue().equals(wantedStr)).count() == 0);
+            boolean found = !(filtersForType.stream().noneMatch(f -> f.getValue().equals(wantedStr)));
             Assert.assertTrue(String.format("Filter from type: %s and value %s was not found in call to FlowService", filterType, wanted), found);
         }
     }

--- a/src/test/java/com/checkmarx/flow/controller/FlowControllerTest.java
+++ b/src/test/java/com/checkmarx/flow/controller/FlowControllerTest.java
@@ -5,9 +5,7 @@ import com.checkmarx.flow.config.JiraProperties;
 import com.checkmarx.flow.cucumber.component.scan.ScanFixture;
 import com.checkmarx.flow.dto.EventResponse;
 import com.checkmarx.flow.dto.ScanRequest;
-import com.checkmarx.flow.service.FlowService;
-import com.checkmarx.flow.service.HelperService;
-import com.checkmarx.flow.service.ResultsService;
+import com.checkmarx.flow.service.*;
 import com.checkmarx.flow.utils.ApiFlowControllerComponentTestProperties;
 import com.checkmarx.sdk.config.CxProperties;
 import com.checkmarx.sdk.dto.Filter;
@@ -72,6 +70,9 @@ public class FlowControllerTest {
     @Autowired
     ResultsService resultsService;
 
+    @Autowired
+    SastScanner sastScanner;
+
     @BeforeEach
     public void initMocks() throws CheckmarxException {
         when(cxClient.getTeamId(anyString())).thenReturn(ScanFixture.TEAM_ID);
@@ -83,10 +84,10 @@ public class FlowControllerTest {
 
     @ParameterizedTest
     @MethodSource("generateDataForSuccessfulScanResults")
-    public void testSSuccessfullScanResult(String severity, String cwe, String category, String status, String assignee, String override, String bug) {
+    public void testSSuccessfulScanResult(String severity, String cwe, String category, String status, String assignee, String override, String bug) {
         ScanResults results = new ScanResults();
         CompletableFuture<ScanResults> cf = CompletableFuture.completedFuture(results);
-        when(resultsService.cxGetResults(any(ScanRequest.class), isNull())).thenReturn(cf);
+        when(sastScanner.cxGetResults(any(ScanRequest.class), isNull())).thenReturn(cf);
 
         ArgumentCaptor<ScanRequest> captor = ArgumentCaptor.forClass(ScanRequest.class);
         List<String> severityFilters = TestsParseUtils.parseCsvToList(severity);
@@ -95,7 +96,7 @@ public class FlowControllerTest {
         List<String> statusFilters = TestsParseUtils.parseCsvToList(status);
         ScanResults scanResults = flowController.latestScanResults(testProps.getProject(), flowProperties.getToken(), ScanFixture.TEAM_ID, testProps.getApplication(), severityFilters,
                 cweFilters, categoryFilters, statusFilters, assignee, override, bug);
-        verify(resultsService, times(1)).cxGetResults(captor.capture(), isNull());
+        verify(sastScanner, times(1)).cxGetResults(captor.capture(), isNull());
         ScanRequest actual = captor.getValue();
         assertScanResultsRequest(actual, testProps.getApplication(), ScanFixture.TEAM_ID, severityFilters, cweFilters, categoryFilters, statusFilters);
     }
@@ -223,7 +224,7 @@ public class FlowControllerTest {
                 .collect(Collectors.toList());
 
         for (String wantedStr : wanted) {
-            boolean found = !filtersForType.stream().filter(f -> f.getValue().equals(wantedStr)).collect(Collectors.toList()).isEmpty();
+            boolean found = !(filtersForType.stream().filter(f -> f.getValue().equals(wantedStr)).count() == 0);
             Assert.assertTrue(String.format("Filter from type: %s and value %s was not found in call to FlowService", filterType, wanted), found);
         }
     }
@@ -232,12 +233,12 @@ public class FlowControllerTest {
         if (wanted == null) {
             Assert.assertNull(actual);
         } else {
-            Assert.assertTrue("Filters does not match", actual != null);
+            Assert.assertNotNull("Filters does not match", actual);
         }
         for(Filter wantedFilter: wanted) {
-            Assert.assertFalse(String.format("Filter Type %s with value %s not found in actual call", wantedFilter.getType(), wantedFilter.getValue()),actual.stream().filter(f ->
+            Assert.assertNotEquals(String.format("Filter Type %s with value %s not found in actual call", wantedFilter.getType(), wantedFilter.getValue()), 0, actual.stream().filter(f ->
                     f.getType().equals(wantedFilter.getType()) &&
-                    f.getValue().equals(wantedFilter.getValue())).collect(Collectors.toList()).isEmpty());
+                            f.getValue().equals(wantedFilter.getValue())).count());
         }
     }
 

--- a/src/test/java/com/checkmarx/flow/cucumber/component/analytics/get/GetResultsAnalyticsTestSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/analytics/get/GetResultsAnalyticsTestSteps.java
@@ -51,7 +51,6 @@ public class GetResultsAnalyticsTestSteps {
     private static final String PULL_REQUEST_STATUSES_URL = "statuses url stub";
     private static final String MERGE_NOTE_URL = "merge note url stub";
     private final CxClient cxClientMock;
-    private final FlowProperties flowProperties;
     private final EmailService emailService;
     private final CxProperties cxProperties;
     private ScanResults scanResultsToInject;
@@ -62,7 +61,6 @@ public class GetResultsAnalyticsTestSteps {
                                         CxProperties cxProperties, EmailService emailService) {
         this.cxClientMock = cxClientMock;
         flowProperties.setThresholds(new HashMap<>());
-        this.flowProperties = flowProperties;
         this.cxProperties = cxProperties;
         this.emailService = emailService;
     }
@@ -83,9 +81,9 @@ public class GetResultsAnalyticsTestSteps {
                 null,
                 null,
                 null,
-                null, emailService,
-                cxProperties,
-                flowProperties);
+                null,
+                emailService,
+                cxProperties);
     }
 
 
@@ -108,7 +106,7 @@ public class GetResultsAnalyticsTestSteps {
 
         scaResults.setScanId("" + SCAN_ID);
 
-        List<Finding> findings = new LinkedList<Finding>();
+        List<Finding> findings = new LinkedList<>();
         addFinding(high, findingCounts, findings, Severity.HIGH, Filter.Severity.HIGH);
         addFinding(medium, findingCounts, findings, Severity.MEDIUM, Filter.Severity.MEDIUM);
         addFinding(low, findingCounts, findings, Severity.LOW, Filter.Severity.LOW);

--- a/src/test/java/com/checkmarx/flow/cucumber/component/analytics/pullrequest/AnalyticsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/analytics/pullrequest/AnalyticsSteps.java
@@ -214,7 +214,7 @@ public class AnalyticsSteps {
     }
 
     private ResponseEntity<String> createResponseForGetComments() {
-        return new ResponseEntity<>("{}", HttpStatus.OK);
+        return ResponseEntity.ok("{}");
     }
 
     private void initMock(CxClient cxClientMock) {

--- a/src/test/java/com/checkmarx/flow/cucumber/component/analytics/pullrequest/AnalyticsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/analytics/pullrequest/AnalyticsSteps.java
@@ -214,8 +214,7 @@ public class AnalyticsSteps {
     }
 
     private ResponseEntity<String> createResponseForGetComments() {
-        ResponseEntity<String> result = new ResponseEntity<>("{}", HttpStatus.OK);
-        return result;
+        return new ResponseEntity<>("{}", HttpStatus.OK);
     }
 
     private void initMock(CxClient cxClientMock) {
@@ -244,8 +243,7 @@ public class AnalyticsSteps {
                 null,
                 null,
                 null,
-                cxProperties,
-                flowProperties);
+                cxProperties);
     }
 
     private static ScanResults createFakeSASTScanResults(Map<FindingSeverity, Integer> findingsPerSeverity) {
@@ -270,13 +268,13 @@ public class AnalyticsSteps {
 
     private static ScanResults createFakeSCAScanResults(Map<FindingSeverity, Integer> findingsPerSeverity, int scanId) {
 
-        Map<Filter.Severity, Integer> findingCounts= new HashMap<Filter.Severity, Integer>() ;
+        Map<Filter.Severity, Integer> findingCounts= new HashMap<>() ;
 
         SCAResults scaResults = new SCAResults();
 
         scaResults.setScanId("" + scanId);
 
-        List<Finding> findings = new LinkedList<Finding>();
+        List<Finding> findings = new LinkedList<>();
         addFinding(findingsPerSeverity.get(FindingSeverity.HIGH), findingCounts, findings, Severity.HIGH, Filter.Severity.HIGH);
         addFinding(findingsPerSeverity.get(FindingSeverity.MEDIUM), findingCounts, findings, Severity.MEDIUM, Filter.Severity.MEDIUM);
         addFinding(findingsPerSeverity.get(FindingSeverity.LOW), findingCounts, findings, Severity.LOW, Filter.Severity.LOW);

--- a/src/test/java/com/checkmarx/flow/cucumber/component/ast/parse/GitHubCommentsASTSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/ast/parse/GitHubCommentsASTSteps.java
@@ -135,8 +135,7 @@ public class GitHubCommentsASTSteps {
                     null,
                     null,
                     null, emailService,
-                    cxProperties,
-                    flowProperties);
+                    cxProperties);
         }
         
         throw new UnsupportedOperationException();
@@ -148,7 +147,7 @@ public class GitHubCommentsASTSteps {
         ASTResults astResults = new ASTResults();
         AstSastResults astSastResults = new AstSastResults();
 
-        List<Finding> findings = new LinkedList<Finding>();
+        List<Finding> findings = new LinkedList<>();
 
         astSastResults.setScanId("" + SCAN_ID);
 
@@ -156,7 +155,7 @@ public class GitHubCommentsASTSteps {
         if(highCount + mediumCount + lowCount > 0){
             addNodes = true;
         }
-        List<StatusCounter> findingCounts= new  LinkedList<StatusCounter> ();
+        List<StatusCounter> findingCounts = new LinkedList<> ();
         addFinding(highCount, findingCounts, findings, Severity.HIGH.name(),addNodes, "SQL_INJECTION");
         addFinding(mediumCount, findingCounts, findings, Severity.MEDIUM.name(), addNodes, "Hardcoded_password_in_Connection_String");
         addFinding(lowCount, findingCounts, findings, Severity.LOW.name(),addNodes, "Open_Redirect");
@@ -180,7 +179,7 @@ public class GitHubCommentsASTSteps {
 
     private static ScanResults createFakeSCAScanResults(int high, int medium, int low) {
 
-        Map<Filter.Severity, Integer> findingCounts= new HashMap<Filter.Severity, Integer>() ;
+        Map<Filter.Severity, Integer> findingCounts= new HashMap<>() ;
 
         SCAResults scaResults = new SCAResults();
 

--- a/src/test/java/com/checkmarx/flow/cucumber/component/thresholds/sastPR/ThresholdsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/thresholds/sastPR/ThresholdsSteps.java
@@ -283,8 +283,7 @@ public class ThresholdsSteps {
                 null,
                 adoService,
                 emailService,
-                cxProperties,
-                flowProperties);
+                cxProperties);
     }
 
     private static ScanResults createFakeScanResults() {

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/azure/publishing/github2ado/Github2AdoSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/azure/publishing/github2ado/Github2AdoSteps.java
@@ -307,8 +307,7 @@ public class Github2AdoSteps {
                 null,
                 null,
                 emailService,
-                cxProperties,
-                flowProperties));
+                cxProperties));
     }
 
     private ScanResults createFakeResults() {

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cli/sca/ScaCliSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cli/sca/ScaCliSteps.java
@@ -35,6 +35,8 @@ public class ScaCliSteps {
 
     private final FlowProperties flowProperties;
     private final JiraProperties jiraProperties;
+    private final ScaProperties scaProperties;
+
     private final CxFlowRunner cxFlowRunner;
     private Throwable cxFlowExecutionException;
 
@@ -50,6 +52,7 @@ public class ScaCliSteps {
     public void beforeEachScenario() throws IOException {
         log.info("Setting bugTracker: Jira");
         flowProperties.setBugTracker("JIRA");
+        initSCAConfig();
 
         List<String> scaOnly = Collections.singletonList(ScaProperties.CONFIG_PREFIX);
         flowProperties.setEnabledVulnerabilityScanners(scaOnly);
@@ -220,5 +223,11 @@ public class ScaCliSteps {
         log.info("Cleaning jira project before test: {}", jiraProperties.getProject());
         jiraUtils.ensureProjectExists(jiraProperties.getProject());
         jiraUtils.cleanProject(jiraProperties.getProject());
+    }
+
+    private void initSCAConfig() {
+        scaProperties.setAppUrl("https://sca.scacheckmarx.com");
+        scaProperties.setApiUrl("https://api.scacheckmarx.com");
+        scaProperties.setAccessControlUrl("https://platform.checkmarx.net");
     }
 }

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cli/sca/ScaCliSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cli/sca/ScaCliSteps.java
@@ -182,7 +182,7 @@ public class ScaCliSteps {
         log.info("Assuming finding count: {} for the previous scan.", count);
     }
 
-    @When("running CxFlow with `publish latest scan results` options for the project")
+    @When("running CxFlow with `publish latest scan results` options")
     public void runningCxFlowWithPublishLatestScanResultsOptions() {
         String commandLine = String.format("--project --cx-project=%s --app=MyApp --blocksysexit", customScaProjectName);
         tryRunCxFlow(commandLine);

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cli/sca/ScaCliSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cli/sca/ScaCliSteps.java
@@ -22,6 +22,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * This step implementation relies on specific projects that already exist in SCA (see customScaProjectName).
+ */
 @SpringBootTest(classes = {CxFlowApplication.class, JiraTestUtils.class})
 @Slf4j
 @RequiredArgsConstructor

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
@@ -558,9 +558,9 @@ public class CxConfigSteps {
                 gitHubServiceMock,
                 null,
                 null,
-                null, emailService,
-                cxProperties,
-                flowProperties);
+                null,
+                emailService,
+                cxProperties);
     }
 
     private static ScanResults createFakeScanResults() {

--- a/src/test/resources/cucumber/features/integrationTests/cli/sastCliScan.feature
+++ b/src/test/resources/cucumber/features/integrationTests/cli/sastCliScan.feature
@@ -1,7 +1,7 @@
 @SAST_CLI_SCAN @IntegrationTest
 Feature: Cx-Flow CLI SAST Integration tests
 
-  Background: running Sca scan
+  Background: running SAST scan
     Given repository is github-sast
 
   Scenario Outline: Testing break-build functionality

--- a/src/test/resources/cucumber/features/integrationTests/cli/scaCliScan.feature
+++ b/src/test/resources/cucumber/features/integrationTests/cli/scaCliScan.feature
@@ -29,7 +29,7 @@ Feature: SCA support in CxFlow command-line
         # Normal flow. Make sure that only the latest scan is used.
         Given previous scan for a SCA project contains 2 findings
         And last scan for the project contains <latest count> findings
-        When running CxFlow with `publish latest scan results` options for the project
+        When running CxFlow with `publish latest scan results` options
         Then bug tracker contains <latest count> issues
         Examples:
             | latest count |
@@ -40,16 +40,13 @@ Feature: SCA support in CxFlow command-line
     Scenario: Trying to publish latest scan results for a non-existent project
         # Make sure CxFlow doesn't crash in this case.
         Given the "ci-non-existent-project-test" project doesn't exist in SCA
-        When running CxFlow with `publish latest scan results` options for the project
+        When running CxFlow with `publish latest scan results` options
         Then bug tracker contains no issues
         And no exception is thrown
 
     Scenario: Trying to publish latest scan results for a project with no scans
         # Make sure CxFlow doesn't crash in this case either.
         Given the "ci-project-no-scans-test" project exists in SCA but doesn't have any scans
-        When running CxFlow with `publish latest scan results` options for the project
+        When running CxFlow with `publish latest scan results` options
         Then bug tracker contains no issues
         And no exception is thrown
-
-    @Skip
-    Scenario: While publishing latest scan results, CxFlow must respect SCA filters

--- a/src/test/resources/cucumber/features/integrationTests/cli/scaCliScan.feature
+++ b/src/test/resources/cucumber/features/integrationTests/cli/scaCliScan.feature
@@ -1,11 +1,8 @@
 @SCA_CLI_SCAN  @IntegrationTest
-Feature: Cx-Flow CLI SCA Integration tests
-
-    Background: running Sca scan
-        Given repository is github-sca
+Feature: SCA support in CxFlow command-line
 
     Scenario Outline: Testing break-build functionality
-        When running with break-build on <issue-type>
+        When running a SCA scan with break-build on <issue-type>
         Then run should exit with exit code <exit-code-number>
 
         Examples:

--- a/src/test/resources/cucumber/features/integrationTests/cli/scaCliScan.feature
+++ b/src/test/resources/cucumber/features/integrationTests/cli/scaCliScan.feature
@@ -1,5 +1,6 @@
 @SCA_CLI_SCAN  @IntegrationTest
 Feature: SCA support in CxFlow command-line
+    Background: Only SCA vulnerability scanner is enabled in CxFlow
 
     Scenario Outline: Testing break-build functionality
         When running a SCA scan with break-build on <issue-type>
@@ -22,3 +23,32 @@ Feature: SCA support in CxFlow command-line
             | no-filter              | x+y+z           |
             # | filter-High-and-Medium | x+y             |
             # | filter-only-Medium     | y               |
+
+    Scenario Outline: Publishing latest scan results
+        # Normal flow. Make sure that only the latest scan is used.
+        Given bug tracker contains no issues
+        And last scan for the corresponding SCA project contains "<latest count>" findings
+        And previous scan for the project contains 2 findings
+        When running CxFlow to publish latest scan results
+        Then bug tracker contains <latest count> issues
+        Examples:
+            | latest count |
+            | 0            |
+            | 1            |
+            | 3            |
+
+    Scenario: Trying to publish latest scan results for a non-existent project
+        # Make sure CxFlow doesn't crash in this case.
+        Given bug tracker contains no issues
+        And the "non-existent-test" project doesn't exist in SCA
+        When running CxFlow to publish latest scan results for the "non-existent-test" project
+        Then bug tracker still contains no issues
+        And no exception is thrown
+
+    Scenario: Trying to publish latest scan results for a project with no scans
+        # Make sure CxFlow doesn't crash in this case either.
+        Given bug tracker contains no issues
+        And the "project-without-scans" project exists in SCA but doesn't have any scans
+        When running CxFlow to publish latest scan results for the "project-without-scans" project
+        Then bug tracker still contains no issues
+        And no exception is thrown

--- a/src/test/resources/cucumber/features/integrationTests/cli/scaCliScan.feature
+++ b/src/test/resources/cucumber/features/integrationTests/cli/scaCliScan.feature
@@ -1,6 +1,7 @@
 @SCA_CLI_SCAN  @IntegrationTest
 Feature: SCA support in CxFlow command-line
     Background: Only SCA vulnerability scanner is enabled in CxFlow
+        Bug tracker doesn't contain any issues at the beginning of each test run.
 
     Scenario Outline: Testing break-build functionality
         When running a SCA scan with break-build on <issue-type>
@@ -16,7 +17,7 @@ Feature: SCA support in CxFlow command-line
     Scenario Outline: Testing cli filter functionality
         Given code has x High, y Medium and z low issues
         When running sca scan <filter>
-        Then bugTracker contains <number of issue> issues
+        Then bug tracker contains <number of issue> issues
 
         Examples:
             | filter                 | number of issue |
@@ -26,29 +27,29 @@ Feature: SCA support in CxFlow command-line
 
     Scenario Outline: Publishing latest scan results
         # Normal flow. Make sure that only the latest scan is used.
-        Given bug tracker contains no issues
-        And last scan for the corresponding SCA project contains "<latest count>" findings
-        And previous scan for the project contains 2 findings
-        When running CxFlow to publish latest scan results
+        Given previous scan for a SCA project contains 2 findings
+        And last scan for the project contains <latest count> findings
+        When running CxFlow with `publish latest scan results` options for the project
         Then bug tracker contains <latest count> issues
         Examples:
             | latest count |
             | 0            |
             | 1            |
-            | 3            |
+            | 5            |
 
     Scenario: Trying to publish latest scan results for a non-existent project
         # Make sure CxFlow doesn't crash in this case.
-        Given bug tracker contains no issues
-        And the "non-existent-test" project doesn't exist in SCA
-        When running CxFlow to publish latest scan results for the "non-existent-test" project
-        Then bug tracker still contains no issues
+        Given the "ci-non-existent-project-test" project doesn't exist in SCA
+        When running CxFlow with `publish latest scan results` options for the project
+        Then bug tracker contains no issues
         And no exception is thrown
 
     Scenario: Trying to publish latest scan results for a project with no scans
         # Make sure CxFlow doesn't crash in this case either.
-        Given bug tracker contains no issues
-        And the "project-without-scans" project exists in SCA but doesn't have any scans
-        When running CxFlow to publish latest scan results for the "project-without-scans" project
-        Then bug tracker still contains no issues
+        Given the "ci-project-no-scans-test" project exists in SCA but doesn't have any scans
+        When running CxFlow with `publish latest scan results` options for the project
+        Then bug tracker contains no issues
         And no exception is thrown
+
+    @Skip
+    Scenario: While publishing latest scan results, CxFlow must respect SCA filters


### PR DESCRIPTION
### Command line example for publishing latest SCA results

Provided that `enabled-vulnerability-scanners` property in application.yml contains `sca`, CxFlow command line will look like the following:

`java -jar cx-flow-1.6.5.jar --project --cx-project=my-sca-project --app=my-app`

There are several edge cases:
-    specified SCA project doesn't exist
 -   SCA project has no scans
 -   all scans for the SCA project failed
 In these cases no issues will be published. However, no errors will be thrown either (only log messages appear).

### References

Work item [219](https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/219).

### Testing

New scenarios were added to scaCliScan.feature.