### PR TITLE
"fix wrong hints in log message when team creation fail

### DIFF
--- a/src/main/java/com/checkmarx/flow/sastscanning/ScanRequestConverter.java
+++ b/src/main/java/com/checkmarx/flow/sastscanning/ScanRequestConverter.java
@@ -214,8 +214,6 @@ public class ScanRequestConverter {
                 "Some hints:\n" +
                 "\t- team name is case-sensitive\n" +
                 "\t- trailing slash is not allowed\n" +
-                "\t- team name separator depends on Checkmarx product version specified in CxFlow configuration:\n" +
-                String.format("\t\tCheckmarx version: %s%n", cxProperties.getVersion()) +
-                String.format("\t\tSeparator that should be used: %s%n", cxProperties.getTeamPathSeparator());
+                "\t- team name separator depends on Checkmarx product version specified in CxFlow configuration: (github.com/checkmarx-ltd/cx-flow/wiki/Configuration)";
     }
 }


### PR DESCRIPTION
### Description

Fix misleading hints in cxflow logs when team creation failed in CxSAST

### References

#447 

### Testing

manual tests to verify new format
end to end automation and integration tests pass

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
