### PR TITLE
enforcing groovy return trype

### DIFF
--- a/src/main/java/com/checkmarx/flow/service/ProjectNameGenerator.java
+++ b/src/main/java/com/checkmarx/flow/service/ProjectNameGenerator.java
@@ -88,6 +88,8 @@ public class ProjectNameGenerator {
                 Object result = scriptService.runScript(script, bindings);
                 if (result instanceof String) {
                     return ((String) result);
+                } else {
+                    throw new IOException("Script must return a result of type 'java.lang.String'");
                 }
             } catch (IOException e) {
                 log.error("Error reading script file for checkmarx project {}", scriptFile, e);


### PR DESCRIPTION

### Description

determine of project name using groovy script fails silently, if return type was not java.lang.String.
now it will throw an IO exception (will be loved, that return type must be a java.lang.String

### References

#378 
### Testing

N/A