### PR TITLE
improve pr-comment tests

### DIFF
--- a/src/test/java/com/checkmarx/flow/cucumber/integration/ast/AstCommonSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/ast/AstCommonSteps.java
@@ -23,14 +23,6 @@ public class AstCommonSteps {
         astProperties.setPreset("Default");
     }
 
-
-    protected void initSCAConfig() {
-        scaProperties.setAppUrl("https://sca.scacheckmarx.com");
-        scaProperties.setApiUrl("https://api.scacheckmarx.com");
-        scaProperties.setAccessControlUrl("https://platform.checkmarx.net");
-    }
-
-
     protected ScanRequest getBasicScanRequest(String projectName, String repoWithAuth) {
         return ScanRequest.builder()
                 .project(projectName)

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/ast/scans/AstRemoteRepoScanSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/ast/scans/AstRemoteRepoScanSteps.java
@@ -6,6 +6,7 @@ import com.checkmarx.flow.config.GitHubProperties;
 
 import com.checkmarx.flow.cucumber.integration.ast.AstCommonSteps;
 
+import com.checkmarx.flow.cucumber.integration.sca_scanner.ScaCommonSteps;
 import com.checkmarx.flow.dto.ScanRequest;
 
 import com.checkmarx.flow.service.*;
@@ -91,7 +92,7 @@ public class AstRemoteRepoScanSteps extends AstCommonSteps {
     @Before("@ASTRemoteRepoScan")
     public void init() {
         initAstConfig();
-        initSCAConfig();
+        ScaCommonSteps.initSCAConfig(scaProperties);
         resultsService = mock(ResultsService.class);
         ResultsServiceAnswerer answerer = new ResultsServiceAnswerer();
         when(resultsService.publishCombinedResults(any(), any())).thenAnswer(answerer);

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cli/sca/ScaCliSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cli/sca/ScaCliSteps.java
@@ -5,6 +5,7 @@ import com.checkmarx.flow.CxFlowRunner;
 import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.config.JiraProperties;
 import com.checkmarx.flow.cucumber.common.utils.TestUtils;
+import com.checkmarx.flow.cucumber.integration.sca_scanner.ScaCommonSteps;
 import com.checkmarx.flow.exception.ExitThrowable;
 import com.checkmarx.jira.IJiraTestUtils;
 import com.checkmarx.jira.JiraTestUtils;
@@ -52,7 +53,7 @@ public class ScaCliSteps {
     public void beforeEachScenario() throws IOException {
         log.info("Setting bugTracker: Jira");
         flowProperties.setBugTracker("JIRA");
-        initSCAConfig();
+        ScaCommonSteps.initSCAConfig(scaProperties);
 
         List<String> scaOnly = Collections.singletonList(ScaProperties.CONFIG_PREFIX);
         flowProperties.setEnabledVulnerabilityScanners(scaOnly);
@@ -223,11 +224,5 @@ public class ScaCliSteps {
         log.info("Cleaning jira project before test: {}", jiraProperties.getProject());
         jiraUtils.ensureProjectExists(jiraProperties.getProject());
         jiraUtils.cleanProject(jiraProperties.getProject());
-    }
-
-    private void initSCAConfig() {
-        scaProperties.setAppUrl("https://sca.scacheckmarx.com");
-        scaProperties.setApiUrl("https://api.scacheckmarx.com");
-        scaProperties.setAccessControlUrl("https://platform.checkmarx.net");
     }
 }

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/CxConfigBugTrackerConfiguration.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/CxConfigBugTrackerConfiguration.java
@@ -4,14 +4,12 @@ import com.checkmarx.sdk.service.CxService;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
 
 @TestConfiguration
 public class CxConfigBugTrackerConfiguration {
 
 
-    @Bean("cxConfigurationTestBean")
-    @Primary
+    @Bean(name = "cxConfigurationTestBean")
     public CxService getCxService() {
         return Mockito.mock(CxService.class);
     }

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/CxConfigBugTrackerConfiguration.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/CxConfigBugTrackerConfiguration.java
@@ -1,6 +1,5 @@
 package com.checkmarx.flow.cucumber.integration.cxconfigbugtracker;
 
-import com.checkmarx.flow.service.FlowService;
 import com.checkmarx.sdk.service.CxService;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -11,7 +10,7 @@ import org.springframework.context.annotation.Primary;
 public class CxConfigBugTrackerConfiguration {
 
 
-    @Bean
+    @Bean("cxConfigurationTestBean")
     @Primary
     public CxService getCxService() {
         return Mockito.mock(CxService.class);

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/CxConfigBugTrackerSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/CxConfigBugTrackerSteps.java
@@ -30,8 +30,10 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import javax.annotation.Resource;
 import java.util.*;
 
 import static org.junit.Assert.fail;
@@ -42,12 +44,12 @@ import static org.mockito.Mockito.*;
 @SpringBootTest(classes = {CxFlowApplication.class, CxConfigBugTrackerConfiguration.class, PublishUtils.class})
 @Slf4j
 public class CxConfigBugTrackerSteps {
-    private static final String PULL_REQUEST_STATUSES_URL = "statuses url stub";
     public static final String BRANCH_NAME = "udi-tests";
     public static final String CUSTOM_BEAN_NAME = "GitHub";
     public static final String GITHUB_USER = "cxflowtestuser";
 
     @Autowired
+    @Qualifier("cxConfigurationTestBean")
     private CxClient cxClientMock;
     private final GitHubService gitHubService;
     private GitHubController gitHubControllerSpy;

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
@@ -74,6 +74,7 @@ public class UpdatePullRequestCommentsSteps {
     private SourceControlType sourceControl;
     private FlowProperties flowProperties;
     private CxProperties cxProperties;
+    private CxAuthClient authClient;
     private String branchGitHub;
     private ScannerType scannerType;
 
@@ -92,6 +93,7 @@ public class UpdatePullRequestCommentsSteps {
         this.flowProperties = flowProperties;
         this.cxProperties = cxProperties;
         this.scaProperties = scaProperties;
+        this.authClient = authClient;
         sastFile = toFullResourcePath(filePath);
     }
 

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
@@ -80,8 +80,8 @@ public class UpdatePullRequestCommentsSteps {
     private ScannerType scannerType;
 
     private File sastFile = TestUtils.getFileFromResource(filePath);
-    private FilterConfiguration filterMedium = setSeverityFilter("Medium");
-    private FilterConfiguration filterLow = setSeverityFilter("Low");
+    private FilterConfiguration filterMedium = getSeverityFilter("Medium");
+    private FilterConfiguration filterLow = getSeverityFilter("Low");
 
     public UpdatePullRequestCommentsSteps(GitHubService gitHubService, GitHubProperties gitHubProperties, GitHubController gitHubController, ADOService adoService,
                                           ADOController adoController, FlowProperties flowProperties, CxProperties cxProperties, ScaProperties scaProperties, CxAuthClient authClient) throws IOException {
@@ -94,10 +94,6 @@ public class UpdatePullRequestCommentsSteps {
         this.flowProperties = flowProperties;
         this.cxProperties = cxProperties;
         this.scaProperties = scaProperties;
-    }
-
-    private FilterConfiguration setSeverityFilter(String filter){
-        return FilterConfiguration.fromSimpleFilters(Collections.singletonList(new Filter(Filter.Type.SEVERITY, filter)));
     }
 
     private void initSca() {
@@ -476,6 +472,10 @@ public class UpdatePullRequestCommentsSteps {
         controllerRequest.setTeam("\\CxServer\\SP");
         AdoDetailsRequest adoRequest = new AdoDetailsRequest();
         adoControllerSpy.pullRequest(pullEvent,"Basic Y3hmbG93OjEyMzQ=", null, controllerRequest, adoRequest);
+    }
+
+    private FilterConfiguration getSeverityFilter(String filter){
+        return FilterConfiguration.fromSimpleFilters(Collections.singletonList(new Filter(Filter.Type.SEVERITY, filter)));
     }
 
     enum SourceControlType {

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
@@ -11,13 +11,16 @@ import com.checkmarx.flow.dto.azure.AdoDetailsRequest;
 import com.checkmarx.flow.dto.azure.Project;
 import com.checkmarx.flow.dto.azure.Resource;
 import com.checkmarx.flow.dto.github.*;
-import com.checkmarx.flow.service.ADOService;
-import com.checkmarx.flow.service.GitHubService;
-import com.checkmarx.flow.service.HelperService;
-import com.checkmarx.flow.service.PullRequestCommentsHelper;
+import com.checkmarx.flow.service.*;
+import com.checkmarx.sdk.config.Constants;
 import com.checkmarx.sdk.config.CxProperties;
 import com.checkmarx.sdk.config.ScaProperties;
+import com.checkmarx.sdk.dto.Filter;
 import com.checkmarx.sdk.dto.ScanResults;
+import com.checkmarx.sdk.dto.cx.CxScanSummary;
+import com.checkmarx.sdk.dto.filtering.FilterConfiguration;
+import com.checkmarx.sdk.exception.CheckmarxException;
+import com.checkmarx.sdk.service.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.java.After;
@@ -31,24 +34,26 @@ import org.junit.Assert;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.ClassPathResource;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
+import java.util.*;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 
-@SpringBootTest(classes = {CxFlowApplication.class})
+@SpringBootTest(classes = {CxFlowApplication.class, UpdatePullRequestConfiguration.class})
 @Slf4j
 public class UpdatePullRequestCommentsSteps {
 
-
+    @Autowired
+    private CxClient cxClientMock;
     public static final int COMMENTS_POLL_INTERVAL = 5;
     private static final String GIT_PROJECT_NAME = "vb_test_pr_comments";
     private static final String GITHUB_PR_BASE_URL = "https://api.github.com/repos/cxflowtestuser/" + GIT_PROJECT_NAME;
@@ -57,6 +62,7 @@ public class UpdatePullRequestCommentsSteps {
     public static final String PULL_REQUEST_COMMENTS_URL = GITHUB_PR_BASE_URL + "/issues/"+ GITHUB_PR_ID + "/comments";
     private static final String GIT_URL = "https://github.com/cxflowtestuser/" + GIT_PROJECT_NAME;
     private static final String ADO_PR_COMMENTS_URL = "https://dev.azure.com/CxNamespace/d50fc6e5-a5ab-4123-9bc9-ccb756c0bf16/_apis/git/repositories/a89a9d2f-ab67-4bda-9c56-a571224c2c66/pullRequests/" + ADO_PR_ID + "/threads";
+    private final String filePath = "sample-sast-results" + "/" + "3-findings-filter-script-test.xml";
     private final GitHubService gitHubService;
     private final ADOService adoService;
     private GitHubController gitHubControllerSpy;
@@ -64,17 +70,19 @@ public class UpdatePullRequestCommentsSteps {
     private final ObjectMapper mapper = new ObjectMapper();
     private final GitHubProperties gitHubProperties;
     private final HelperService helperService;
-    private ScanResults scanResultsToInject;
+    private final ScaProperties scaProperties;
     private SourceControlType sourceControl;
     private FlowProperties flowProperties;
     private CxProperties cxProperties;
-    private String branchAdo;
     private String branchGitHub;
     private ScannerType scannerType;
-    private final ScaProperties scaProperties;
 
+    private File sastFile;
+    private FilterConfiguration filterMedium = FilterConfiguration.fromSimpleFilters(Collections.singletonList(new Filter(Filter.Type.SEVERITY, "Medium")));
+    private FilterConfiguration filterLow = FilterConfiguration.fromSimpleFilters(Collections.singletonList(new Filter(Filter.Type.SEVERITY, "Low")));
 
-    public UpdatePullRequestCommentsSteps(GitHubService gitHubService, GitHubProperties gitHubProperties, GitHubController gitHubController, ADOService adoService, ADOController adoController, FlowProperties flowProperties, CxProperties cxProperties, ScaProperties scaProperties) {
+    public UpdatePullRequestCommentsSteps(GitHubService gitHubService, GitHubProperties gitHubProperties, GitHubController gitHubController, ADOService adoService,
+                                          ADOController adoController, FlowProperties flowProperties, CxProperties cxProperties, ScaProperties scaProperties, CxAuthClient authClient) throws IOException {
         this.helperService = mock(HelperService.class);
         this.gitHubService = gitHubService;
         this.gitHubProperties = gitHubProperties;
@@ -84,7 +92,12 @@ public class UpdatePullRequestCommentsSteps {
         this.flowProperties = flowProperties;
         this.cxProperties = cxProperties;
         this.scaProperties = scaProperties;
+        sastFile = toFullResourcePath(filePath);
+    }
 
+    private static File toFullResourcePath(String relativePath) throws IOException {
+        String path = Paths.get(com.checkmarx.flow.cucumber.common.Constants.CUCUMBER_DATA_DIR, relativePath).toString();
+        return new ClassPathResource(path).getFile();
     }
 
     private void initSca() {
@@ -93,20 +106,84 @@ public class UpdatePullRequestCommentsSteps {
         scaProperties.setAccessControlUrl("https://platform.checkmarx.net");
     }
 
+    private class ScanResultsAnswerer implements Answer<ScanResults> {
+
+        private FilterConfiguration filterConfiguration;
+
+        private FilterConfiguration switchFilterConfiguration(){
+            if(filterConfiguration == filterMedium){
+                return filterLow;
+            }
+            else{
+                return filterMedium;
+            }
+        }
+
+        @Override
+        public ScanResults answer(InvocationOnMock invocation) throws CheckmarxException {
+
+            filterConfiguration = switchFilterConfiguration();
+            ScanResults results = cxClientMock.getReportContent(sastFile, filterConfiguration);
+            CxScanSummary summary =  new CxScanSummary();
+            results.setScanSummary(summary);
+
+            Map<String, Object> details = new HashMap<>();
+            details.put(Constants.SUMMARY_KEY, new HashMap<>());
+            results.setAdditionalDetails(details);
+
+            return results;
+        }
+    }
+
+
     @Before
-    public void initMocks() {
+    public void initMocks(){
         initGitHubProperties();
         initSca();
         flowProperties.getBranches().add("udi-tests-2");
         flowProperties.setEnabledVulnerabilityScanners(Arrays.asList("sast"));
+        cxProperties.setOffline(true);
         initGitHubControllerSpy();
         initHelperServiceMock();
         setBranches();
+        initCxClientMock();
+    }
+
+    private void initCxClientMock() {
+        try {
+            ScanResultsAnswerer answerer = new ScanResultsAnswerer();
+            when(cxClientMock.getReportContentByScanId(anyInt(), any())).thenAnswer(answerer);
+            when(cxClientMock.getScanIdOfExistingScanIfExists(anyInt())).thenReturn(-1);
+            when(cxClientMock.getTeamId(anyString())).thenReturn("teamId");
+            when(cxClientMock.getReportContent(sastFile, filterLow)).thenCallRealMethod();
+            when(cxClientMock.getReportContent(sastFile, filterMedium)).thenCallRealMethod();
+        } catch (CheckmarxException e) {
+            Assert.fail("Error initializing mock." + e);
+        }
+    }
+
+    @Given("different filters configuration is set")
+    public void setConfigAsCodeFilters() {
+        /*
+        This is required to test 'comment updated' flow
+        However mockito mockers are initialized in the beginning of the test, including the answerer and all the fields and properties inside for example (sastFile, filterConfiguration)
+        Using ScanResultsAnswerer::switchFilterConfiguration to change filter configuration in the between steps in same test scenario
+         */
+    }
+
+    @Given("no comments on pull request")
+    public void deletePRComments() throws IOException, InterruptedException {
+
+        if (sourceControl.equals(SourceControlType.GITHUB)) {
+            deleteGitHubComments();
+        } else if (sourceControl.equals(SourceControlType.ADO)) {
+            deleteADOComments();
+        }
     }
 
     private void setBranches() {
-        branchAdo =  "udi-tests-2";
         branchGitHub = "pr-comments-tests";
+        // ADO repo and branch defined by the ADO_PR_COMMENTS_URL
     }
 
     @After
@@ -135,11 +212,6 @@ public class UpdatePullRequestCommentsSteps {
         }
     }
 
-    @Given("different filters configuration is set")
-    public void setConfigAsCodeFilters() {
-        gitHubProperties.setConfigAsCode("cx.config.high.json");
-    }
-
     @Given("source control is GitHub")
     public void scGitHub() {
         sourceControl = SourceControlType.GITHUB;
@@ -148,16 +220,6 @@ public class UpdatePullRequestCommentsSteps {
     @Given("source control is ADO")
     public void scAdo() {
         sourceControl = SourceControlType.ADO;
-    }
-
-
-    @Given("no comments on pull request")
-    public void deletePRComments() throws IOException, InterruptedException {
-        if (sourceControl.equals(SourceControlType.GITHUB)) {
-            deleteGitHubComments();
-        } else if (sourceControl.equals(SourceControlType.ADO)) {
-            deleteADOComments();
-        }
     }
 
     private void deleteADOComments() throws IOException {
@@ -195,17 +257,22 @@ public class UpdatePullRequestCommentsSteps {
 
     @Then("Wait for comments")
     public void waitForNewComments() {
+        log.info("waiting for new comments. scanner type {}", scannerType);
+
         int minutesToWait = scannerType == ScannerType.BOTH ? 3 : 2;
         Awaitility.await().atMost(Duration.ofMinutes(minutesToWait)).pollInterval(Duration.ofSeconds(COMMENTS_POLL_INTERVAL)).until(this::areThereCommentsAtAll);
     }
 
     @Then("verify new comments")
     public void verifyNewComments() throws IOException {
+        log.info("verifying comments. scanner type: {} source control type: {}", scannerType, sourceControl);
+
         int expectedNumOfComments = getExpectedNumOfNewComments();
         List<RepoComment> comments = getRepoComments();
         Assert.assertEquals("Wrong number of comments", expectedNumOfComments, comments.size());
-        comments.stream().forEach(c -> Assert.assertTrue("Comment is not new (probably updated", isCommentNew(c)));
+        comments.stream().forEach(c -> Assert.assertTrue("Comment is not new (probably updated)", isCommentNew(c)));
 
+        log.info("Found the correct comments in pull request !!");
     }
 
     private int getExpectedNumOfNewComments() {
@@ -222,10 +289,15 @@ public class UpdatePullRequestCommentsSteps {
     @Then("Wait for updated comment")
     public void waitForUpdatedComment() {
         Awaitility.await().pollInterval(Duration.ofSeconds(COMMENTS_POLL_INTERVAL)).atMost(Duration.ofSeconds(125)).until(this::isThereUpdatedComment);
+
+        log.info("Found the correct comments in pull request !!");
     }
 
     private boolean areThereCommentsAtAll() throws IOException {
         List<RepoComment> comments = getRepoComments();
+
+        log.info("found {} comments in {}", comments.size(), sourceControl);
+
         if (scannerType == ScannerType.SCA) {
             if (comments.size() < 1) {
                 return false;
@@ -237,6 +309,7 @@ public class UpdatePullRequestCommentsSteps {
         } else {
             throw new IllegalArgumentException("Wrong Scanner Type: " + scannerType.name());
         }
+
         return areThereCorrectComments(comments, scannerType);
     }
 
@@ -247,8 +320,10 @@ public class UpdatePullRequestCommentsSteps {
             boolean foundScanStarted = false;
             for (RepoComment comment : comments) {
                 if (PullRequestCommentsHelper.isScanStartedComment(comment.getComment())) {
+                    log.info("BOTH: found pull request 'scan started' comment");
                     foundScanStarted = true;
                 } else if (PullRequestCommentsHelper.isSastAndScaComment(comment.getComment())) {
+                    log.info("BOTH: found pull request Sca&Sast comment");
                     foundScaAndSast = true;
                 }
             }
@@ -259,8 +334,10 @@ public class UpdatePullRequestCommentsSteps {
             boolean foundScanStarted = false;
             for (RepoComment comment : comments) {
                 if (PullRequestCommentsHelper.isSastFindingsComment(comment.getComment())) {
+                    log.info("SAST: found pull request sast comment");
                     foundSast = true;
                 } else if (PullRequestCommentsHelper.isScanStartedComment(comment.getComment())) {
+                    log.info("SAST: found pull request 'scan started' comment");
                     foundScanStarted = true;
                 }
             }
@@ -269,6 +346,7 @@ public class UpdatePullRequestCommentsSteps {
         else if (sct.equals(ScannerType.SCA)) {
             for (RepoComment comment : comments) {
                 if (PullRequestCommentsHelper.isScaComment(comment.getComment())) {
+                    log.info("SCA: found pull request comment");
                     return true;
                 }
             }
@@ -278,11 +356,14 @@ public class UpdatePullRequestCommentsSteps {
 
     private boolean isThereUpdatedComment() throws IOException {
         List<RepoComment> comments = getRepoComments();
+        log.info("isThereUpdatedComment: found {} comments", comments.size());
         for (RepoComment comment: comments) {
             if (isCommentUpdated(comment)) {
+                log.info("isThereUpdatedComment: True");
                 return true;
             }
         }
+        log.info("isThereUpdatedComment: False");
         return false;
     }
 
@@ -389,13 +470,6 @@ public class UpdatePullRequestCommentsSteps {
         controllerRequest.setTeam("\\CxServer\\SP");
         AdoDetailsRequest adoRequest = new AdoDetailsRequest();
         adoControllerSpy.pullRequest(pullEvent,"Basic Y3hmbG93OjEyMzQ=", null, controllerRequest, adoRequest);
-    }
-
-    private class ScanResultsAnswerer implements Answer<ScanResults> {
-        @Override
-        public ScanResults answer(InvocationOnMock invocation) {
-            return scanResultsToInject;
-        }
     }
 
     enum SourceControlType {

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
@@ -7,6 +7,7 @@ import com.checkmarx.flow.controller.ADOController;
 import com.checkmarx.flow.controller.GitHubController;
 import com.checkmarx.flow.dto.ControllerRequest;
 import com.checkmarx.flow.dto.RepoComment;
+import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.dto.azure.*;
 import com.checkmarx.flow.dto.github.PullEvent;
 import com.checkmarx.flow.dto.github.Repository;

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestConfiguration.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestConfiguration.java
@@ -13,7 +13,7 @@ import org.springframework.web.client.RestTemplate;
 @TestConfiguration
 public class UpdatePullRequestConfiguration {
 
-    @Bean("updatePullTestRequestBean")
+    @Bean
     @Primary
     public CxService getCxService(CxAuthClient authClient,
                                   CxProperties cxProperties,

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestConfiguration.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestConfiguration.java
@@ -13,7 +13,7 @@ import org.springframework.web.client.RestTemplate;
 @TestConfiguration
 public class UpdatePullRequestConfiguration {
 
-    @Bean
+    @Bean("updatePullTestRequestBean")
     @Primary
     public CxService getCxService(CxAuthClient authClient,
                                   CxProperties cxProperties,

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestConfiguration.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestConfiguration.java
@@ -1,0 +1,29 @@
+package com.checkmarx.flow.cucumber.integration.pullrequest.updatecomments;
+
+import com.checkmarx.sdk.config.CxProperties;
+import com.checkmarx.sdk.service.*;
+import org.mockito.Mockito;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.web.client.RestTemplate;
+
+@TestConfiguration
+public class UpdatePullRequestConfiguration {
+
+    @Bean
+    @Primary
+    public CxService getCxService(CxAuthClient authClient,
+                                  CxProperties cxProperties,
+                                  CxLegacyService cxLegacyService,
+                                  @Qualifier("cxRestTemplate") RestTemplate restTemplate,
+                                  ScanSettingsClient scanSettingsClient,
+                                  FilterValidator filterValidator) {
+
+
+        return Mockito.mock(CxService.class, Mockito.withSettings().useConstructor(authClient, cxProperties, cxLegacyService, restTemplate, scanSettingsClient, filterValidator));
+    }
+
+}

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/sca_scanner/ScaCommonSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/sca_scanner/ScaCommonSteps.java
@@ -13,10 +13,9 @@ import java.util.Arrays;
 public class ScaCommonSteps {
 
     protected final FlowProperties flowProperties;
-    protected final ScaProperties scaProperties;
     protected final SCAScanner scaScanner;
 
-    protected void initSCAConfig() {
+    public static void initSCAConfig(ScaProperties scaProperties) {
         scaProperties.setAppUrl("https://sca.scacheckmarx.com");
         scaProperties.setApiUrl("https://api.scacheckmarx.com");
         scaProperties.setAccessControlUrl("https://platform.checkmarx.net");

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/sca_scanner/filters/ScaFiltersSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/sca_scanner/filters/ScaFiltersSteps.java
@@ -29,14 +29,16 @@ public class ScaFiltersSteps extends ScaCommonSteps {
 
     private ScanRequest scanRequest;
     private SCAResults scaResults;
+    private ScaProperties scaProperties;
 
     public ScaFiltersSteps(FlowProperties flowProperties, ScaProperties scaProperties, SCAScanner scaScanner) {
-        super(flowProperties, scaProperties, scaScanner);
+        super(flowProperties, scaScanner);
+        this.scaProperties = scaProperties;
     }
 
     @Before("@SCA_Filtering")
     public void init() {
-        initSCAConfig();
+        initSCAConfig(scaProperties);
         scanRequest = getBasicScanRequest(PROJECT_NAME, GIT_REPO_URL);
     }
 

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/sca_scanner/scans/SCARemoteRepoScanSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/sca_scanner/scans/SCARemoteRepoScanSteps.java
@@ -45,16 +45,18 @@ public class SCARemoteRepoScanSteps extends ScaCommonSteps {
 
     private ScanRequest scanRequest;
     private SCAResults scaResults;
+    private ScaProperties scaProperties;
 
     public SCARemoteRepoScanSteps(FlowProperties flowProperties, ScaProperties scaProperties,
                                   SCAScanner scaScanner, GitHubProperties gitHubProperties) {
-        super(flowProperties, scaProperties, scaScanner);
+        super(flowProperties, scaScanner);
         this.gitHubProperties = gitHubProperties;
+        this.scaProperties = scaProperties;
     }
 
     @Before("@SCARemoteRepoScan")
     public void init() {
-        initSCAConfig();
+        initSCAConfig(scaProperties);
     }
 
     @Given("scan initiator is SCA")

--- a/src/test/resources/cucumber/features/integrationTests/pull-request-comments-update.feature
+++ b/src/test/resources/cucumber/features/integrationTests/pull-request-comments-update.feature
@@ -1,7 +1,7 @@
 @PullRequestUpdateComment @Integration
   Feature: After scan that was initiated by pull request, CxFlow should update the PR comments, instead of creating new one.
 
-    Scenario Outline: Pull request arrives to CxFlow, then scan is initiated, pull request should be without comments, and we should verify that the comments are new.
+    Scenario Outline: CxFlow should create new comments on Github Pull request with scan results summary
       Given scanner is set to "<scanner>"
       Given source control is GitHub
       And no comments on pull request
@@ -16,7 +16,7 @@
         | both    |
 
 
-    Scenario Outline: Pull request arrives to CxFlow, then scan is initiated, and pull request comments should be updated.
+    Scenario Outline: CxFlow should update existing comments on Github Pull request with scan results summary
       Given scanner is set to "<scanner>"
       Given source control is GitHub
       And no comments on pull request
@@ -32,7 +32,7 @@
         | sast   |
         | both    |
 
-    Scenario Outline: Pull request arrives from ADO to CxFlow, then scan is initiated, pull request should be without comments, and we should verify that the comments are new.
+    Scenario Outline: CxFlow should create new comments on Github Pull request with scan results summary
       Given scanner is set to "<scanner>"
       Given source control is ADO
       And no comments on pull request

--- a/src/test/resources/cucumber/features/integrationTests/pull-request-comments-update.feature
+++ b/src/test/resources/cucumber/features/integrationTests/pull-request-comments-update.feature
@@ -35,7 +35,6 @@
     Scenario Outline: Pull request arrives from ADO to CxFlow, then scan is initiated, pull request should be without comments, and we should verify that the comments are new.
       Given scanner is set to "<scanner>"
       Given source control is ADO
-#      Given branch is udi-test-2
       And no comments on pull request
       When pull request arrives to CxFlow
       Then Wait for comments


### PR DESCRIPTION
purpose of this pull request is to improve the time of pull-request-comments integration tests
now we use cxService mocker to mock sast scans instead of perform more many scans on the same project with the same results - which doesn't effect the pr-comments functionality

there are no changes in production code
   