### PR TITLE
fix parse component tests

### DIFF
--- a/src/test/java/com/checkmarx/flow/cucumber/component/parse/RunningCxFlowSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/parse/RunningCxFlowSteps.java
@@ -106,7 +106,7 @@ public class RunningCxFlowSteps {
         }
         testContext.setOutputFilename(outputFilename);
 
-        String commandLineArgs = String.format("--parse --offline --%s --app=ABC --f=%s %s",
+        String commandLineArgs = String.format("--parse --offline --%s --app=ABC --bug-tracker=Json --f=%s %s",
                 CxFlowRunner.THROW_INSTEAD_OF_EXIT_OPTION,
                 inputFilePath,
                 customCommandLineArgs);


### PR DESCRIPTION

Fix parse component tests: 
force bug-tracker: Json to the Parse flow
