### PR TITLE
fix bug tracker None not functioning as expected

### DIFF
--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -58,10 +58,11 @@ public class CxFlowRunner implements ApplicationRunner {
     private final ConfigurationOverrider configOverrider;
     private final List<VulnerabilityScanner> scanners;
     private final ThresholdValidator thresholdValidator;
-    private static final String ERROR_BREAK_MSG = "Exiting with Error code 10 due to checkmarx findings";
+    private static final String ERROR_BREAK_MSG = String.format("Exiting with Error code %d due to Checkmarx findings", ExitCode.BUILD_INTERRUPTED.getValue());
 
     @Override
     public void run(ApplicationArguments args) throws InvocationTargetException {
+
         if (!args.getOptionNames().isEmpty()) {
             try {
                 if (args.containsOption("web")) {
@@ -517,7 +518,7 @@ public class CxFlowRunner implements ApplicationRunner {
                 log.info("Fail build on Thresholds exceeded.");
                 breakBuildResult = true;
             }
-        } else if(flowProperties.isBreakBuild() && results != null && resultsService.filteredSastIssuesPresent(results)){
+        } else if(flowProperties.isBreakBuild() && resultsService.filteredSastIssuesPresent(results)){
             log.info("Build failed because some issues were found");
             breakBuildResult = true;
         }

--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -58,7 +58,7 @@ public class CxFlowRunner implements ApplicationRunner {
     private final ConfigurationOverrider configOverrider;
     private final List<VulnerabilityScanner> scanners;
     private final ThresholdValidator thresholdValidator;
-    private static final String ERROR_BREAK_MSG = "Exiting with Error code 10 due to issues present";
+    private static final String ERROR_BREAK_MSG = "Exiting with Error code 10 due to checkmarx findings";
 
     @Override
     public void run(ApplicationArguments args) throws InvocationTargetException {

--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -517,7 +517,7 @@ public class CxFlowRunner implements ApplicationRunner {
                 log.info("Fail build on Thresholds exceeded.");
                 breakBuildResult = true;
             }
-        } else if(flowProperties.isBreakBuild() && resultsService.filteredSastIssuesPresent(results)){
+        } else if(flowProperties.isBreakBuild() && results != null && resultsService.filteredSastIssuesPresent(results)){
             log.info("Build failed because some issues were found");
             breakBuildResult = true;
         }

--- a/src/main/java/com/checkmarx/flow/service/BugTrackerEventTrigger.java
+++ b/src/main/java/com/checkmarx/flow/service/BugTrackerEventTrigger.java
@@ -61,6 +61,9 @@ public class BugTrackerEventTrigger {
                 eventsWereTriggered = false;
                 break; // No action is needed
 
+            case NONE:
+                eventsWereTriggered = false;
+                break;
             default:
                 eventsWereTriggered = false;
                 log.warn("Bug-Tracker type: {} is not supported", bugTrackerType);

--- a/src/main/java/com/checkmarx/flow/service/BugTrackerEventTrigger.java
+++ b/src/main/java/com/checkmarx/flow/service/BugTrackerEventTrigger.java
@@ -58,12 +58,10 @@ public class BugTrackerEventTrigger {
 
             case JIRA:
             case CUSTOM:
+            case NONE:
                 eventsWereTriggered = false;
                 break; // No action is needed
 
-            case NONE:
-                eventsWereTriggered = false;
-                break;
             default:
                 eventsWereTriggered = false;
                 log.warn("Bug-Tracker type: {} is not supported", bugTrackerType);

--- a/src/main/java/com/checkmarx/flow/service/ResultsService.java
+++ b/src/main/java/com/checkmarx/flow/service/ResultsService.java
@@ -336,8 +336,8 @@ public class ResultsService {
     }
 
     public boolean filteredSastIssuesPresent(ScanResults results) {
-        if(results.getAdditionalDetails()==null) {
-            // assuming SCA results only
+        if(results == null || results.getAdditionalDetails()==null) {
+            // assuming no bugTracker or SCA results only
             return false;
         }
 

--- a/src/test/resources/cucumber/features/integrationTests/cli/sastCliScan.feature
+++ b/src/test/resources/cucumber/features/integrationTests/cli/sastCliScan.feature
@@ -4,6 +4,7 @@ Feature: Cx-Flow CLI SAST Integration tests
   Background: running SAST scan
     Given repository is github-sast
 
+
   Scenario Outline: Testing break-build functionality
     When running with break-build on <issue-type>
     Then run should exit with exit code <exit-code-number>
@@ -26,3 +27,10 @@ Feature: Cx-Flow CLI SAST Integration tests
       | filter-High-and-Medium | x+y             | 10          |
       | filter-only-Medium     | y               | 10          |
       | filter-invalid-cwe     | 0               | 0           |
+
+
+  Scenario: Testing SAST scans with bugTracker None
+    Given bug tracker is set to 'None'
+    When running cxflow to execute SAST scan
+    Then cxflow should not wait for scan results
+    And cxflow exit with success return code

--- a/src/test/resources/cucumber/features/integrationTests/cli/sastCliScan.feature
+++ b/src/test/resources/cucumber/features/integrationTests/cli/sastCliScan.feature
@@ -7,7 +7,7 @@ Feature: Cx-Flow CLI SAST Integration tests
 
   Scenario Outline: Testing break-build functionality
     When running with break-build on <issue-type>
-    Then run should exit with exit code <exit-code-number>
+    Then cxflow should exit with exit code: <exit-code-number>
 
     Examples:
       | issue-type                  | exit-code-number |
@@ -19,7 +19,7 @@ Feature: Cx-Flow CLI SAST Integration tests
     Given code has x High, y Medium and z low issues
     When running sast scan <filter>
     Then bugTracker contains <number of issue> issues
-    And cxflow should exit with <return code>
+    And cxflow should exit with exit code: <return code>
 
     Examples:
       | filter                 | number of issue | return code |
@@ -33,4 +33,4 @@ Feature: Cx-Flow CLI SAST Integration tests
     Given bug tracker is set to 'None'
     When running cxflow to execute SAST scan
     Then cxflow should not wait for scan results
-    And cxflow exit with success return code
+    And cxflow should exit with exit code: 0


### PR DESCRIPTION

### Description

Fix bug tracker None for SAST scanner
when bugTrracker is None CxFlow should not wait for scan results, and finish the execution with success return code

this PR come to fix the issue for SAST. additional bug added to the backlog to support bug Tracker None to SCA\AST (BUG 298)

### References

Bug Tracker of NONE not functioning as expected #445

### Testing

Added automation in 
integrationTests/cli/sastCliScan.feature

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
