### PR TITLE
Pr feature/sarif sca

### DIFF
--- a/src/main/java/com/checkmarx/flow/config/SarifProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/SarifProperties.java
@@ -13,8 +13,11 @@ import java.util.Map;
 @Validated
 public class SarifProperties {
     private String filePath = "./cx.sarif";
-    private String scannerName = "Checkmarx";
-    private String organization = "Checkmarx";
+    private String scaScannerName = "Checkmarx - SCA";
+    private String sastScannerName = "Checkmarx - SAST";
+    private String scaOrganization = "Checkmarx - SCA";
+    private String sastOrganization = "Checkmarx - SAST";
+
     private String sarifSchema="https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json";
     private String sarifVersion = "2.1.0";
     private String semanticVersion = "1.0.0";
@@ -36,24 +39,41 @@ public class SarifProperties {
         this.filePath = filePath;
     }
 
-    public String getScannerName() {
-        return scannerName;
+
+    public String getScaScannerName() {
+        return scaScannerName;
     }
 
-    public void setScannerName(String scannerName) {
-        this.scannerName = scannerName;
+    public void setScaScannerName(String scaScannerName) {
+        this.scaScannerName = scaScannerName;
     }
 
-    public String getOrganization() {
-        return organization;
+    public String getSastScannerName() {
+        return sastScannerName;
     }
 
-    public void setOrganization(String organization) {
-        this.organization = organization;
+    public void setSastScannerName(String sastScannerName) {
+        this.sastScannerName = sastScannerName;
     }
 
     public String getSarifSchema() {
         return sarifSchema;
+    }
+
+    public String getScaOrganization() {
+        return scaOrganization;
+    }
+
+    public void setScaOrganization(String scaOrganization) {
+        this.scaOrganization = scaOrganization;
+    }
+
+    public String getSastOrganization() {
+        return sastOrganization;
+    }
+
+    public void setSastOrganization(String sastOrganization) {
+        this.sastOrganization = sastOrganization;
     }
 
     public void setSarifSchema(String sarifSchema) {

--- a/src/main/java/com/checkmarx/flow/custom/SarifIssueTracker.java
+++ b/src/main/java/com/checkmarx/flow/custom/SarifIssueTracker.java
@@ -41,205 +41,16 @@ public class SarifIssueTracker extends ImmutableIssueTracker {
     @Override
     public void complete(ScanRequest request, ScanResults results) throws MachinaException {
         log.info("Finalizing SARIF output");
-        List<Rule> sastScanrules = Lists.newArrayList();
-        List<Result> sastScanresultList = Lists.newArrayList();
-        List<Rule> scaScanrules = Lists.newArrayList();
-        List<Result> scaScanresultList = Lists.newArrayList();
+        List<SarifVulnerability> run=Lists.newArrayList();
         if(results.getXIssues() != null) {
+            log.info("Generating SAST Sarif Report");
+            generateSastResults(results,run);
             // Filter issues without false-positives
             // Build the run object
-            List<ScanResults.XIssue> filteredXIssues =
-                    results.getXIssues()
-                            .stream()
-                            .filter(x -> !x.isAllFalsePositive())
-                            .collect(Collectors.toList());
-            //Distinct list of Vulns (Rules)
-            List<ScanResults.XIssue> filteredByVulns =
-                    results.getXIssues()
-                            .stream()
-                            .collect(Collectors.toCollection(() ->
-                                    new TreeSet<>(Comparator.comparing(ScanResults.XIssue::getVulnerability))))
-                            .stream()
-                            .filter(x -> !x.isAllFalsePositive())
-                            .collect(Collectors.toList());
-            // Build the collection of the rules objects (Vulnerabilities)
-            sastScanrules = filteredByVulns.stream().map(i -> Rule.builder()
-                    .id(i.getVulnerability())
-                    .name(i.getVulnerability())
-                    .shortDescription(ShortDescription.builder().text(i.getVulnerability()).build())
-                    .fullDescription(FullDescription.builder().text(i.getVulnerability()).build())
-                    .help(Help.builder()
-                            .markdown(String.format("[%s Details](%s)",
-                                    i.getVulnerability(),
-                                    i.getAdditionalDetails().get("recommendedFix")))
-                            .text((String) i.getAdditionalDetails().get("recommendedFix"))
-                            .build())
-                    .properties(Properties.builder()
-                            .tags(Arrays.asList("security", "external/cwe/cwe-".concat(i.getCwe())))
-                            .build())
-                    .build()).collect(Collectors.toList());
-            //All issues to create the results/locations that are not all false positive
-
-            filteredXIssues.forEach(
-                    issue -> {
-                        List<Location> locations = Lists.newArrayList();
-                        issue.getDetails().forEach((k, v) -> {
-                            if (!v.isFalsePositive()) {
-                                locations.add(Location.builder()
-                                        .physicalLocation(PhysicalLocation.builder()
-                                                .artifactLocation(ArtifactLocation.builder()
-                                                        .uri(issue.getFilename())
-                                                        .build())
-                                                .region(Region.builder()
-                                                        .startLine(k)
-                                                        .endLine(k)
-                                                        .build())
-                                                .build())
-                                        .build());
-
-                            }
-                        });
-                        // Build collection of the results -> locations
-                        sastScanresultList.add(
-                                Result.builder()
-                                        .level(properties.getSeverityMap().get(issue.getSeverity()) != null ? properties.getSeverityMap().get(issue.getSeverity()) : DEFAULT_LEVEL)
-                                        .locations(locations)
-                                        .message(Message.builder()
-                                                .text(issue.getDescription())
-                                                .build())
-                                        .ruleId(issue.getVulnerability())
-                                        .build()
-                        );
-
-                    }
-            );
         }
         if(results.getScaResults() != null ){
-
-            Map<String, List<Finding>> findingsMap = results.getScaResults()
-                    .getFindings().stream().collect(Collectors.groupingBy(Finding::getPackageId));
-
-            List<Package> packages = new ArrayList<>(results.getScaResults()
-                    .getPackages());
-
-            Map<String,Package> map = new HashMap<>();
-            for(Package p : packages) map.put(p.getId(),p);
-
-
-
-            for (Map.Entry<String, List<Finding>> entry : findingsMap.entrySet()) {
-                String key = entry.getKey();
-                StringBuilder markDownValue = new StringBuilder();
-                markDownValue.append(String.format(MARKDOWN_TABLE_FORMAT, "Reference", "Description", "CVE Name", "Score")).append("\r");
-                markDownValue.append(String.format(MARKDOWN_TABLE_FORMAT,"---","---","---","---")).append("\r");
-                List<Finding> val = entry.getValue();
-                List<String> tags = new ArrayList<>();
-                val.forEach( v -> {
-                    markDownValue.append(String.format(MARKDOWN_TABLE_FORMAT,v.getReferences(),v.getDescription(),v.getCveName(),v.getScore())).append("\r");
-                    if(!tags.contains(String.valueOf(v.getScore())))
-                        tags.add(String.valueOf(v.getScore()));
-                });
-                tags.replaceAll(s -> "CVSS-" + s);
-                tags.add("security");
-                Rule rule = Rule.builder().id(key)
-                        .shortDescription(ShortDescription.builder().text(key).build())
-                        .fullDescription(FullDescription.builder().text(key).build())
-                        .help(Help.builder().markdown(String.valueOf(markDownValue).replace("\n"," ").replace("[","").replace("]","")).text(String.valueOf(markDownValue).replace("\n"," ")).build())
-                        .properties(Properties.builder().tags(tags).build())
-                        .build();
-
-                List<Location> locations = Lists.newArrayList();
-                List<String> locationString = Lists.newArrayList();
-                map.get(key).getLocations().forEach(k -> {
-                    if(!locationString.contains(k)) {
-                        locationString.add(k);
-                    }
-                });
-
-
-                locations.add(Location.builder()
-                        .physicalLocation(PhysicalLocation.builder()
-                                .artifactLocation(ArtifactLocation.builder()
-                                        .uri(locationString.stream().map(String::valueOf).collect(Collectors.joining(",")))
-                                        .build())
-                                .build())
-                        .build());
-
-                // Build collection of the results -> locations
-                scaScanresultList.add(
-                        Result.builder()
-                                .level(properties.getSeverityMap().get(map.get(key).getSeverity().toString()) != null ? properties.getSeverityMap().get(map.get(key).getSeverity().toString()) : DEFAULT_LEVEL)
-                                .locations(locations)
-                                .message(Message.builder()
-                                        .text(key)
-                                        .build())
-                                .ruleId(key)
-                                .build()
-                );
-
-                scaScanrules.add(rule);
-
-
-            }
-        }
-
-        List<SarifVulnerability> run=Lists.newArrayList();
-        if(results.getScaResults() != null && results.getXIssues() != null) {
-            run.add(SarifVulnerability
-                    .builder()
-                    .tool(Tool.builder()
-                            .driver(Driver.builder()
-                                    .name(properties.getScaScannerName())
-                                    .organization(properties.getScaOrganization())
-                                    .semanticVersion(properties.getSemanticVersion())
-                                    .rules(scaScanrules)
-                                    .build())
-                            .build())
-                    .results(scaScanresultList)
-                    .build());
-
-            run.add(SarifVulnerability
-                    .builder()
-                    .tool(Tool.builder()
-                            .driver(Driver.builder()
-                                    .name(properties.getSastScannerName())
-                                    .organization(properties.getSastOrganization())
-                                    .semanticVersion(properties.getSemanticVersion())
-                                    .rules(sastScanrules)
-                                    .build())
-                            .build())
-                    .results(sastScanresultList)
-                    .build());
-
-        }
-
-        else if (results.getXIssues() != null) {
-            run.add(SarifVulnerability
-                    .builder()
-                    .tool(Tool.builder()
-                            .driver(Driver.builder()
-                                    .name(properties.getSastScannerName())
-                                    .organization(properties.getSastOrganization())
-                                    .semanticVersion(properties.getSemanticVersion())
-                                    .rules(sastScanrules)
-                                    .build())
-                            .build())
-                    .results(sastScanresultList)
-                    .build());
-        }
-        else {
-            run.add(SarifVulnerability
-                    .builder()
-                    .tool(Tool.builder()
-                            .driver(Driver.builder()
-                                    .name(properties.getScaScannerName())
-                                    .organization(properties.getScaOrganization())
-                                    .semanticVersion(properties.getSemanticVersion())
-                                    .rules(scaScanrules)
-                                    .build())
-                            .build())
-                    .results(scaScanresultList)
-                    .build());
+            log.info("Generating SCA Sarif Report");
+            generateScaResults(results,run);
         }
 
         // Build the report
@@ -252,6 +63,167 @@ public class SarifIssueTracker extends ImmutableIssueTracker {
         writeJsonOutput(request, report, log);
     }
 
+    private void generateScaResults(ScanResults results, List<SarifVulnerability> run) {
+        List<Rule> scaScanrules = Lists.newArrayList();
+        List<Result> scaScanresultList = Lists.newArrayList();
+        Map<String, List<Finding>> findingsMap = results.getScaResults()
+                .getFindings().stream().collect(Collectors.groupingBy(Finding::getPackageId));
+
+        List<Package> packages = new ArrayList<>(results.getScaResults()
+                .getPackages());
+
+        Map<String, Package> map = new HashMap<>();
+        for (Package p : packages) map.put(p.getId(), p);
+
+
+        for (Map.Entry<String, List<Finding>> entry : findingsMap.entrySet()) {
+            String key = entry.getKey();
+            StringBuilder markDownValue = new StringBuilder();
+            markDownValue.append(String.format(MARKDOWN_TABLE_FORMAT, "Reference", "Description", "CVE Name", "Score")).append("\r");
+            markDownValue.append(String.format(MARKDOWN_TABLE_FORMAT, "---", "---", "---", "---")).append("\r");
+            List<Finding> val = entry.getValue();
+            List<String> tags = new ArrayList<>();
+            val.forEach(v -> {
+                markDownValue.append(String.format(MARKDOWN_TABLE_FORMAT, v.getReferences(), v.getDescription(), v.getCveName(), v.getScore())).append("\r");
+                if (!tags.contains(String.valueOf(v.getScore())))
+                    tags.add(String.valueOf(v.getScore()));
+            });
+            tags.replaceAll(s -> "CVSS-" + s);
+            tags.add("security");
+            Rule rule = Rule.builder().id(key)
+                    .shortDescription(ShortDescription.builder().text(key).build())
+                    .fullDescription(FullDescription.builder().text(key).build())
+                    .help(Help.builder().markdown(String.valueOf(markDownValue).replace("\n", " ").replace("[", "").replace("]", "")).text(String.valueOf(markDownValue).replace("\n", " ")).build())
+                    .properties(Properties.builder().tags(tags).build())
+                    .build();
+
+            List<Location> locations = Lists.newArrayList();
+            List<String> locationString = Lists.newArrayList();
+            map.get(key).getLocations().forEach(k -> {
+                if (!locationString.contains(k)) {
+                    locationString.add(k);
+                }
+            });
+
+
+            locations.add(Location.builder()
+                    .physicalLocation(PhysicalLocation.builder()
+                            .artifactLocation(ArtifactLocation.builder()
+                                    .uri(locationString.stream().map(String::valueOf).collect(Collectors.joining(",")))
+                                    .build())
+                            .build())
+                    .build());
+
+            // Build collection of the results -> locations
+            scaScanresultList.add(
+                    Result.builder()
+                            .level(properties.getSeverityMap().get(map.get(key).getSeverity().toString()) != null ? properties.getSeverityMap().get(map.get(key).getSeverity().toString()) : DEFAULT_LEVEL)
+                            .locations(locations)
+                            .message(Message.builder()
+                                    .text(key)
+                                    .build())
+                            .ruleId(key)
+                            .build()
+            );
+
+            scaScanrules.add(rule);
+
+        }
+        run.add(SarifVulnerability
+                .builder()
+                .tool(Tool.builder()
+                        .driver(Driver.builder()
+                                .name(properties.getScaScannerName())
+                                .organization(properties.getScaOrganization())
+                                .semanticVersion(properties.getSemanticVersion())
+                                .rules(scaScanrules)
+                                .build())
+                        .build())
+                .results(scaScanresultList)
+                .build());
+    }
+
+    private void generateSastResults(ScanResults results, List<SarifVulnerability> run) {
+        List<Rule> sastScanrules;
+        List<Result> sastScanresultList = Lists.newArrayList();
+        List<ScanResults.XIssue> filteredXIssues =
+                results.getXIssues()
+                        .stream()
+                        .filter(x -> !x.isAllFalsePositive())
+                        .collect(Collectors.toList());
+        //Distinct list of Vulns (Rules)
+        List<ScanResults.XIssue> filteredByVulns =
+                results.getXIssues()
+                        .stream()
+                        .collect(Collectors.toCollection(() ->
+                                new TreeSet<>(Comparator.comparing(ScanResults.XIssue::getVulnerability))))
+                        .stream()
+                        .filter(x -> !x.isAllFalsePositive())
+                        .collect(Collectors.toList());
+        // Build the collection of the rules objects (Vulnerabilities)
+        sastScanrules = filteredByVulns.stream().map(i -> Rule.builder()
+                .id(i.getVulnerability())
+                .name(i.getVulnerability())
+                .shortDescription(ShortDescription.builder().text(i.getVulnerability()).build())
+                .fullDescription(FullDescription.builder().text(i.getVulnerability()).build())
+                .help(Help.builder()
+                        .markdown(String.format("[%s Details](%s)",
+                                i.getVulnerability(),
+                                i.getAdditionalDetails().get("recommendedFix")))
+                        .text((String) i.getAdditionalDetails().get("recommendedFix"))
+                        .build())
+                .properties(Properties.builder()
+                        .tags(Arrays.asList("security", "external/cwe/cwe-".concat(i.getCwe())))
+                        .build())
+                .build()).collect(Collectors.toList());
+        //All issues to create the results/locations that are not all false positive
+
+        filteredXIssues.forEach(
+                issue -> {
+                    List<Location> locations = Lists.newArrayList();
+                    issue.getDetails().forEach((k, v) -> {
+                        if (!v.isFalsePositive()) {
+                            locations.add(Location.builder()
+                                    .physicalLocation(PhysicalLocation.builder()
+                                            .artifactLocation(ArtifactLocation.builder()
+                                                    .uri(issue.getFilename())
+                                                    .build())
+                                            .region(Region.builder()
+                                                    .startLine(k)
+                                                    .endLine(k)
+                                                    .build())
+                                            .build())
+                                    .build());
+
+                        }
+                    });
+                    // Build collection of the results -> locations
+                    sastScanresultList.add(
+                            Result.builder()
+                                    .level(properties.getSeverityMap().get(issue.getSeverity()) != null ? properties.getSeverityMap().get(issue.getSeverity()) : DEFAULT_LEVEL)
+                                    .locations(locations)
+                                    .message(Message.builder()
+                                            .text(issue.getDescription())
+                                            .build())
+                                    .ruleId(issue.getVulnerability())
+                                    .build()
+                    );
+
+                }
+        );
+        run.add(SarifVulnerability
+                .builder()
+                .tool(Tool.builder()
+                        .driver(Driver.builder()
+                                .name(properties.getSastScannerName())
+                                .organization(properties.getSastOrganization())
+                                .semanticVersion(properties.getSemanticVersion())
+                                .rules(sastScanrules)
+                                .build())
+                        .build())
+                .results(sastScanresultList)
+                .build());
+    }
 
 
     @Data

--- a/src/main/java/com/checkmarx/flow/custom/SarifIssueTracker.java
+++ b/src/main/java/com/checkmarx/flow/custom/SarifIssueTracker.java
@@ -79,12 +79,12 @@ public class SarifIssueTracker extends ImmutableIssueTracker {
         for (Map.Entry<String, List<Finding>> entry : findingsMap.entrySet()) {
             String key = entry.getKey();
             StringBuilder markDownValue = new StringBuilder();
-            markDownValue.append(String.format(MARKDOWN_TABLE_FORMAT, "Reference", "Description", "CVE Name", "Score")).append("\r");
+            markDownValue.append(String.format(MARKDOWN_TABLE_FORMAT, "CVE Name", "Description", "Score", "References")).append("\r");
             markDownValue.append(String.format(MARKDOWN_TABLE_FORMAT, "---", "---", "---", "---")).append("\r");
             List<Finding> val = entry.getValue();
             List<String> tags = new ArrayList<>();
             val.forEach(v -> {
-                markDownValue.append(String.format(MARKDOWN_TABLE_FORMAT, v.getReferences(), v.getDescription(), v.getCveName(), v.getScore())).append("\r");
+                markDownValue.append(String.format(MARKDOWN_TABLE_FORMAT, v.getCveName(), v.getDescription(), v.getScore(), v.getReferences())).append("\r");
                 if (!tags.contains(String.valueOf(v.getScore())))
                     tags.add(String.valueOf(v.getScore()));
             });

--- a/src/main/java/com/checkmarx/flow/custom/SarifIssueTracker.java
+++ b/src/main/java/com/checkmarx/flow/custom/SarifIssueTracker.java
@@ -5,14 +5,19 @@ import com.checkmarx.sdk.dto.ScanResults;
 import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.exception.MachinaException;
 import com.checkmarx.flow.service.FilenameFormatter;
+import com.cx.restclient.ast.dto.sca.report.Finding;
+import com.cx.restclient.ast.dto.sca.report.Package;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import com.google.common.collect.Lists;
 import lombok.Builder;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
 import java.util.*;
+
 import java.util.stream.Collectors;
 
 /**
@@ -26,6 +31,7 @@ public class SarifIssueTracker extends ImmutableIssueTracker {
     private final SarifProperties properties;
     private final FilenameFormatter filenameFormatter;
     private static final String DEFAULT_LEVEL = "error";
+    private static final String MARKDOWN_TABLE_FORMAT = "| %s | %s | %s | %s |";
 
     @Override
     public void init(ScanRequest request, ScanResults results) throws MachinaException {
@@ -35,98 +41,218 @@ public class SarifIssueTracker extends ImmutableIssueTracker {
     @Override
     public void complete(ScanRequest request, ScanResults results) throws MachinaException {
         log.info("Finalizing SARIF output");
+        List<Rule> sastScanrules = Lists.newArrayList();
+        List<Result> sastScanresultList = Lists.newArrayList();
+        List<Rule> scaScanrules = Lists.newArrayList();
+        List<Result> scaScanresultList = Lists.newArrayList();
+        if(results.getXIssues() != null) {
+            // Filter issues without false-positives
+            // Build the run object
+            List<ScanResults.XIssue> filteredXIssues =
+                    results.getXIssues()
+                            .stream()
+                            .filter(x -> !x.isAllFalsePositive())
+                            .collect(Collectors.toList());
+            //Distinct list of Vulns (Rules)
+            List<ScanResults.XIssue> filteredByVulns =
+                    results.getXIssues()
+                            .stream()
+                            .collect(Collectors.toCollection(() ->
+                                    new TreeSet<>(Comparator.comparing(ScanResults.XIssue::getVulnerability))))
+                            .stream()
+                            .filter(x -> !x.isAllFalsePositive())
+                            .collect(Collectors.toList());
+            // Build the collection of the rules objects (Vulnerabilities)
+            sastScanrules = filteredByVulns.stream().map(i -> Rule.builder()
+                    .id(i.getVulnerability())
+                    .name(i.getVulnerability())
+                    .shortDescription(ShortDescription.builder().text(i.getVulnerability()).build())
+                    .fullDescription(FullDescription.builder().text(i.getVulnerability()).build())
+                    .help(Help.builder()
+                            .markdown(String.format("[%s Details](%s)",
+                                    i.getVulnerability(),
+                                    i.getAdditionalDetails().get("recommendedFix")))
+                            .text((String) i.getAdditionalDetails().get("recommendedFix"))
+                            .build())
+                    .properties(Properties.builder()
+                            .tags(Arrays.asList("security", "external/cwe/cwe-".concat(i.getCwe())))
+                            .build())
+                    .build()).collect(Collectors.toList());
+            //All issues to create the results/locations that are not all false positive
 
-        // Filter issues without false-positives
-        List<ScanResults.XIssue> filteredXIssues =
-                results.getXIssues()
-                        .stream()
-                        .filter(x -> !x.isAllFalsePositive())
-                        .collect(Collectors.toList());
-        //Distinct list of Vulns (Rules)
-        List<ScanResults.XIssue> filteredByVulns =
-                results.getXIssues()
-                        .stream()
-                        .collect(Collectors.toCollection(() ->
-                                new TreeSet<>(Comparator.comparing(ScanResults.XIssue::getVulnerability))))
-                        .stream()
-                        .filter(x -> !x.isAllFalsePositive())
-                        .collect(Collectors.toList());
-        // Build the collection of the rules objects (Vulnerabilities)
-        List<Rule> rules = filteredByVulns.stream().map(i -> Rule.builder()
-                .id(i.getVulnerability())
-                .name(i.getVulnerability())
-                .shortDescription(ShortDescription.builder().text(i.getVulnerability()).build())
-                .fullDescription(FullDescription.builder().text(i.getVulnerability()).build())
-                .help(Help.builder()
-                        .markdown(String.format("[%s Details](%s)",
-                                i.getVulnerability(),
-                                i.getAdditionalDetails().get("recommendedFix")))
-                        .text((String) i.getAdditionalDetails().get("recommendedFix"))
-                        .build())
-                .properties(Properties.builder()
-                        .tags(Arrays.asList("security", "external/cwe/cwe-".concat(i.getCwe())))
-                        .build())
-                .build()).collect(Collectors.toList());
-        //All issues to create the results/locations that are not all false positive
-        List<Result> resultList = Lists.newArrayList();
-        filteredXIssues.forEach(
-                issue -> {
-                    List<Location> locations = Lists.newArrayList();
-                    issue.getDetails().forEach((k, v) -> {
-                        if(!v.isFalsePositive()) {
-                            locations.add(Location.builder()
-                                    .physicalLocation(PhysicalLocation.builder()
-                                            .artifactLocation(ArtifactLocation.builder()
-                                                    .uri(issue.getFilename())
-                                                    .build())
-                                            .region(Region.builder()
-                                                    .startLine(k)
-                                                    .endLine(k)
-                                                    .build())
-                                            .build())
-                                    .build());
+            filteredXIssues.forEach(
+                    issue -> {
+                        List<Location> locations = Lists.newArrayList();
+                        issue.getDetails().forEach((k, v) -> {
+                            if (!v.isFalsePositive()) {
+                                locations.add(Location.builder()
+                                        .physicalLocation(PhysicalLocation.builder()
+                                                .artifactLocation(ArtifactLocation.builder()
+                                                        .uri(issue.getFilename())
+                                                        .build())
+                                                .region(Region.builder()
+                                                        .startLine(k)
+                                                        .endLine(k)
+                                                        .build())
+                                                .build())
+                                        .build());
 
-                        }
-                    });
-                    // Build collection of the results -> locations
-                    resultList.add(
-                            Result.builder()
-                            .level(properties.getSeverityMap().get(issue.getSeverity()) != null ? properties.getSeverityMap().get(issue.getSeverity()) : DEFAULT_LEVEL)
-                            .locations(locations)
-                            .message(Message.builder()
-                                    .text(issue.getDescription())
-                                    .build())
-                            .ruleId(issue.getVulnerability())
-                            .build()
-                    );
+                            }
+                        });
+                        // Build collection of the results -> locations
+                        sastScanresultList.add(
+                                Result.builder()
+                                        .level(properties.getSeverityMap().get(issue.getSeverity()) != null ? properties.getSeverityMap().get(issue.getSeverity()) : DEFAULT_LEVEL)
+                                        .locations(locations)
+                                        .message(Message.builder()
+                                                .text(issue.getDescription())
+                                                .build())
+                                        .ruleId(issue.getVulnerability())
+                                        .build()
+                        );
 
-                }
-        );
+                    }
+            );
+        }
+        if(results.getScaResults() != null ){
 
-        // Build the run object
-        SarifVulnerability run =
-                SarifVulnerability
-                        .builder()
-                        .tool(Tool.builder()
-                                .driver(Driver.builder()
-                                    .name(properties.getScannerName())
-                                    .organization(properties.getOrganization())
-                                    .semanticVersion(properties.getSemanticVersion())
-                                    .rules(rules)
-                                    .build())
-                                .build())
-                        .results(resultList)
+            Map<String, List<Finding>> findingsMap = results.getScaResults()
+                    .getFindings().stream().collect(Collectors.groupingBy(Finding::getPackageId));
+
+            List<Package> packages = new ArrayList<>(results.getScaResults()
+                    .getPackages());
+
+            Map<String,Package> map = new HashMap<>();
+            for(Package p : packages) map.put(p.getId(),p);
+
+
+
+            for (Map.Entry<String, List<Finding>> entry : findingsMap.entrySet()) {
+                String key = entry.getKey();
+                StringBuilder markDownValue = new StringBuilder();
+                markDownValue.append(String.format(MARKDOWN_TABLE_FORMAT, "Reference", "Description", "CVE Name", "Score")).append("\r");
+                markDownValue.append(String.format(MARKDOWN_TABLE_FORMAT,"---","---","---","---")).append("\r");
+                List<Finding> val = entry.getValue();
+                List<String> tags = new ArrayList<>();
+                val.forEach( v -> {
+                    markDownValue.append(String.format(MARKDOWN_TABLE_FORMAT,v.getReferences(),v.getDescription(),v.getCveName(),v.getScore())).append("\r");
+                    if(!tags.contains(String.valueOf(v.getScore())))
+                        tags.add(String.valueOf(v.getScore()));
+                });
+                tags.replaceAll(s -> "CVSS-" + s);
+                tags.add("security");
+                Rule rule = Rule.builder().id(key)
+                        .shortDescription(ShortDescription.builder().text(key).build())
+                        .fullDescription(FullDescription.builder().text(key).build())
+                        .help(Help.builder().markdown(String.valueOf(markDownValue).replace("\n"," ").replace("[","").replace("]","")).text(String.valueOf(markDownValue).replace("\n"," ")).build())
+                        .properties(Properties.builder().tags(tags).build())
                         .build();
+
+                List<Location> locations = Lists.newArrayList();
+                List<String> locationString = Lists.newArrayList();
+                map.get(key).getLocations().forEach(k -> {
+                    if(!locationString.contains(k)) {
+                        locationString.add(k);
+                    }
+                });
+
+
+                locations.add(Location.builder()
+                        .physicalLocation(PhysicalLocation.builder()
+                                .artifactLocation(ArtifactLocation.builder()
+                                        .uri(locationString.stream().map(String::valueOf).collect(Collectors.joining(",")))
+                                        .build())
+                                .build())
+                        .build());
+
+                // Build collection of the results -> locations
+                scaScanresultList.add(
+                        Result.builder()
+                                .level(properties.getSeverityMap().get(map.get(key).getSeverity().toString()) != null ? properties.getSeverityMap().get(map.get(key).getSeverity().toString()) : DEFAULT_LEVEL)
+                                .locations(locations)
+                                .message(Message.builder()
+                                        .text(key)
+                                        .build())
+                                .ruleId(key)
+                                .build()
+                );
+
+                scaScanrules.add(rule);
+
+
+            }
+        }
+
+        List<SarifVulnerability> run=Lists.newArrayList();
+        if(results.getScaResults() != null && results.getXIssues() != null) {
+            run.add(SarifVulnerability
+                    .builder()
+                    .tool(Tool.builder()
+                            .driver(Driver.builder()
+                                    .name(properties.getScaScannerName())
+                                    .organization(properties.getScaOrganization())
+                                    .semanticVersion(properties.getSemanticVersion())
+                                    .rules(scaScanrules)
+                                    .build())
+                            .build())
+                    .results(scaScanresultList)
+                    .build());
+
+            run.add(SarifVulnerability
+                    .builder()
+                    .tool(Tool.builder()
+                            .driver(Driver.builder()
+                                    .name(properties.getSastScannerName())
+                                    .organization(properties.getSastOrganization())
+                                    .semanticVersion(properties.getSemanticVersion())
+                                    .rules(sastScanrules)
+                                    .build())
+                            .build())
+                    .results(sastScanresultList)
+                    .build());
+
+        }
+
+        else if (results.getXIssues() != null) {
+            run.add(SarifVulnerability
+                    .builder()
+                    .tool(Tool.builder()
+                            .driver(Driver.builder()
+                                    .name(properties.getSastScannerName())
+                                    .organization(properties.getSastOrganization())
+                                    .semanticVersion(properties.getSemanticVersion())
+                                    .rules(sastScanrules)
+                                    .build())
+                            .build())
+                    .results(sastScanresultList)
+                    .build());
+        }
+        else {
+            run.add(SarifVulnerability
+                    .builder()
+                    .tool(Tool.builder()
+                            .driver(Driver.builder()
+                                    .name(properties.getScaScannerName())
+                                    .organization(properties.getScaOrganization())
+                                    .semanticVersion(properties.getSemanticVersion())
+                                    .rules(scaScanrules)
+                                    .build())
+                            .build())
+                    .results(scaScanresultList)
+                    .build());
+        }
 
         // Build the report
         SarifReport report = SarifReport.builder()
                 .schema(properties.getSarifSchema())
                 .version(properties.getSarifVersion())
-                .runs(Collections.singletonList(run))
+                .runs(run)
                 .build();
 
         writeJsonOutput(request, report, log);
     }
+
+
 
     @Data
     @Builder


### PR DESCRIPTION
Based on the current implementation, SARIF report is generated only for SAST scans and not for SCA results. The modified code adds this feature to generate the SARIF report for SCA scans as well.

Modified files:
src/main/java/com/checkmarx/flow/custom/SarifIssueTracker.java
src/main/java/com/checkmarx/flow/config/SarifProperties.java

Screenshots of the issues when the cx.sarif file is uploaded in github:
![image](https://user-images.githubusercontent.com/72423211/96911438-d8baa200-146e-11eb-9455-2dbbe3fa39b5.png)
![image](https://user-images.githubusercontent.com/72423211/96911521-f25be980-146e-11eb-855a-115149392b1e.png)
