### PR TITLE
SCA filtering improvement

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.4.48"
+        CxSBSDK = "0.4.49"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.2.6.RELEASE'

--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.4.47"
+        CxSBSDK = "0.4.48"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.2.6.RELEASE'

--- a/build-cxgo.gradle
+++ b/build-cxgo.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.1.40"
+        CxSBSDK = "0.1.41"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.2.6.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.4.48"
+        CxSBSDK = "0.4.49"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.2.6.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.4.47"
+        CxSBSDK = "0.4.48"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.2.6.RELEASE'

--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -42,13 +42,12 @@ public class ConfigurationOverrider {
             BugTracker.Type.GITLABMERGE));
 
     private final FlowProperties flowProperties;
-    private final ScaProperties scaProperties;
     private final SCAScanner scaScanner;
     private final SastScanner sastScanner;
 
     public ScanRequest overrideScanRequestProperties(CxConfig override, ScanRequest request) {
         ConfigProvider configProvider = ConfigProvider.getInstance();
-        if (request == null || (!isConfigAsCodeAvailable(configProvider) && !isLegacyConfigAsCodeAvailable(override))) {
+        if (request == null || (!configProviderResultsAreAvailable(configProvider) && !configAsCodeIsAvailable(override))) {
             return request;
         }
 
@@ -75,12 +74,14 @@ public class ConfigurationOverrider {
         return request;
     }
 
-    private boolean isConfigAsCodeAvailable(ConfigProvider configProvider) {
+    private boolean configProviderResultsAreAvailable(ConfigProvider configProvider) {
         return configProvider.hasAnyConfiguration(MDC.get(FlowConstants.MAIN_MDC_ENTRY));
     }
 
-    private boolean isLegacyConfigAsCodeAvailable(CxConfig override) {
-        return override != null && !(Boolean.FALSE.equals(override.getActive()));
+    private boolean configAsCodeIsAvailable(CxConfig override) {
+        // Config-as-code should be enabled if the 'active' property is either
+        // true or null => checking against Boolean.FALSE.
+        return override != null && !Boolean.FALSE.equals(override.getActive());
     }
 
     private void applyFlowOverride(FlowOverride fo, ScanRequest request, Map<String, String> overrideReport) {

--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -15,7 +15,9 @@ import com.checkmarx.sdk.config.CxProperties;
 import com.checkmarx.sdk.config.ScaConfig;
 import com.checkmarx.sdk.config.ScaProperties;
 import com.checkmarx.sdk.dto.CxConfig;
+import com.checkmarx.sdk.dto.Filter;
 import com.checkmarx.sdk.dto.Sca;
+import com.checkmarx.sdk.dto.filtering.EngineFilterConfiguration;
 import com.checkmarx.sdk.dto.filtering.FilterConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -145,13 +147,17 @@ public class ConfigurationOverrider {
                     override.getCwe(),
                     override.getCategory(),
                     override.getStatus());
-            FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null);
-            request.setFilter(filter);
+            FilterConfiguration filterConfig = filterFactory.getFilter(controllerRequest, null);
+            request.setFilter(filterConfig);
 
             String filterDescr;
-            if (CollectionUtils.isNotEmpty(filter.getSimpleFilters())) {
-                filterDescr = filter.getSimpleFilters()
-                        .stream()
+            List<Filter> simpleFilters = Optional.ofNullable(filterConfig)
+                    .map(FilterConfiguration::getSastFilters)
+                    .map(EngineFilterConfiguration::getSimpleFilters)
+                    .orElse(null);
+
+            if (CollectionUtils.isNotEmpty(simpleFilters)) {
+                filterDescr = simpleFilters.stream()
                         .map(Object::toString)
                         .collect(Collectors.joining(","));
             } else {

--- a/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
+++ b/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
@@ -2,33 +2,38 @@ package com.checkmarx.flow.utils;
 
 import com.checkmarx.flow.config.JiraProperties;
 import com.checkmarx.flow.constants.SCATicketingConstants;
-import com.checkmarx.flow.dto.*;
+import com.checkmarx.flow.dto.BugTracker;
+import com.checkmarx.flow.dto.Field;
+import com.checkmarx.flow.dto.FlowOverride;
+import com.checkmarx.flow.dto.RepoIssue;
+import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.exception.MachinaRuntimeException;
 import com.checkmarx.sdk.config.Constants;
 import com.checkmarx.sdk.dto.Filter;
 import com.checkmarx.sdk.dto.ScanResults;
 import com.checkmarx.sdk.dto.ast.SCAResults;
-import com.cx.restclient.ast.dto.sast.report.FindingNode;
 import com.checkmarx.sdk.dto.cx.CxScanSummary;
+import com.cx.restclient.ast.dto.sast.report.FindingNode;
 import com.cx.restclient.ast.dto.sca.report.Finding;
 import com.cx.restclient.ast.dto.sca.report.Package;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
-
 import org.slf4j.Logger;
-
 import org.springframework.web.bind.annotation.RequestParam;
 
 import javax.validation.constraints.NotNull;
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-
 import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -59,14 +64,12 @@ public class ScanUtils {
 
 
     private ScanUtils() {
-        // this is to hide the public constractor
+        // this is to hide the public constructor
     }
     /**
      * Function used to determine if file extension of full filename is preset in list
      *
-     * @param list
      * @param value - extension of file, or full filename
-     * @return
      */
     public static boolean fileListContains(List<String> list, String value){
         for(String s: list){
@@ -99,7 +102,7 @@ public class ScanUtils {
             xIssueBuilder.cwe("" + finding.getCweID());
             xIssueBuilder.severity(finding.getSeverity());
             xIssueBuilder.vulnerability(finding.getQueryName());
-            if(finding.getNodes().size() >0) {
+            if(!finding.getNodes().isEmpty()) {
                 xIssueBuilder.file(finding.getNodes().get(0).getFileName());
             }
             xIssueBuilder.vulnerabilityStatus(finding.getState());
@@ -174,8 +177,6 @@ public class ScanUtils {
 
     /**
      * Check if string is empty or null
-     * @param str
-     * @return
      */
     public static boolean empty(String str) {
         return str == null || str.trim().isEmpty();
@@ -190,8 +191,6 @@ public class ScanUtils {
     }
     /**
      * Check if list is empty or null
-     * @param list
-     * @return
      */
     public static boolean empty(List<?> list) {
         return (list == null) || list.isEmpty();
@@ -421,9 +420,6 @@ public class ScanUtils {
 
     /**
      * Creates a map of GitLab Issues
-     *
-     * @param issues
-     * @return
      */
     public static Map<String, ? extends RepoIssue> getRepoIssueMap(List<? extends RepoIssue> issues, String prefix) {
         Map<String, RepoIssue> map = new HashMap<>();
@@ -438,7 +434,6 @@ public class ScanUtils {
     /**
      *  Parse cx custom field which is csv for custom field mapping in jira:
      *  type, name, jira-field-name, jira-field-value, jira-field-type (separated by ; for multiple)
-     * @param cxFields
      * @return List of Fields
      */
     public static List<Field> getCustomFieldsFromCx(@NotNull String cxFields){
@@ -510,7 +505,7 @@ public class ScanUtils {
             int port = uri.getPort();
             hostWithProtocol = uri.getScheme() + "//"  + uri.getHost() + (port > 0 ? ":" + port : "");
         } catch (URISyntaxException e) {
-            log.debug("Could not parse given URL" + url, e);
+            log.debug(String.format("Could not parse given URL: %s", url), e);
         }
         return hostWithProtocol;
     }
@@ -585,8 +580,6 @@ public class ScanUtils {
 
     /**
      * Returns the string with first letter in uppercase and the remainder in lowercase
-     * @param s
-     * @return
      */
     public static String toProperCase(String s) {
         return s.substring(0, 1).toUpperCase() +

--- a/src/test/java/com/checkmarx/flow/controller/FlowControllerTest.java
+++ b/src/test/java/com/checkmarx/flow/controller/FlowControllerTest.java
@@ -151,7 +151,7 @@ public class FlowControllerTest {
         ArgumentCaptor<ScanRequest> captor = ArgumentCaptor.forClass(ScanRequest.class);
         verify(flowService).initiateAutomation(captor.capture());
         ScanRequest actual = captor.getValue();
-        assertScanApiFilters(actual.getFilter().getSimpleFilters(), filters);
+        assertScanApiFilters(actual.getFilter().getSastFilters().getSimpleFilters(), filters);
         assertOKResponse(response);
     }
 
@@ -218,13 +218,14 @@ public class FlowControllerTest {
 
     private void assertScanResultsFilters(List<String> wanted, ScanRequest scanRequest, Filter.Type filterType) {
         List<Filter> filtersForType = scanRequest.getFilter()
+                .getSastFilters()
                 .getSimpleFilters()
                 .stream()
                 .filter(f -> f.getType().equals(filterType))
                 .collect(Collectors.toList());
 
         for (String wantedStr : wanted) {
-            boolean found = !(filtersForType.stream().noneMatch(f -> f.getValue().equals(wantedStr)));
+            boolean found = filtersForType.stream().anyMatch(f -> f.getValue().equals(wantedStr));
             Assert.assertTrue(String.format("Filter from type: %s and value %s was not found in call to FlowService", filterType, wanted), found);
         }
     }

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
@@ -311,10 +311,10 @@ public class CxConfigSteps {
     }
 
     private void validateRequestFilter() {
-        List<Filter> filters = request.getFilter().getSimpleFilters();
+        List<Filter> filters = request.getFilter().getSastFilters().getSimpleFilters();
         List<String> filterSeverity = getFilter(filters, Filter.Type.SEVERITY);
         List<String> filterCwe = getFilter(filters, Filter.Type.CWE);
-        List<String> filterCatergory = getFilter(filters, Filter.Type.TYPE);
+        List<String> filterCategory = getFilter(filters, Filter.Type.TYPE);
 
         boolean asExpected = false;
         switch (branch) {
@@ -323,20 +323,20 @@ public class CxConfigSteps {
                 asExpected = filterSeverity.size() == 2 &&
                         filterSeverity.contains(FindingSeverity.HIGH.toString()) &&
                         filterSeverity.contains(FindingSeverity.MEDIUM.toString()) &&
-                        filterCwe.isEmpty() && filterCatergory.isEmpty();
+                        filterCwe.isEmpty() && filterCategory.isEmpty();
                 break;
             case "test8":
                 //Filter cwe: "79", "89"
                 asExpected = filterCwe.size() == 2 &&
                         filterCwe.contains(CWE_79) &&
                         filterCwe.contains(CWE_89) &&
-                        filterCatergory.isEmpty() && filterSeverity.isEmpty();
+                        filterCategory.isEmpty() && filterSeverity.isEmpty();
                 break;
             case "test9":
                 // filter category: "XSS_Reflected", "SQL_Injection"
-                asExpected = filterCatergory.size() == 2 &&
-                        filterCatergory.contains(XSS_REFLECTED) &&
-                        filterCatergory.contains(SQL_INJECTION) &&
+                asExpected = filterCategory.size() == 2 &&
+                        filterCategory.contains(XSS_REFLECTED) &&
+                        filterCategory.contains(SQL_INJECTION) &&
                         filterCwe.isEmpty() && filterSeverity.isEmpty();
                 break;
             case "test10":
@@ -346,9 +346,9 @@ public class CxConfigSteps {
                 asExpected = filterCwe.size() == 2 &&
                         filterCwe.contains(CWE_79) &&
                         filterCwe.contains(CWE_89) &&
-                        filterCatergory.size() == 2 &&
-                        filterCatergory.contains(XSS_REFLECTED) &&
-                        filterCatergory.contains(SQL_INJECTION) &&
+                        filterCategory.size() == 2 &&
+                        filterCategory.contains(XSS_REFLECTED) &&
+                        filterCategory.contains(SQL_INJECTION) &&
                         filterSeverity.isEmpty();
                 break;
             case "test11":
@@ -358,9 +358,9 @@ public class CxConfigSteps {
                         filterSeverity.size() == 2 &&
                                 filterSeverity.contains(FindingSeverity.HIGH.toString()) &&
                                 filterSeverity.contains(FindingSeverity.MEDIUM.toString()) &&
-                                filterCatergory.size() == 2 &&
-                                filterCatergory.contains(XSS_REFLECTED) &&
-                                filterCatergory.contains(SQL_INJECTION) &&
+                                filterCategory.size() == 2 &&
+                                filterCategory.contains(XSS_REFLECTED) &&
+                                filterCategory.contains(SQL_INJECTION) &&
                                 filterCwe.isEmpty();
                 break;
             case "test12":
@@ -368,7 +368,7 @@ public class CxConfigSteps {
                 asExpected = filterSeverity.size() == 2 &&
                         filterSeverity.contains(FindingSeverity.HIGH.toString()) &&
                         filterSeverity.contains(FindingSeverity.LOW.toString()) &&
-                        filterCwe.isEmpty() && filterCatergory.isEmpty();
+                        filterCwe.isEmpty() && filterCategory.isEmpty();
                 break;
             default:
                 fail("Invalid Branch");

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/sast/config/OverwritingProjectConfigSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/sast/config/OverwritingProjectConfigSteps.java
@@ -109,7 +109,7 @@ public class OverwritingProjectConfigSteps {
 
     @And("project has the {string} preset and the {string} scan configuration")
     public void projectPresetIs(String preset, String config) {
-        cxClientSpy.createScanSetting(projectId, presetMapping.get(preset), configMapping.get(config));
+        cxClientSpy.createScanSetting(projectId, presetMapping.get(preset), configMapping.get(config), 0);
     }
 
     @And("CxFlow config has the {string} preset and the {string} scan configuration")

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/sca_scanner/ScaCommonSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/sca_scanner/ScaCommonSteps.java
@@ -6,8 +6,9 @@ import com.checkmarx.flow.service.SCAScanner;
 import com.checkmarx.sdk.config.ScaProperties;
 import lombok.RequiredArgsConstructor;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 public class ScaCommonSteps {
@@ -30,7 +31,9 @@ public class ScaCommonSteps {
                 .build();
     }
 
-    protected ArrayList<String> createFiltersListFromString(String filters) {
-        return new ArrayList<>(Arrays.asList(filters.split(",")));
+    protected List<String> createFiltersListFromString(String filters) {
+        return Arrays.stream(filters.split(","))
+                .map(String::trim)
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/checkmarx/flow/utils/ScanUtilsTest.java
+++ b/src/test/java/com/checkmarx/flow/utils/ScanUtilsTest.java
@@ -41,7 +41,7 @@ public class ScanUtilsTest {
         scaProperties = new ScaProperties();
 
         jiraProperties = new JiraProperties();
-        configOverrider = new ConfigurationOverrider(flowProperties, scaProperties, scaScanner, sastScanner);
+        configOverrider = new ConfigurationOverrider(flowProperties, scaScanner, sastScanner);
     }
     @Test
     public void testCxConfigOverride(){
@@ -104,8 +104,8 @@ public class ScanUtilsTest {
         assertEquals("test app", request.getApplication());
         assertEquals(2, request.getActiveBranches().size());
         assertNotNull(request.getFilter());
-        assertNotNull(request.getFilter().getSimpleFilters());
-        assertFalse(request.getFilter().getSimpleFilters().isEmpty());
+        assertNotNull(request.getFilter().getSastFilters().getSimpleFilters());
+        assertFalse(request.getFilter().getSastFilters().getSimpleFilters().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
### Description

Implemented using common filtering mechanism for SCA, instead of custom logic. The changes are based on new CxSDK and CxGo SDK functionality.

### References

Work item [299](https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/299/)

### Testing

Test scenario is defined in scanResultsProcessing.feature: "Apply filter severity and filter score on SCA results".

