### PR TITLE
Create directory path if not exist + Fix SCA cli scan test

### DIFF
--- a/src/main/java/com/checkmarx/flow/custom/CsvIssueTracker.java
+++ b/src/main/java/com/checkmarx/flow/custom/CsvIssueTracker.java
@@ -35,10 +35,10 @@ public class CsvIssueTracker extends ImmutableIssueTracker {
     public void init(ScanRequest request, ScanResults results) throws MachinaException {
         String filename = filenameFormatter.formatPath(request, properties.getFileNameFormat(), properties.getDataFolder());
         request.setFilename(filename);
-        log.info("Creating file {}", filename);
-        log.info("Deleting if already exists");
+        log.info("Creating file {}, Deleting if already exists", filename);
         try {
             Files.deleteIfExists(Paths.get(filename));
+            Files.createDirectories(Paths.get(properties.getDataFolder()));
             Files.createFile(Paths.get(filename));
             if (properties.isIncludeHeader()) {
                 log.debug("Writing headers for CSV");

--- a/src/main/java/com/checkmarx/flow/custom/CsvIssueTracker.java
+++ b/src/main/java/com/checkmarx/flow/custom/CsvIssueTracker.java
@@ -46,7 +46,7 @@ public class CsvIssueTracker extends ImmutableIssueTracker {
                 Files.write(Paths.get(request.getFilename()), headers.getBytes());
             }
         } catch (IOException e) {
-            log.error("Issue deleting existing file or writing initial {}", filename, e);
+            log.error("Issue deleting or creating file {}", filename,e);
         }
     }
 

--- a/src/main/java/com/checkmarx/flow/custom/CxXMLIssueTracker.java
+++ b/src/main/java/com/checkmarx/flow/custom/CxXMLIssueTracker.java
@@ -29,13 +29,13 @@ public class CxXMLIssueTracker extends ImmutableIssueTracker {
     public void init(ScanRequest request, ScanResults results) throws MachinaException {
         String filename = filenameFormatter.formatPath(request, properties.getFileNameFormat(), properties.getDataFolder());
         request.setFilename(filename);
-        log.info("Creating file {}", filename);
-        log.info("Deleting if already exists");
+        log.info("Creating file {}, Deleting if already exists", filename);
         try {
             Files.deleteIfExists(Paths.get(filename));
+            Files.createDirectories(Paths.get(properties.getDataFolder()));
             Files.createFile(Paths.get(filename));
         } catch (IOException e){
-            log.error("Issue deleting existing file {}", filename, e);
+            log.error("Issue deleting or creating file {}", filename,e);
         }
     }
 

--- a/src/main/java/com/checkmarx/flow/custom/JsonIssueTracker.java
+++ b/src/main/java/com/checkmarx/flow/custom/JsonIssueTracker.java
@@ -29,14 +29,15 @@ public class JsonIssueTracker implements IssueTracker {
         if (properties != null) {
             if(request != null) {
                 String filename = filenameFormatter.formatPath(request, properties.getFileNameFormat(), properties.getDataFolder());
+
                 request.setFilename(filename);
-                log.info("Creating file {}", filename);
-                log.info("Deleting if already exists");
+                log.info("Creating file {}, Deleting if already exists", filename);
                 try {
                     Files.deleteIfExists(Paths.get(filename));
+                    Files.createDirectories(Paths.get(properties.getDataFolder()));
                     Files.createFile(Paths.get(filename));
                 } catch (IOException e) {
-                    log.error("Issue deleting existing file {}", filename, e);
+                    log.error("Issue deleting or creating file {}", filename,e);
                 }
             } else {
                 log.error("Filename or Request is not set");

--- a/src/test/resources/cucumber/features/integrationTests/cli/scaCliScan.feature
+++ b/src/test/resources/cucumber/features/integrationTests/cli/scaCliScan.feature
@@ -71,4 +71,4 @@ Feature: SCA support in CxFlow command-line
             | filters         | expected issue count |
             | Medium          | 3                    |
             | Medium,Low      | 4                    |
-            | none            | 54                   |
+            | none            | 55                   |


### PR DESCRIPTION
### Description

1. If bug tracker set to Json/CSV/XML and the directory path mentioned in application.yml doesn't exist cx-flow app will create a new directory path before file creation.

- In case the directory path already exists none will happen.  

2. Fix SCA cli scan test - Due to SCA scan update expected issue count set to 55

### References

issue 1
src/main/java/com/checkmarx/flow/custom/CsvIssueTracker.java
src/main/java/com/checkmarx/flow/custom/CxXMLIssueTracker.java
src/main/java/com/checkmarx/flow/custom/JsonIssueTracker.java

issue 2 
src/test/resources/cucumber/features/integrationTests/cli/scaCliScan.feature

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
