### PR TITLE
change labels id to long in github

### DIFF
--- a/src/main/java/com/checkmarx/flow/dto/github/LabelsItem.java
+++ b/src/main/java/com/checkmarx/flow/dto/github/LabelsItem.java
@@ -16,13 +16,13 @@ public class LabelsItem{
 	private String name;
 
 	@JsonProperty("id")
-	private int id;
+	private long id;
 
 	@JsonProperty("url")
 	private String url;
 
     @ConstructorProperties({"jsonMemberDefault", "color", "name", "id", "url"})
-    public LabelsItem(boolean jsonMemberDefault, String color, String name, int id, String url) {
+    public LabelsItem(boolean jsonMemberDefault, String color, String name, long id, String url) {
         this.jsonMemberDefault = jsonMemberDefault;
         this.color = color;
         this.name = name;
@@ -49,7 +49,7 @@ public class LabelsItem{
         return this.name;
     }
 
-    public int getId() {
+    public long getId() {
         return this.id;
     }
 
@@ -69,7 +69,7 @@ public class LabelsItem{
         this.name = name;
     }
 
-    public void setId(int id) {
+    public void setId(long id) {
         this.id = id;
     }
 
@@ -85,7 +85,7 @@ public class LabelsItem{
         private boolean jsonMemberDefault;
         private String color;
         private String name;
-        private int id;
+        private long id;
         private String url;
 
         LabelsItemBuilder() {
@@ -106,7 +106,7 @@ public class LabelsItem{
             return this;
         }
 
-        public LabelsItem.LabelsItemBuilder id(int id) {
+        public LabelsItem.LabelsItemBuilder id(long id) {
             this.id = id;
             return this;
         }


### PR DESCRIPTION
### Description

In preparing for a POC, we encountered an issue with Github repository enabled with Dependabot security (Github SCA solution); this is used by the prospect for SCA

During the parsing of existing Github issues, error was flagged while extracting the response - JsonMappingException: Numeric value (2175583853) out of range of int (-2147483648 - 2147483647)

### References

Cases 00056883

### Testing
N/A

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
