### PR TITLE
BBCloud : Fix for broken source link due to forward slash(/) present in branch name.

### DIFF
--- a/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
+++ b/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
@@ -280,7 +280,7 @@ public class ScanUtils {
                 }
             }
             else if (request.getRepoType().equals(ScanRequest.Repository.BITBUCKET)) {
-                return repoUrl.concat("src/").concat(branch).concat("/").concat(filename);
+                return repoUrl.concat("src/").concat(request.getHash()).concat("/").concat(filename);
             }
             else if (request.getRepoType().equals(ScanRequest.Repository.ADO)) {
                 return null;


### PR DESCRIPTION
### Description

> This fixes the issue for the link containing the line number mentioned in PR comment for Bitbucket Cloud. Now the latest commit hash is used to refer to the branch instead of the branch name. This will avoid the broken links due to branch names that contain '/'.

### References

> #159 

### Testing

> Manual Testing done.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
