### PR TITLE
Support reading bean configuration from remote repo via Config-Provider component

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -100,6 +100,7 @@ dependencies {
     compile("ch.qos.logback.contrib:logback-json-classic:0.1.5")
     compile("ch.qos.logback.contrib:logback-jackson:0.1.5")
     compile("net.logstash.logback:logstash-logback-encoder:5.2")
+    compile("com.checkmarx:cx-config-provider:1.0.7")
     compile("org.jasypt:jasypt:1.9.3")
     compileJava.dependsOn(processResources)
 }

--- a/build-11.gradle
+++ b/build-11.gradle
@@ -84,7 +84,6 @@ dependencies {
     compile group: 'javax.xml.ws', name: 'jaxws-api', version: '2.3.1'
     compile group: 'com.sun.xml.bind', name: 'jaxb-core', version: '2.3.0.1'
     compile group: 'com.sun.xml.messaging.saaj', name: 'saaj-impl', version: '1.4.0'
-    compile("com.checkmarx:cx-config-provider:1.0.8")
     compileOnly ('org.springframework.boot:spring-boot-configuration-processor')
 
     runtime('org.springframework.boot:spring-boot-devtools')

--- a/build-11.gradle
+++ b/build-11.gradle
@@ -84,6 +84,7 @@ dependencies {
     compile group: 'javax.xml.ws', name: 'jaxws-api', version: '2.3.1'
     compile group: 'com.sun.xml.bind', name: 'jaxb-core', version: '2.3.0.1'
     compile group: 'com.sun.xml.messaging.saaj', name: 'saaj-impl', version: '1.4.0'
+    compile("com.checkmarx:cx-config-provider:1.0.8")
     compileOnly ('org.springframework.boot:spring-boot-configuration-processor')
 
     runtime('org.springframework.boot:spring-boot-devtools')

--- a/build-11.gradle
+++ b/build-11.gradle
@@ -100,7 +100,7 @@ dependencies {
     compile("ch.qos.logback.contrib:logback-json-classic:0.1.5")
     compile("ch.qos.logback.contrib:logback-jackson:0.1.5")
     compile("net.logstash.logback:logstash-logback-encoder:5.2")
-    compile("com.checkmarx:cx-config-provider:1.0.7")
+    compile("com.checkmarx:cx-config-provider:1.0.8")
     compile("org.jasypt:jasypt:1.9.3")
     compileJava.dependsOn(processResources)
 }

--- a/build-cxgo.gradle
+++ b/build-cxgo.gradle
@@ -116,7 +116,7 @@ dependencies {
     compile("ch.qos.logback.contrib:logback-json-classic:0.1.5")
     compile("ch.qos.logback.contrib:logback-jackson:0.1.5")
     compile("net.logstash.logback:logstash-logback-encoder:5.2")
-    compile("com.checkmarx:cx-config-provider:1.0.7")
+    compile("com.checkmarx:cx-config-provider:1.0.8")
 }
 
 springBoot {

--- a/build-cxgo.gradle
+++ b/build-cxgo.gradle
@@ -116,6 +116,7 @@ dependencies {
     compile("ch.qos.logback.contrib:logback-json-classic:0.1.5")
     compile("ch.qos.logback.contrib:logback-jackson:0.1.5")
     compile("net.logstash.logback:logstash-logback-encoder:5.2")
+    compile("com.checkmarx:cx-config-provider:1.0.7")
 }
 
 springBoot {

--- a/build.gradle
+++ b/build.gradle
@@ -197,7 +197,7 @@ task integrationTest(type: Test) {
         include 'com/checkmarx/flow/cucumber/integration/azure/publishing/**'
         include 'com/checkmarx/flow/cucumber/integration/azure/publishing/github2ado/*'
         include 'com/checkmarx/flow/cucumber/integration/cxconfig/*'
-        include 'com/checkmarx/flow/cucumber/integration/config_provider/*'
+        include 'com/checkmarx/flow/cucumber/integration/config_provider/**'
         include 'com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/**'
         include 'com/checkmarx/flow/cucumber/integration/multiScmInstances/**'
 

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ dependencies {
     compile("ch.qos.logback.contrib:logback-json-classic:0.1.5")
     compile("ch.qos.logback.contrib:logback-jackson:0.1.5")
     compile("net.logstash.logback:logstash-logback-encoder:5.2")
+    compile("com.checkmarx:cx-config-provider:1.0.8")
 }
 
 springBoot {

--- a/build.gradle
+++ b/build.gradle
@@ -197,6 +197,7 @@ task integrationTest(type: Test) {
         include 'com/checkmarx/flow/cucumber/integration/azure/publishing/**'
         include 'com/checkmarx/flow/cucumber/integration/azure/publishing/github2ado/*'
         include 'com/checkmarx/flow/cucumber/integration/cxconfig/*'
+        include 'com/checkmarx/flow/cucumber/integration/config_provider/*'
         include 'com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/**'
         include 'com/checkmarx/flow/cucumber/integration/multiScmInstances/**'
 

--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -1,6 +1,7 @@
 package com.checkmarx.flow;
 
 import com.checkmarx.flow.config.*;
+import com.checkmarx.flow.constants.FlowConstants;
 import com.checkmarx.flow.dto.*;
 import com.checkmarx.flow.exception.*;
 import com.checkmarx.flow.service.*;
@@ -114,7 +115,7 @@ public class CxFlowRunner implements ApplicationRunner {
         FlowOverride o = null;
         ObjectMapper mapper = new ObjectMapper();
         String uid = helperService.getShortUid();
-        MDC.put("cx", uid);
+        MDC.put(FlowConstants.MAIN_MDC_ENTRY, uid);
 
         if (args.containsOption("branch-create")) {
             exit(ExitCode.SUCCESS);

--- a/src/main/java/com/checkmarx/flow/aop/LoggingAop.java
+++ b/src/main/java/com/checkmarx/flow/aop/LoggingAop.java
@@ -1,5 +1,6 @@
 package com.checkmarx.flow.aop;
 
+import com.checkmarx.flow.constants.FlowConstants;
 import com.checkmarx.flow.dto.ScanRequest;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.After;
@@ -21,7 +22,7 @@ public class LoggingAop {
     public void beforeAdvice(JoinPoint joinPoint, ScanRequest request) {
         if(request != null) {
             String id = request.getId();
-            MDC.put("cx", id);
+            MDC.put(FlowConstants.MAIN_MDC_ENTRY, id);
         }
     }
     @After(value = "execution(* com.checkmarx.flow.service.ResultsService.processScanResultsAsync(.., com.checkmarx.flow.dto.ScanRequest, ..)) &&  (args(.., request) || args(request, ..))")

--- a/src/main/java/com/checkmarx/flow/config/external/ASTConfig.java
+++ b/src/main/java/com/checkmarx/flow/config/external/ASTConfig.java
@@ -1,0 +1,21 @@
+package com.checkmarx.flow.config.external;
+
+import com.typesafe.config.Optional;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ASTConfig {
+
+    private String apiUrl;
+    private String preset;
+    @Optional
+    private boolean incremental;
+    private String clientSecret;
+    private String clientId;
+}

--- a/src/main/java/com/checkmarx/flow/config/external/ASTConfig.java
+++ b/src/main/java/com/checkmarx/flow/config/external/ASTConfig.java
@@ -10,8 +10,11 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+/*
+  This class serves as an external bean class populated by the config-provider component
+  It represents current AST allowed properties configuration
+ */
 public class ASTConfig {
-
     private String apiUrl;
     private String preset;
     @Optional

--- a/src/main/java/com/checkmarx/flow/constants/FlowConstants.java
+++ b/src/main/java/com/checkmarx/flow/constants/FlowConstants.java
@@ -1,0 +1,11 @@
+package com.checkmarx.flow.constants;
+
+public class FlowConstants {
+
+    public static final String MAIN_MDC_ENTRY = "cx";
+
+    private FlowConstants() {
+    }
+
+
+}

--- a/src/main/java/com/checkmarx/flow/controller/ADOController.java
+++ b/src/main/java/com/checkmarx/flow/controller/ADOController.java
@@ -4,6 +4,7 @@ import com.checkmarx.flow.config.ADOProperties;
 import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.config.JiraProperties;
 import com.checkmarx.flow.config.ScmConfigOverrider;
+import com.checkmarx.flow.constants.FlowConstants;
 import com.checkmarx.flow.dto.BugTracker;
 import com.checkmarx.flow.dto.ControllerRequest;
 import com.checkmarx.flow.dto.EventResponse;
@@ -65,7 +66,7 @@ public class ADOController extends AdoControllerBase {
             AdoDetailsRequest adoDetailsRequest
     ) {
         String uid = helperService.getShortUid();
-        MDC.put("cx", uid);
+        MDC.put(FlowConstants.MAIN_MDC_ENTRY, uid);
         log.info("Processing Azure PULL request");
         Action action = Action.PULL;
         controllerRequest = ensureNotNull(controllerRequest);
@@ -194,7 +195,7 @@ public class ADOController extends AdoControllerBase {
     ) {
         //TODO handle different state (Active/Closed)
         String uid = helperService.getShortUid();
-        MDC.put("cx", uid);
+        MDC.put(FlowConstants.MAIN_MDC_ENTRY, uid);
         log.info("Processing Azure Push request");
         Action action = Action.PUSH;
 

--- a/src/main/java/com/checkmarx/flow/controller/BitbucketCloudController.java
+++ b/src/main/java/com/checkmarx/flow/controller/BitbucketCloudController.java
@@ -3,6 +3,7 @@ package com.checkmarx.flow.controller;
 import com.checkmarx.flow.config.BitBucketProperties;
 import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.config.JiraProperties;
+import com.checkmarx.flow.constants.FlowConstants;
 import com.checkmarx.flow.dto.BugTracker;
 import com.checkmarx.flow.dto.ControllerRequest;
 import com.checkmarx.flow.dto.EventResponse;
@@ -57,7 +58,7 @@ public class BitbucketCloudController extends WebhookController {
 
     ) {
         String uid = helperService.getShortUid();
-        MDC.put("cx", uid);
+        MDC.put(FlowConstants.MAIN_MDC_ENTRY, uid);
         validateBitBucketRequest(token);
         log.info("Processing BitBucket MERGE request");
         controllerRequest = ensureNotNull(controllerRequest);
@@ -153,7 +154,7 @@ public class BitbucketCloudController extends WebhookController {
 
     ) {
         String uid = helperService.getShortUid();
-        MDC.put("cx", uid);
+        MDC.put(FlowConstants.MAIN_MDC_ENTRY, uid);
         validateBitBucketRequest(token);
         controllerRequest = ensureNotNull(controllerRequest);
 

--- a/src/main/java/com/checkmarx/flow/controller/BitbucketServerController.java
+++ b/src/main/java/com/checkmarx/flow/controller/BitbucketServerController.java
@@ -3,6 +3,7 @@ package com.checkmarx.flow.controller;
 import com.checkmarx.flow.config.BitBucketProperties;
 import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.config.JiraProperties;
+import com.checkmarx.flow.constants.FlowConstants;
 import com.checkmarx.flow.dto.BugTracker;
 import com.checkmarx.flow.dto.ControllerRequest;
 import com.checkmarx.flow.dto.EventResponse;
@@ -133,7 +134,7 @@ public class BitbucketServerController extends WebhookController {
                                                        String signature,
                                                        ControllerRequest controllerRequest) {
         String uid = helperService.getShortUid();
-        MDC.put("cx", uid);
+        MDC.put(FlowConstants.MAIN_MDC_ENTRY, uid);
         verifyHmacSignature(body, signature);
         controllerRequest = ensureNotNull(controllerRequest);
 
@@ -262,7 +263,7 @@ public class BitbucketServerController extends WebhookController {
 
     ) {
         String uid = helperService.getShortUid();
-        MDC.put("cx", uid);
+        MDC.put(FlowConstants.MAIN_MDC_ENTRY, uid);
         verifyHmacSignature(body, signature);
         controllerRequest = ensureNotNull(controllerRequest);
 

--- a/src/main/java/com/checkmarx/flow/controller/FlowController.java
+++ b/src/main/java/com/checkmarx/flow/controller/FlowController.java
@@ -2,6 +2,7 @@ package com.checkmarx.flow.controller;
 
 import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.config.JiraProperties;
+import com.checkmarx.flow.constants.FlowConstants;
 import com.checkmarx.flow.dto.*;
 import com.checkmarx.flow.exception.InvalidTokenException;
 import com.checkmarx.flow.service.*;
@@ -72,7 +73,7 @@ public class FlowController {
             @RequestParam(value = "bug", required = false) String bug) {
 
         String uid = helperService.getShortUid();
-        MDC.put("cx", uid);
+        MDC.put(FlowConstants.MAIN_MDC_ENTRY, uid);
         // Validate shared API token from header
         validateToken(token);
 
@@ -116,7 +117,7 @@ public class FlowController {
     ){
         String uid = helperService.getShortUid();
         String errorMessage = "Error submitting Scan Request.";
-        MDC.put("cx", uid);
+        MDC.put(FlowConstants.MAIN_MDC_ENTRY, uid);
         log.info("Processing Scan initiation request");
 
         validateToken(token);

--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -261,7 +261,6 @@ public class GitHubController extends WebhookController {
             throw new MachinaRuntimeException();
         }
 
-
         //verify message signature
         verifyHmacSignature(body, signature, controllerRequest);
 

--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -263,6 +263,8 @@ public class GitHubController extends WebhookController {
                 Repository repository = event.getRepository();
                 String ref = event.getRef();
 
+                // According to GitHub the recommended way to extract the branch name
+                // is by using the 'ref' parameter which is in the following format: 'refs/heads/<branch>'
                 configProvider.init(uid, new RepoReader(properties.getApiUrl(), repository.getOwner().getName(),
                         repository.getName(), ref.substring(ref.lastIndexOf('/') + 1),
                         properties.getToken(), SourceProviderType.GITHUB));

--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -118,6 +118,21 @@ public class GitHubController extends WebhookController {
         } catch (IOException e) {
             throw new MachinaRuntimeException(e);
         }
+
+        if (properties != null) {
+            try {
+                ConfigProvider configProvider = ConfigProvider.getInstance();
+                Repository repository = event.getRepository();
+                String branch = event.getPullRequest().getHead().getRef();
+
+                configProvider.init(uid, new RepoReader(properties.getApiUrl(), repository.getOwner().getLogin(),
+                        repository.getName(), branch,
+                        properties.getToken(), SourceProviderType.GITHUB));
+            } catch (ConfigurationException e) {
+                log.warn("Failed to init config provider with the following error: {}", e.getMessage());
+            }
+        }
+
         //verify message signature
         verifyHmacSignature(body, signature, controllerRequest);
 

--- a/src/main/java/com/checkmarx/flow/controller/GitLabController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitLabController.java
@@ -4,6 +4,7 @@ import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.config.GitLabProperties;
 import com.checkmarx.flow.config.JiraProperties;
 import com.checkmarx.flow.config.ScmConfigOverrider;
+import com.checkmarx.flow.constants.FlowConstants;
 import com.checkmarx.flow.dto.BugTracker;
 import com.checkmarx.flow.dto.ControllerRequest;
 import com.checkmarx.flow.dto.EventResponse;
@@ -68,7 +69,7 @@ public class GitLabController extends WebhookController {
             ControllerRequest controllerRequest
     ){
         String uid = helperService.getShortUid();
-        MDC.put("cx", uid);
+        MDC.put(FlowConstants.MAIN_MDC_ENTRY, uid);
         log.info("Processing GitLab MERGE request");
         controllerRequest = ensureNotNull(controllerRequest);
         validateGitLabRequest(token, controllerRequest);
@@ -187,7 +188,7 @@ public class GitLabController extends WebhookController {
             ControllerRequest controllerRequest
     ){
         String uid = helperService.getShortUid();
-        MDC.put("cx", uid);
+        MDC.put(FlowConstants.MAIN_MDC_ENTRY, uid);
         controllerRequest = ensureNotNull(controllerRequest);
         validateGitLabRequest(token, controllerRequest);
 

--- a/src/main/java/com/checkmarx/flow/controller/TfsController.java
+++ b/src/main/java/com/checkmarx/flow/controller/TfsController.java
@@ -3,6 +3,7 @@ package com.checkmarx.flow.controller;
 import com.checkmarx.flow.config.ADOProperties;
 import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.config.JiraProperties;
+import com.checkmarx.flow.constants.FlowConstants;
 import com.checkmarx.flow.dto.*;
 import com.checkmarx.flow.dto.ScanRequest.Product;
 import com.checkmarx.flow.dto.ScanRequest.ScanRequestBuilder;
@@ -62,7 +63,7 @@ public class TfsController extends AdoControllerBase {
         String action = getAction(httpRequest);
 
         String uid = helperService.getShortUid();
-        MDC.put("cx", uid);
+        MDC.put(FlowConstants.MAIN_MDC_ENTRY, uid);
         if (log.isInfoEnabled()) {
             log.info(String.format("Processing TFS %s request", action));
         }

--- a/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
@@ -1,6 +1,7 @@
 package com.checkmarx.flow.dto;
 
 import com.checkmarx.flow.config.FindingSeverity;
+import com.checkmarx.flow.config.external.ASTConfig;
 import com.checkmarx.flow.service.VulnerabilityScanner;
 import com.checkmarx.sdk.config.ScaConfig;
 import com.checkmarx.sdk.dto.filtering.FilterConfiguration;
@@ -80,6 +81,7 @@ public class ScanRequest {
     private Map<String, String> additionalMetadata;
     private List<VulnerabilityScanner> vulnerabilityScanners;
     private ScaConfig scaConfig;
+    private ASTConfig astConfig;
 
     public ScanRequest(ScanRequest other) {
         this.namespace = other.namespace;
@@ -115,6 +117,7 @@ public class ScanRequest {
         this.forceScan = other.forceScan;
         this.vulnerabilityScanners = other.vulnerabilityScanners;
         this.scaConfig = other.scaConfig;
+        this.astConfig = other.astConfig;
         this.thresholds = other.thresholds;
     }
 

--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -46,7 +46,7 @@ public class ConfigurationOverrider {
 
     public ScanRequest overrideScanRequestProperties(CxConfig override, ScanRequest request) {
         ConfigProvider configProvider = ConfigProvider.getInstance();
-        if (request == null || (!isConfigAsCodeAvailable(configProvider) && isLegacyConfigAsCodeAvailable(override))) {
+        if (request == null || (!isConfigAsCodeAvailable(configProvider) && isLegacyConfigAsCodeNotAvailable(override))) {
             return request;
         }
 
@@ -77,7 +77,7 @@ public class ConfigurationOverrider {
         return configProvider.hasAnyConfiguration(MDC.get(FlowConstants.MAIN_MDC_ENTRY));
     }
 
-    private boolean isLegacyConfigAsCodeAvailable(CxConfig override) {
+    private boolean isLegacyConfigAsCodeNotAvailable(CxConfig override) {
         return override == null || Boolean.FALSE.equals(override.getActive());
     }
 

--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -46,7 +46,7 @@ public class ConfigurationOverrider {
 
     public ScanRequest overrideScanRequestProperties(CxConfig override, ScanRequest request) {
         ConfigProvider configProvider = ConfigProvider.getInstance();
-        if (request == null || (!isConfigAsCodeAvailable(configProvider) && isLegacyConfigAsCodeNotAvailable(override))) {
+        if (request == null || (!isConfigAsCodeAvailable(configProvider) && !isLegacyConfigAsCodeAvailable(override))) {
             return request;
         }
 
@@ -77,8 +77,8 @@ public class ConfigurationOverrider {
         return configProvider.hasAnyConfiguration(MDC.get(FlowConstants.MAIN_MDC_ENTRY));
     }
 
-    private boolean isLegacyConfigAsCodeNotAvailable(CxConfig override) {
-        return override == null || Boolean.FALSE.equals(override.getActive());
+    private boolean isLegacyConfigAsCodeAvailable(CxConfig override) {
+        return override != null && !(Boolean.FALSE.equals(override.getActive()));
     }
 
     private void applyFlowOverride(FlowOverride fo, ScanRequest request, Map<String, String> overrideReport) {

--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -1,7 +1,9 @@
 package com.checkmarx.flow.service;
 
+import com.checkmarx.configprovider.ConfigProvider;
 import com.checkmarx.flow.config.FindingSeverity;
 import com.checkmarx.flow.config.FlowProperties;
+import com.checkmarx.flow.config.external.ASTConfig;
 import com.checkmarx.flow.dto.BugTracker;
 import com.checkmarx.flow.dto.ControllerRequest;
 import com.checkmarx.flow.dto.FlowOverride;
@@ -18,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.MDC;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -40,15 +43,17 @@ public class ConfigurationOverrider {
     private final SastScanner sastScanner;
 
     public ScanRequest overrideScanRequestProperties(CxConfig override, ScanRequest request) {
-        if (override == null || request == null || Boolean.FALSE.equals(override.getActive())) {
+        ConfigProvider configProvider = ConfigProvider.getInstance();
+        if (request == null || (!configProvider.hasAnyConfiguration(MDC.get("cx")) && (override == null || Boolean.FALSE.equals(override.getActive())))) {
             return request;
         }
 
         Map<String, String> overrideReport = new HashMap<>();
-        overrideMainProperties(override, request, overrideReport);
+        overrideMainProperties(Optional.ofNullable(override), request, overrideReport);
 
         try {
-            Optional.ofNullable(override.getAdditionalProperties()).ifPresent(ap -> {
+            Optional.ofNullable(override)
+                .map(CxConfig::getAdditionalProperties).ifPresent(ap -> {
                 Object flow = ap.get("cxFlow");
                 ObjectMapper mapper = new ObjectMapper();
                 Optional.ofNullable(mapper.convertValue(flow, FlowOverride.class)).ifPresent(flowOverride ->
@@ -146,8 +151,8 @@ public class ConfigurationOverrider {
         });
     }
 
-    private void overrideMainProperties(CxConfig override, ScanRequest request, Map<String, String> overrideReport) {
-        Optional.ofNullable(override.getProject())
+    private void overrideMainProperties(Optional<CxConfig> override, ScanRequest request, Map<String, String> overrideReport) {
+        override.map(CxConfig::getProject)
                 .filter(StringUtils::isNotBlank)
                 .ifPresent(p -> {
                     /*Replace ${repo} and ${branch}  with the actual reponame and branch - then strip out non-alphanumeric (-_ are allowed)*/
@@ -157,13 +162,13 @@ public class ConfigurationOverrider {
                     request.setProject(project);
                     overrideReport.put("project", project);
                 });
-        Optional.ofNullable(override.getTeam())
+        override.map(CxConfig::getTeam)
                 .filter(StringUtils::isNotBlank)
                 .ifPresent(t -> {
                     request.setTeam(t);
                     overrideReport.put("team", t);
                 });
-        Optional.ofNullable(override.getSast()).ifPresent(s -> {
+        override.map(CxConfig::getSast).ifPresent(s -> {
             Optional.ofNullable(s.getIncremental()).ifPresent(si -> {
                 request.setIncremental(si);
                 overrideReport.put("incremental", si.toString());
@@ -188,7 +193,42 @@ public class ConfigurationOverrider {
                 overrideReport.put("exclude files", sf);
             });
         });
-        overridePropertiesSca(Optional.ofNullable(override.getSca()), overrideReport, request);
+        ConfigProvider configProvider = ConfigProvider.getInstance();
+        String uid = MDC.get("cx");
+        if (configProvider.hasConfiguration(uid, "sca")) {
+            ScaConfig scaConfiguration = configProvider.getConfiguration(uid, "sca", ScaConfig.class);
+            log.info("Overriding SCA properties from config provider configuration");
+            overridePropertiesSca(scaConfiguration, overrideReport, request);
+        } else {
+            overridePropertiesSca(override.map(CxConfig::getSca), overrideReport, request);
+        }
+
+        if (configProvider.hasConfiguration(uid, "ast")) {
+            ASTConfig astConfiguration = configProvider.getConfiguration(uid, "ast", ASTConfig.class);
+            log.info("Overriding AST properties from config provider configuration");
+            overriderPropertiesAst(astConfiguration, overrideReport, request);
+        }
+    }
+
+    private void overriderPropertiesAst(ASTConfig astConfiguration, Map<String, String> overrideReport, ScanRequest request) {
+        overrideReport.put("AST apiUrl", astConfiguration.getApiUrl());
+        overrideReport.put("AST preset", astConfiguration.getPreset());
+        overrideReport.put("AST incremental", String.valueOf(astConfiguration.isIncremental()));
+
+        request.setAstConfig(astConfiguration);
+    }
+
+    private void overridePropertiesSca(ScaConfig scaConfiguration, Map<String, String> overrideReport, ScanRequest request) {
+        overrideReport.put("accessControlUrl", scaConfiguration.getAccessControlUrl());
+        overrideReport.put("apiUrl", scaConfiguration.getApiUrl());
+        overrideReport.put("appUrl", scaConfiguration.getAppUrl());
+        overrideReport.put("tenant", scaConfiguration.getTenant());
+        overrideReport.put("thresholdsSeverity", convertMapToString(scaConfiguration.getThresholdsSeverity()));
+        overrideReport.put("thresholdsScore", String.valueOf(scaConfiguration.getThresholdsScore()));
+        overrideReport.put("filterSeverity", scaConfiguration.getFilterSeverity().toString());
+        overrideReport.put("filterScore", String.valueOf(scaConfiguration.getFilterScore()));
+
+        request.setScaConfig(scaConfiguration);
     }
 
     private void overridePropertiesSca(Optional<Sca> sca, Map<String, String> overrideReport, ScanRequest request) {

--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -196,16 +196,16 @@ public class ConfigurationOverrider {
         });
         ConfigProvider configProvider = ConfigProvider.getInstance();
         String uid = MDC.get("cx");
-        if (configProvider.hasConfiguration(uid, ScaProperties.CONFIG_PREFIX)) {
-            ScaConfig scaConfiguration = configProvider.getConfiguration(uid, ScaProperties.CONFIG_PREFIX, ScaConfig.class);
+        ScaConfig scaConfiguration = configProvider.getConfiguration(uid, ScaProperties.CONFIG_PREFIX, ScaConfig.class);
+        if (scaConfiguration != null) {
             log.info("Overriding SCA properties from config provider configuration");
             overridePropertiesSca(scaConfiguration, overrideReport, request);
         } else {
             overridePropertiesSca(override.map(CxConfig::getSca), overrideReport, request);
         }
 
-        if (configProvider.hasConfiguration(uid, AstProperties.CONFIG_PREFIX)) {
-            ASTConfig astConfiguration = configProvider.getConfiguration(uid, AstProperties.CONFIG_PREFIX, ASTConfig.class);
+        ASTConfig astConfiguration = configProvider.getConfiguration(uid, AstProperties.CONFIG_PREFIX, ASTConfig.class);
+        if (astConfiguration != null) {
             log.info("Overriding AST properties from config provider configuration");
             overriderPropertiesAst(astConfiguration, overrideReport, request);
         }

--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -46,6 +46,7 @@ import com.atlassian.jira.rest.client.api.domain.input.TransitionInput;
 import com.atlassian.jira.rest.client.internal.async.CustomAsynchronousJiraRestClientFactory;
 import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.config.JiraProperties;
+import com.checkmarx.flow.constants.FlowConstants;
 import com.checkmarx.flow.constants.JiraConstants;
 import com.checkmarx.flow.constants.SCATicketingConstants;
 import com.checkmarx.flow.dto.BugTracker;
@@ -448,7 +449,7 @@ public class JiraService {
                 }
 
                 switch (fieldType) {
-                    case "cx":
+                    case FlowConstants.MAIN_MDC_ENTRY:
                         log.debug("Checkmarx custom field {}", f.getName());
                         if (request.getCxFields() != null) {
                             log.debug("Checkmarx custom field");

--- a/src/main/java/com/checkmarx/flow/service/ResultsService.java
+++ b/src/main/java/com/checkmarx/flow/service/ResultsService.java
@@ -1,6 +1,7 @@
 package com.checkmarx.flow.service;
 
 import com.atlassian.jira.rest.client.api.RestClientException;
+import com.checkmarx.flow.constants.FlowConstants;
 import com.checkmarx.flow.dto.Field;
 import com.checkmarx.flow.dto.ScanDetails;
 import com.checkmarx.flow.dto.ScanRequest;
@@ -327,7 +328,7 @@ public class ResultsService {
             return false;
         }
         for (Field f : fields) {
-            if (f.getType().equals("cx")) {
+            if (f.getType().equals(FlowConstants.MAIN_MDC_ENTRY)) {
                 return true;
             }
         }

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/azure/publishing/github2ado/Github2AdoSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/azure/publishing/github2ado/Github2AdoSteps.java
@@ -189,6 +189,7 @@ public class Github2AdoSteps {
         Pusher pusher = new Pusher();
         pusher.setEmail("some@email");
         pushEvent.setPusher(pusher);
+        pushEvent.setRef("refs/heads/master");
 
 
         try {

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/config_provider/remote_repo/ConfigProviderRemoteRepoSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/config_provider/remote_repo/ConfigProviderRemoteRepoSteps.java
@@ -38,8 +38,15 @@ public class ConfigProviderRemoteRepoSteps {
     }
 
     @When("initializing config provider")
-    public void initConfigProvider() {
-        init();
+    public void initConfigProvider() throws ConfigurationException {
+        String nameSpace = "cxflowtestuser";
+        String repoName = "configProviderTestRepo";
+        String branchName = "main";
+
+        ConfigProvider configProvider = ConfigProvider.getInstance();
+        configProvider.init(uid, new RepoReader(gitHubProperties.getApiUrl(),
+                nameSpace, repoName, branchName,
+                gitHubProperties.getToken(), sourceProviderType));
     }
 
     @And("getting {string} config provider configuration")
@@ -89,20 +96,5 @@ public class ConfigProviderRemoteRepoSteps {
         Assert.assertEquals((Double)8.5, scaConfiguration.getThresholdsScore());
         Assert.assertEquals("[high, medium, low]", scaConfiguration.getFilterSeverity().toString());
         Assert.assertEquals((Double)7.5, scaConfiguration.getFilterScore());
-    }
-
-    private void init() {
-        String nameSpace = "cxflowtestuser";
-        String repoName = "configProviderTestRepo";
-        String branchName = "main";
-
-        try {
-            ConfigProvider configProvider = ConfigProvider.getInstance();
-            configProvider.init(uid, new RepoReader(gitHubProperties.getApiUrl(), nameSpace,
-                    repoName, branchName,
-                    gitHubProperties.getToken(), sourceProviderType));
-        } catch (ConfigurationException e) {
-            Assert.fail("Failed to init config provider with the following error: " + e.getMessage());
-        }
     }
 }

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/config_provider/remote_repo/ConfigProviderRemoteRepoSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/config_provider/remote_repo/ConfigProviderRemoteRepoSteps.java
@@ -1,0 +1,108 @@
+package com.checkmarx.flow.cucumber.integration.config_provider.remote_repo;
+
+import com.checkmarx.configprovider.ConfigProvider;
+import com.checkmarx.configprovider.dto.SourceProviderType;
+import com.checkmarx.configprovider.readers.RepoReader;
+import com.checkmarx.flow.CxFlowApplication;
+import com.checkmarx.flow.config.GitHubProperties;
+import com.checkmarx.flow.config.external.ASTConfig;
+import com.checkmarx.flow.exception.MachinaRuntimeException;
+import com.checkmarx.sdk.config.AstProperties;
+import com.checkmarx.sdk.config.ScaConfig;
+import com.checkmarx.sdk.config.ScaProperties;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.naming.ConfigurationException;
+
+@SpringBootTest(classes = {CxFlowApplication.class})
+@RequiredArgsConstructor
+public class ConfigProviderRemoteRepoSteps {
+
+    private final GitHubProperties gitHubProperties;
+
+    private SourceProviderType sourceProviderType;
+    private ScaConfig scaConfiguration;
+    private ASTConfig astConfiguration;
+    private String uid = "12345";
+
+    @Given("github repo contains a Checkmarx configuration")
+    public void setSourceProviderType() {
+        sourceProviderType = SourceProviderType.GITHUB;
+    }
+
+    @When("initializing config provider")
+    public void initConfigProvider() {
+        init();
+    }
+
+    @And("getting {string} config provider configuration")
+    public void setVulnerabilityScanner(String scanner) {
+        ConfigProvider configProvider = ConfigProvider.getInstance();
+        switch (scanner) {
+            case ScaProperties.CONFIG_PREFIX:
+                scaConfiguration = configProvider.getConfiguration(uid, ScaProperties.CONFIG_PREFIX, ScaConfig.class);
+                break;
+            case AstProperties.CONFIG_PREFIX:
+                astConfiguration = configProvider.getConfiguration(uid, AstProperties.CONFIG_PREFIX, ASTConfig.class);
+                break;
+            default:
+                throw new MachinaRuntimeException("Scanner: " + scanner + " is not yet supported");
+        }
+    }
+
+    @Then("{string} configuration on Cx-Flow side should match the remote repo configuration data")
+    public void validateScannerConfigurationProperties(String scanner) {
+        switch (scanner) {
+            case ScaProperties.CONFIG_PREFIX:
+                assertScaConfiguration();
+                break;
+            case AstProperties.CONFIG_PREFIX:
+                assertAstConfiguration();
+                break;
+            default:
+                throw new MachinaRuntimeException("Scanner: " + scanner + " is not yet supported");
+        }
+
+    }
+
+    private void assertAstConfiguration() {
+        Assert.assertEquals("https://ast.astcheckmarx.com//config-provider-test", astConfiguration.getApiUrl());
+        Assert.assertEquals("default", astConfiguration.getPreset());
+        Assert.assertFalse(astConfiguration.isIncremental());
+        Assert.assertEquals(System.getenv("JAVA_HOME"), astConfiguration.getClientSecret());
+        Assert.assertEquals("astClientId", astConfiguration.getClientId());
+    }
+
+    private void assertScaConfiguration() {
+        Assert.assertEquals("https://sca.scacheckmarx.com//config-provider-test", scaConfiguration.getAppUrl());
+        Assert.assertEquals("https://api.scacheckmarx.com//config-provider-test", scaConfiguration.getApiUrl());
+        Assert.assertEquals("https://platform.checkmarx.net//config-provider-test", scaConfiguration.getAccessControlUrl());
+        Assert.assertEquals("cxflow", scaConfiguration.getTenant());
+        Assert.assertEquals("{LOW=25, MEDIUM=18, HIGH=15}", StringUtils.join(scaConfiguration.getThresholdsSeverity()));
+        Assert.assertEquals((Double)8.5, scaConfiguration.getThresholdsScore());
+        Assert.assertEquals("[high, medium, low]", scaConfiguration.getFilterSeverity().toString());
+        Assert.assertEquals((Double)7.5, scaConfiguration.getFilterScore());
+    }
+
+    private void init() {
+        String nameSpace = "cxflowtestuser";
+        String repoName = "configProviderTestRepo";
+        String branchName = "main";
+
+        try {
+            ConfigProvider configProvider = ConfigProvider.getInstance();
+            configProvider.init(uid, new RepoReader(gitHubProperties.getApiUrl(), nameSpace,
+                    repoName, branchName,
+                    gitHubProperties.getToken(), sourceProviderType));
+        } catch (ConfigurationException e) {
+            Assert.fail("Failed to init config provider with the following error: " + e.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/config_provider/remote_repo/ConfigProviderRemoteRepoTestRunner.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/config_provider/remote_repo/ConfigProviderRemoteRepoTestRunner.java
@@ -1,0 +1,12 @@
+package com.checkmarx.flow.cucumber.integration.config_provider.remote_repo;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        features = "src/test/resources/cucumber/features/integrationTests/configProvider/remoteRepo/configProviderRemoteRepo.feature",
+        tags = "@ConfigProviderRemoteRepoFeature and not @Skip")
+public class ConfigProviderRemoteRepoTestRunner {
+}

--- a/src/test/resources/cucumber/features/integrationTests/configProvider/remoteRepo/configProviderRemoteRepo.feature
+++ b/src/test/resources/cucumber/features/integrationTests/configProvider/remoteRepo/configProviderRemoteRepo.feature
@@ -1,0 +1,13 @@
+@ConfigProviderRemoteRepoFeature
+Feature: CxFlow should read configuration from a remote repo
+
+  Scenario Outline: CxFlow should read vulnerability scanner configuration from a remote repo and initialize the scanner's config with the right values
+    Given github repo contains a Checkmarx configuration
+    When initializing config provider
+    And getting "<scanner>" config provider configuration
+    Then "<scanner>" configuration on Cx-Flow side should match the remote repo configuration data
+
+    Examples:
+      | scanner |
+      | ast    |
+      | sca    |


### PR DESCRIPTION
### Description

> Support reading bean configuration from remote repo via Config-Provider component. This PR is relevant for AST & SCA scanners via GitHub remote repo.

### References

> https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/249
>https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/222

### Testing

1. Integration & component test were added on both Cx-flow and Config-Provider component.

### Checklist

- [X] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
