### PR TITLE
Pr ofer@ast no wait on none

### DIFF
--- a/src/main/java/com/checkmarx/flow/service/ASTScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/ASTScanner.java
@@ -25,8 +25,8 @@ import java.util.Optional;
 @Slf4j
 public class ASTScanner extends AbstractASTScanner {
 
-    public ASTScanner(AstClientImpl astClient, FlowProperties flowProperties) {
-        super(astClient, flowProperties, AstProperties.CONFIG_PREFIX);
+    public ASTScanner(AstClientImpl astClient, FlowProperties flowProperties, BugTrackerEventTrigger bugTrackerEventTrigger) {
+        super(astClient, flowProperties, AstProperties.CONFIG_PREFIX, bugTrackerEventTrigger);
     }
 
     @Override

--- a/src/main/java/com/checkmarx/flow/service/SCAScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/SCAScanner.java
@@ -14,8 +14,8 @@ import java.util.Optional;
 @Service
 @Slf4j
 public class SCAScanner extends AbstractASTScanner {
-    public SCAScanner(ScaClientImpl scaClient, FlowProperties flowProperties) {
-        super(scaClient, flowProperties, ScaProperties.CONFIG_PREFIX);
+    public SCAScanner(ScaClientImpl scaClient, FlowProperties flowProperties, BugTrackerEventTrigger bugTrackerEventTrigger) {
+        super(scaClient, flowProperties, ScaProperties.CONFIG_PREFIX, bugTrackerEventTrigger);
     }
 
     @Override


### PR DESCRIPTION
### Description

when running AST or SCA scans while the bug tracker is NONE, we don't want the scan to block the PR.
the change is that now, if the bug tracker is NONE, we will run the scan and update the results in a background thread.

### References


BUG 298 - BugTracker None is not supported for AST\SCA scanners

### Testing
verified manually that PR is not blocked
verified manually that the report is updated after the scan finishes

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
