### PR TITLE
delete Cx-project on ado delete branch event

### DIFF
--- a/src/main/java/com/checkmarx/flow/config/ADOProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/ADOProperties.java
@@ -1,7 +1,5 @@
 package com.checkmarx.flow.config;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;

--- a/src/main/java/com/checkmarx/flow/config/ADOProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/ADOProperties.java
@@ -1,5 +1,7 @@
 package com.checkmarx.flow.config;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
@@ -8,6 +10,8 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "azure")
 @Validated
 public class ADOProperties extends RepoProperties{
+
+    private boolean deleteCxProject = false;
     private String issueType = "issue";
     private String issueBody = "Description";
     private String appTagPrefix = "app";
@@ -115,6 +119,14 @@ public class ADOProperties extends RepoProperties{
 
     public void setTestRepository(String testRepository) {
         this.testRepository = testRepository;
+    }
+
+    public boolean getDeleteCxProject(){
+        return deleteCxProject;
+    }
+
+    public void setDeleteCxProject(boolean deleteProject){
+        this.deleteCxProject = deleteProject;
     }
 
     public String getMergeNoteUri(String namespace, String repo, String mergeId){

--- a/src/main/java/com/checkmarx/flow/controller/ADOController.java
+++ b/src/main/java/com/checkmarx/flow/controller/ADOController.java
@@ -313,7 +313,8 @@ public class ADOController extends AdoControllerBase {
             return false;
         }
 
-        log.info("unexpected number of refUpdates in push event");
+        int refCount = Optional.ofNullable(resource.getRefUpdates().size()).orElse(0);
+        log.warn("unexpected number of refUpdates in push event: {}", refCount);
 
         return false;
     }

--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -430,7 +430,7 @@ public class GitHubController extends WebhookController {
         request = configOverrider.overrideScanRequestProperties(cxConfig, request);
 
         //deletes a project which is not in the middle of a scan, otherwise it will not be deleted
-        sastScanner.deleteProject(request);
+        flowService.deleteProject(request);
 
         final String MESSAGE = "Branch deletion event was handled successfully.";
         log.info(MESSAGE);

--- a/src/main/java/com/checkmarx/flow/service/ADOService.java
+++ b/src/main/java/com/checkmarx/flow/service/ADOService.java
@@ -303,35 +303,36 @@ public class ADOService {
         restTemplate.exchange(url, HttpMethod.DELETE, httpEntity, String.class);
     }
 
-    public CxConfig getCxConfigOverride(ScanRequest request) {
+    public CxConfig getCxConfigOverride(ScanRequest request, String branch) {
         CxConfig result = null;
         if (StringUtils.isNotBlank(properties.getConfigAsCode())) {
             try {
-                result = loadCxConfigFromADO(request);
+                result = loadCxConfigFromADO(request, branch);
             } catch (NullPointerException e) {
                 log.warn(NO_CONTENT_FOUND_IN_RESPONSE);
             } catch (HttpClientErrorException.NotFound e) {
-                log.info(String.format("No Config as code was found with the name: %s", properties.getConfigAsCode()));
+                log.info("No Config as code was found with the name: {}, in branch {}", properties.getConfigAsCode(), branch);
             } catch (Exception e) {
-                log.error(String.format("Error in getting config as code from the repo. Error details : %s", ExceptionUtils.getRootCauseMessage(e)));
+                log.error("Error in getting config as code from the repo. Error details : {}", ExceptionUtils.getRootCauseMessage(e));
             }
         }
         return result;
     }
 
-    private CxConfig loadCxConfigFromADO(ScanRequest request) {
+    private CxConfig loadCxConfigFromADO(ScanRequest request, String branch) {
         CxConfig cxConfig;
         HttpHeaders headers = ADOUtils.createAuthHeaders(scmConfigOverrider.determineConfigToken(properties, request.getScmInstance()));
         String repoSelfUrl = request.getAdditionalMetadata(REPO_SELF_URL);
         String url = repoSelfUrl.concat(GET_FILE_CONTENT);
 
+        log.info("Trying to load config-as-code from '{}' branch", branch);
         ResponseEntity<String> response = restTemplate.exchange(
                 url,
                 HttpMethod.GET,
                 new HttpEntity<>(headers),
                 String.class,
                 properties.getConfigAsCode(),
-                request.getBranch(),
+                branch,
                 properties.getApiVersion()
         );
         if (response.getBody() == null) {

--- a/src/main/java/com/checkmarx/flow/service/FlowService.java
+++ b/src/main/java/com/checkmarx/flow/service/FlowService.java
@@ -3,6 +3,7 @@ package com.checkmarx.flow.service;
 import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.exception.MachinaRuntimeException;
 import com.checkmarx.sdk.dto.ScanResults;
+import jline.internal.Log;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * High level business logic for CxFlow automation.
@@ -72,5 +74,20 @@ public class FlowService {
         }
 
         return enabledScanners;
+    }
+
+    public void deleteProject(ScanRequest request) {
+
+        Optional<SastScanner> sastScanner = getEnabledScanners(request)
+                .stream().filter(scanner -> scanner instanceof SastScanner)
+                .map(scanner -> ((SastScanner) scanner))
+                .findFirst();
+
+        if(!sastScanner.isPresent()){
+            log.warn("Delete branch for non-SAST scanner is not supported");
+            return;
+         }
+
+        sastScanner.ifPresent(scanner -> scanner.deleteProject(request));
     }
 }

--- a/src/main/java/com/checkmarx/flow/service/SastScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/SastScanner.java
@@ -310,7 +310,7 @@ public class SastScanner implements VulnerabilityScanner {
             String projectName = projectNameGenerator.determineProjectName(request);
             request.setProject(projectName);
 
-            log.info("going to delete CxProject: {}", projectName);
+            log.info("Going to delete CxProject: {}", projectName);
             Integer projectId = scanRequestConverter.determinePresetAndProjectId(request, ownerId);
 
             if (canDeleteProject(projectId, request)) {

--- a/src/main/java/com/checkmarx/flow/service/SastScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/SastScanner.java
@@ -310,6 +310,7 @@ public class SastScanner implements VulnerabilityScanner {
             String projectName = projectNameGenerator.determineProjectName(request);
             request.setProject(projectName);
 
+            log.info("going to delete CxProject: {}", projectName);
             Integer projectId = scanRequestConverter.determinePresetAndProjectId(request, ownerId);
 
             if (canDeleteProject(projectId, request)) {

--- a/src/test/java/com/checkmarx/flow/cucumber/component/deletebranch/DeleteBranchSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/deletebranch/DeleteBranchSteps.java
@@ -67,6 +67,7 @@ public class DeleteBranchSteps {
     private final ADOProperties adoProperties;
     private final EmailService emailService;
     private final ScmConfigOverrider scmConfigOverrider;
+    private final BugTrackerEventTrigger bugTrackerEventTrigger;
 
     private final ADOService adoServiceMock;
     private final ResultsService resultsServiceMock;
@@ -82,7 +83,8 @@ public class DeleteBranchSteps {
 
     public DeleteBranchSteps(FlowProperties flowProperties, GitHubService gitHubService,
                              CxProperties cxProperties, GitHubProperties gitHubProperties, FilterFactory filterFactory,
-                             ConfigurationOverrider configOverrider, ADOProperties adoProperties, EmailService emailService, ScmConfigOverrider scmConfigOverrider) {
+                             ConfigurationOverrider configOverrider, ADOProperties adoProperties, EmailService emailService,
+                             BugTrackerEventTrigger bugTrackerEventTrigger, ScmConfigOverrider scmConfigOverrider) {
 
         this.filterFactory = filterFactory;
         this.configOverrider = configOverrider;
@@ -93,6 +95,7 @@ public class DeleteBranchSteps {
         this.adoProperties = adoProperties;
         this.cxConfig = new CxConfig();
         this.emailService = emailService;
+        this.bugTrackerEventTrigger = bugTrackerEventTrigger;
 
         this.adoServiceMock = mock(ADOService.class);
         this.resultsServiceMock = mock(ResultsService.class);
@@ -325,7 +328,7 @@ public class DeleteBranchSteps {
             initProjectNameGeneratorSpy(projectNameGeneratorSpy);
 
         ScanRequestConverter scanRequestConverter = new ScanRequestConverter(helperService, cxProperties, cxClientMock, flowProperties, gitHubService, null, null, null);
-        SastScanner sastScanner = new SastScanner(null, cxClientMock, helperService, cxProperties, flowProperties, null, emailService, scanRequestConverter, null, projectNameGeneratorSpy);
+        SastScanner sastScanner = new SastScanner(null, cxClientMock, helperService, cxProperties, flowProperties, null, emailService, scanRequestConverter, bugTrackerEventTrigger, projectNameGeneratorSpy);
         List<VulnerabilityScanner> scanners= new LinkedList<>();
         scanners.add(sastScanner);
         

--- a/src/test/java/com/checkmarx/flow/cucumber/component/deletebranch/DeleteBranchSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/deletebranch/DeleteBranchSteps.java
@@ -1,15 +1,23 @@
 package com.checkmarx.flow.cucumber.component.deletebranch;
 
 import com.checkmarx.flow.CxFlowApplication;
+import com.checkmarx.flow.config.ADOProperties;
 import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.config.GitHubProperties;
+import com.checkmarx.flow.controller.ADOController;
 import com.checkmarx.flow.config.ScmConfigOverrider;
 import com.checkmarx.flow.controller.GitHubController;
+import com.checkmarx.flow.dto.BugTracker;
+import com.checkmarx.flow.dto.ControllerRequest;
+import com.checkmarx.flow.dto.azure.*;
 import com.checkmarx.flow.dto.github.*;
+import com.checkmarx.flow.dto.github.Repository;
 import com.checkmarx.flow.sastscanning.ScanRequestConverter;
 import com.checkmarx.flow.service.*;
 import com.checkmarx.sdk.config.Constants;
 import com.checkmarx.sdk.config.CxProperties;
+import com.checkmarx.sdk.dto.CxConfig;
+import com.checkmarx.sdk.dto.ScanResults;
 import com.checkmarx.sdk.exception.CheckmarxException;
 import com.checkmarx.sdk.service.CxClient;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -17,12 +25,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.*;
 import lombok.extern.slf4j.Slf4j;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -38,20 +46,33 @@ public class DeleteBranchSteps {
     private static final String PRESET = "Default Preset";
     private static final String BRANCH_REF_TYPE = "branch";
     private static final String GITHUB_USER = "cxflowtestuser";
+    private static final String AZURE_WEBHOOK_TOKEN = "cxflow:1234";
+    private static final String AZURE_WEBHOOK_TOKEN_AUTH = "Basic Y3hmbG93OjEyMzQ=";
+    private static final String AZURE_PUSH_EVENT_TYPE = "git.push";
+    private static final String AZURE_DELETED_BRANCH_OBJ_ID = "0000000000000000000000000000000000000000";
+    private static final String GIT_DEFAULT_BRANCH = "refs/heads/master";
+    private static final int SCAN_ID_EXISTING_SCAN_NOT_EXIST = -1;
     private final CxClient cxClientMock;
     private final GitHubService gitHubService;
     private GitHubController gitHubControllerSpy;
-    private static final ObjectMapper mapper = new ObjectMapper();
+    private ADOController adoControllerSpy;
 
+    private static final ObjectMapper mapper = new ObjectMapper();
     private final FlowProperties flowProperties;
     private final CxProperties cxProperties;
     private final GitHubProperties gitHubProperties;
     private final HelperService helperService;
     private final FilterFactory filterFactory;
     private final ConfigurationOverrider configOverrider;
+    private final ADOProperties adoProperties;
+    private final EmailService emailService;
     private final ScmConfigOverrider scmConfigOverrider;
 
-    private String branch;
+    private final ADOService adoServiceMock;
+    private final ResultsService resultsServiceMock;
+    private CxConfig cxConfig;
+    private String adoRepo;
+    private String githubBranch;
     
     private Boolean deleteCalled;
     private String repoName;
@@ -61,22 +82,22 @@ public class DeleteBranchSteps {
 
     public DeleteBranchSteps(FlowProperties flowProperties, GitHubService gitHubService,
                              CxProperties cxProperties, GitHubProperties gitHubProperties, FilterFactory filterFactory,
-                             ConfigurationOverrider configOverrider, ScmConfigOverrider scmConfigOverrider) {
+                             ConfigurationOverrider configOverrider, ADOProperties adoProperties, EmailService emailService, ScmConfigOverrider scmConfigOverrider) {
+
         this.filterFactory = filterFactory;
-
         this.configOverrider = configOverrider;
-
-        this.cxClientMock = mock(CxClient.class);
-
         this.flowProperties = flowProperties;
-
         this.cxProperties = cxProperties;
-
-        this.helperService = mock(HelperService.class);
-
         this.gitHubService = gitHubService;
-
         this.gitHubProperties = gitHubProperties;
+        this.adoProperties = adoProperties;
+        this.cxConfig = new CxConfig();
+        this.emailService = emailService;
+
+        this.adoServiceMock = mock(ADOService.class);
+        this.resultsServiceMock = mock(ResultsService.class);
+        this.cxClientMock = mock(CxClient.class);
+        this.helperService = mock(HelperService.class, Mockito.withSettings().useConstructor(flowProperties, cxProperties, null));
         this.scmConfigOverrider = scmConfigOverrider;
     }
 
@@ -88,25 +109,40 @@ public class DeleteBranchSteps {
         this.gitHubProperties.setApiUrl("https://api.github.com/repos");
     }
 
+    private void initAdoProperties() {
+        this.adoProperties.setNamespace("TestNameSpace");
+        this.adoProperties.setWebhookToken(AZURE_WEBHOOK_TOKEN);
+    }
+
     @Before("@DeleteBranchFeature")
-    public void prepareServices() {
+    public void prepareServices() throws CheckmarxException {
         deleteCalled = Boolean.FALSE;
         trigger = BRANCH_REF_TYPE;
-        initCxClientMock();
-        initHelperServiceMock();
+        flowProperties.setBugTracker(BugTracker.Type.CUSTOM.toString());
+        initMockers();
         initServices();
         initMockGitHubController();
     }
 
-    private void initCxClientMock() {
+    private void initMockers() throws CheckmarxException {
+
         ScanResultsAnswerer answerer = new ScanResultsAnswerer();
         doAnswer(answerer).when(cxClientMock).deleteProject(any());
-        try {
-            when(cxClientMock.getTeamId(anyString(),anyString())).thenReturn(TEAM);
-            when(cxClientMock.getTeamId(anyString())).thenReturn(TEAM);
-        } catch (CheckmarxException e) {
-            fail(e.getMessage());
-        }
+
+        when(helperService.getShortUid()).thenReturn("12345");
+        when(helperService.getCxTeam(any())).thenReturn(TEAM);
+        when(helperService.getCxProject(any())).thenReturn(PROJECT_NAME);
+        when(helperService.getPresetFromSources(any())).thenReturn(PRESET);
+        when(helperService.isBranchProtected(anyString(), anyList(), any())).thenCallRealMethod();
+        when(helperService.isBranch2Scan(any(), anyList())).thenCallRealMethod();
+
+        when(cxClientMock.getTeamId(anyString(),anyString())).thenReturn(TEAM);
+        when(cxClientMock.getTeamId(anyString())).thenReturn(TEAM);
+        when(cxClientMock.getScanIdOfExistingScanIfExists(anyInt())).thenReturn(SCAN_ID_EXISTING_SCAN_NOT_EXIST);
+        when(cxClientMock.getReportContentByScanId(anyInt(), any())).thenReturn(new ScanResults());
+
+        when(adoServiceMock.getCxConfigOverride(any(), anyString())).thenReturn(cxConfig);
+        when(resultsServiceMock.publishCombinedResults(any(), any())).thenReturn(null);
     }
 
     private class ScanResultsAnswerer implements Answer<Object> {
@@ -117,8 +153,19 @@ public class DeleteBranchSteps {
         }
     }
 
+    @Given("Azure repo name is {string}")
+    public void setAdoRepoName(String repo){
+        adoRepo = repo;
+        initAdoProperties();
+    }
+
+    @And("Azure branch is {}")
+    public void setAdoBranch(String branch){
+
+    }
+
     @Given("GitHub repo name is {string}")
-    public void setRepoName(String repoName){
+    public void setGithubRepoName(String repoName){
         this.repoName = repoName;
         initGitHubProperties();
     }
@@ -134,8 +181,8 @@ public class DeleteBranchSteps {
     }
     
     @And("GitHub branch is {string}")
-    public void setBranch(String branch) {
-        this.branch = branch;
+    public void setGithubBranch(String branch) {
+        this.githubBranch = branch;
     }
     
     @And("a project {string} {string} in SAST")
@@ -149,7 +196,7 @@ public class DeleteBranchSteps {
         when(cxClientMock.getProjectId(anyString(), any())).thenReturn(projectId);
     }
     
-    @And("the {string} branch is {string} as determined by application.yml")
+    @And("the {string} branch is {} as determined by application.yml")
     public void theBranchIsSpecifiedAsProtected(String branch, String protectedOrNot) {
         List<String> protectedBranches = flowProperties.getBranches();
         if (Boolean.parseBoolean(protectedOrNot)) {
@@ -158,14 +205,32 @@ public class DeleteBranchSteps {
             protectedBranches.remove(branch);
         }
     }
-        
-    @When("GitHub notifies cxFlow that a {string} branch/ref was deleted")
-    public void githubNotifiesCxFlowThatABranchWasDeleted(String deletedBranch) {
-        branch = deletedBranch;
-        sendDeleteEvent();
+
+    @And("the Azure properties is {} by application.yml")
+    public void theBranchIsSpecifiedAsProtected(boolean deleteBranch) {
+        adoProperties.setDeleteCxProject(deleteBranch);
     }
 
-    @Then("CxFlow will {string} the SAST delete API for the {string} project")
+    @And("config-as-code in azure default branch include Cx-project {}")
+    public void setAzureConfigAsCodeProject(String cxProject) {
+        if (!cxProject.equals("none")){
+            cxConfig.setProject(cxProject);
+        }
+    }
+
+    @When("GitHub notifies cxFlow that a {string} branch/ref was deleted")
+    public void githubNotifiesCxFlowThatABranchWasDeleted(String deletedBranch) {
+        githubBranch = deletedBranch;
+        sendGithubDeleteEvent();
+    }
+
+    @When("Azure notifies cxFlow that a {string} branch was deleted")
+    public void azureNotifiesCxFlowThatABranchWasDeleted(String deletedBranch) {
+        sendAzureDeleteEvent(deletedBranch);
+    }
+
+
+    @Then("CxFlow will {} the SAST delete API for the {string} project")
     public void cxflowWillNotCallTheSASTDeleteAPI(String willCall, String projectName) {
         boolean expectingCall = Boolean.parseBoolean(willCall);
         verifyDeleteApiCall(expectingCall);
@@ -183,7 +248,7 @@ public class DeleteBranchSteps {
         }
     }
     
-    private void sendDeleteEvent() {
+    private void sendGithubDeleteEvent() {
         DeleteEvent deleteEvent = new DeleteEvent();
         Repository repo = new Repository();
         repo.setName(repoName);
@@ -195,7 +260,7 @@ public class DeleteBranchSteps {
         repo.setOwner(owner);
         deleteEvent.setRepository(repo);
         deleteEvent.setRefType(trigger);
-        deleteEvent.setRef(branch);
+        deleteEvent.setRef(githubBranch);
                 
         try {
             String deleteEventStr = mapper.writeValueAsString(deleteEvent);
@@ -208,28 +273,63 @@ public class DeleteBranchSteps {
         }
     }
 
-     private void initHelperServiceMock() {
-         when(helperService.getShortUid()).thenReturn("123456");
-         when(helperService.getCxTeam(any())).thenReturn(TEAM);
-         when(helperService.getCxProject(any())).thenReturn(PROJECT_NAME);
-         when(helperService.getPresetFromSources(any())).thenReturn(PRESET);
-        when(helperService.isBranchProtected(anyString(), anyList(), any())).thenCallRealMethod();
+    public void sendAzureDeleteEvent(String deletedBranch) {
+
+        String meaningless_string = "some_string";
+        com.checkmarx.flow.dto.azure.PushEvent pushEvent = new com.checkmarx.flow.dto.azure.PushEvent();
+        pushEvent.setEventType(AZURE_PUSH_EVENT_TYPE);
+
+        Project_ project = new Project_();
+        project.setId(meaningless_string);
+        project.setBaseUrl("https://dev.azure.com/OrgName/");
+
+        ResourceContainers resourceContainers = new ResourceContainers();
+        resourceContainers.setProject(project);
+
+        pushEvent.setResourceContainers(resourceContainers);
+        RefUpdate refUpdate = new RefUpdate();
+        refUpdate.setName("refs/heads/" + deletedBranch);
+        refUpdate.setOldObjectId(meaningless_string);
+        refUpdate.setNewObjectId(AZURE_DELETED_BRANCH_OBJ_ID);
+
+        Resource resource = new Resource();
+        resource.setRefUpdates(Collections.singletonList(refUpdate));
+        resource.setStatus(meaningless_string);
+        resource.setUrl(meaningless_string);
+        com.checkmarx.flow.dto.azure.Repository repo = new com.checkmarx.flow.dto.azure.Repository();
+        repo.setId(meaningless_string);
+        repo.setName(adoRepo);
+        repo.setUrl(meaningless_string);
+        repo.setRemoteUrl(meaningless_string);
+
+        repo.setDefaultBranch(GIT_DEFAULT_BRANCH);
+        Project pr = new Project();
+        pr.setId(meaningless_string);
+        pr.setName(meaningless_string);
+        repo.setProject(pr);
+        resource.setRepository(repo);
+
+        pushEvent.setResource(resource);
+        ControllerRequest controllerRequest = new ControllerRequest();
+        AdoDetailsRequest adoRequest = new AdoDetailsRequest();
+        adoControllerSpy.pushRequest(pushEvent, AZURE_WEBHOOK_TOKEN_AUTH, null, controllerRequest, adoRequest);
     }
+
 
     private void initMockGitHubController() {
         doNothing().when(gitHubControllerSpy).verifyHmacSignature(any(), any(), any());
     }
-    
+
     private void initServices() {
         ProjectNameGenerator projectNameGeneratorSpy = spy(new ProjectNameGenerator(helperService, cxProperties, null));
             initProjectNameGeneratorSpy(projectNameGeneratorSpy);
-        
+
         ScanRequestConverter scanRequestConverter = new ScanRequestConverter(helperService, cxProperties, cxClientMock, flowProperties, gitHubService, null, null, null);
-        SastScanner sastScanner = new SastScanner(null, cxClientMock, helperService, cxProperties, flowProperties, null, null, scanRequestConverter, null, projectNameGeneratorSpy);
+        SastScanner sastScanner = new SastScanner(null, cxClientMock, helperService, cxProperties, flowProperties, null, emailService, scanRequestConverter, null, projectNameGeneratorSpy);
         List<VulnerabilityScanner> scanners= new LinkedList<>();
         scanners.add(sastScanner);
         
-        FlowService flowServiceSpy = spy(new FlowService(scanners, projectNameGeneratorSpy, null));
+        FlowService flowServiceSpy = spy(new FlowService(scanners, projectNameGeneratorSpy, resultsServiceMock));
         
         //gitHubControllerSpy is a spy which will run real methods.
         //It will connect to a real github repository to read a real cx.config file
@@ -244,8 +344,18 @@ public class DeleteBranchSteps {
                 sastScanner,
                 filterFactory,
                 configOverrider,
+                null));
+
+        this.adoControllerSpy = spy(new ADOController(adoProperties,
+                flowProperties,
+                cxProperties,
+                null,
+                flowServiceSpy,
+                helperService,
+                filterFactory,
+                configOverrider,
+                adoServiceMock,
                 scmConfigOverrider));
-        
     }
 
     private void initProjectNameGeneratorSpy(ProjectNameGenerator projectNameGenerator) {
@@ -258,6 +368,8 @@ public class DeleteBranchSteps {
             } catch (Throwable throwable) {
                 fail(throwable.getMessage());
             }
-        return null;
+        return calculatedProjectName;
         }
     }
+
+

--- a/src/test/resources/cucumber/features/componentTests/delete-branch.feature
+++ b/src/test/resources/cucumber/features/componentTests/delete-branch.feature
@@ -4,10 +4,10 @@ Feature: CxFlow should delete SAST project when corresponding GitHub branch is d
   Scenario Outline: CxFlow deletes SAST project when a non-protected GitHub branch is deleted
     Given GitHub repo name is "VB_3845"
     And GitHub branch is "test1"
-    And the "test1" branch is "<protected>" as determined by application.yml
+    And the "test1" branch is <protected> as determined by application.yml
     And a project "VB_3845-test1" "<exists>" in SAST
     When GitHub notifies cxFlow that a "test1" branch was deleted
-    Then CxFlow will "<call>" the SAST delete API for the "VB_3845-test1" project
+    Then CxFlow will <call> the SAST delete API for the "VB_3845-test1" project
     And no exception will be thrown
 
     Examples:
@@ -17,6 +17,7 @@ Feature: CxFlow should delete SAST project when corresponding GitHub branch is d
       | false  | true      | false |
       | false  | false     | false |
 
+
   Scenario Outline: Github triggers delete event both when branch and tag are deleted,
   but CxFlow will call SAST delete API only when branch is deleted
     Given GitHub repo name is "VB_3845"
@@ -24,10 +25,31 @@ Feature: CxFlow should delete SAST project when corresponding GitHub branch is d
     And the "test2" branch is "not protected" as determined by application.yml
     And a project "VB_3845-test2" "exists" in SAST
     When GitHub notifies cxFlow that a "test2" ref was deleted
-    Then CxFlow will "<call>" the SAST delete API for the "VB_3845-test2" project
+    Then CxFlow will <call> the SAST delete API for the "VB_3845-test2" project
     And no exception will be thrown
 
     Examples:
       | trigger | call  |
       | branch  | true  |
       | tag     | false |
+
+
+  Scenario Outline: CxFlow deletes SAST project when a non-protected Azure branch is deleted
+    Given Azure repo name is "Delete-Branch-Repo"
+    And Azure branch is "Test"
+    And the "Test" branch is <protected> as determined by application.yml
+    And the Azure properties is <setToDelete> by application.yml
+    And config-as-code in azure default branch include Cx-project <configAsCodeProject>
+    When Azure notifies cxFlow that a "Test" branch was deleted
+    Then CxFlow will <call> the SAST delete API for the "<projectName>" project
+    And no exception will be thrown
+
+    Examples:
+      | protected | setToDelete | configAsCodeProject | call  | projectName             |
+      | false     | true        | none                | true  | Delete-Branch-Repo-Test |
+      | false     | true        | project-to-delete   | true  | project-to-delete       |
+      | false     | true        | foo-${branch}       | true  | foo-Test                |
+      | True      | true        | some-project        | false | none                    |
+      | false     | false       | some-project        | false | none                    |
+
+


### PR DESCRIPTION
### Description

purpose of the pull request is to implement Delete Cx-project on Azure devops branch deletion

### References

STORY 127 - Azure devops: when PR is closed, automatically delete a corresponding SAST project

### Testing

Added component tests for delete branch feature for ADO implementation

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
