### PR TITLE
Adding BuildInfo Bean to add log entry on program launch

### DIFF
--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -18,9 +18,11 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.MDC;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.PostConstruct;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -56,9 +58,18 @@ public class CxFlowRunner implements ApplicationRunner {
     private final OsaScannerService osaScannerService;
     private final FilterFactory filterFactory;
     private final ConfigurationOverrider configOverrider;
+    private final BuildProperties buildProperties;
     private final List<VulnerabilityScanner> scanners;
     private final ThresholdValidator thresholdValidator;
     private static final String ERROR_BREAK_MSG = String.format("Exiting with Error code %d due to Checkmarx findings", ExitCode.BUILD_INTERRUPTED.getValue());
+
+    @PostConstruct
+    private void logVersion() {
+        log.info("=======BUID INFO=======");
+        log.info("Version: {}-{}", buildProperties.getName(), buildProperties.getVersion());
+        log.info("Time: {}", buildProperties.getTime().toString());
+        log.info("=======================");
+    }
 
     @Override
     public void run(ApplicationArguments args) throws InvocationTargetException {

--- a/src/test/java/com/checkmarx/flow/cucumber/component/batch/BatchComponentSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/batch/BatchComponentSteps.java
@@ -16,6 +16,7 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
@@ -46,6 +47,7 @@ public class BatchComponentSteps {
     private final FilterFactory filterFactory;
     private final ConfigurationOverrider configOverrider;
     private final ThresholdValidator thresholdValidator;
+    private final BuildProperties buildProperties;
 
     private CxFlowRunner cxFlowRunner;
     private String projectName;
@@ -75,6 +77,7 @@ public class BatchComponentSteps {
                 osaScannerService,
                 filterFactory,
                 configOverrider,
+                buildProperties,
                 scanners,
                 thresholdValidator);
     }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ts/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Adding logs to show cx-flow version during startup

### References

Fixes #462 

### Testing

Output from test run:
```
2020-11-09 22:38:56.587  INFO 87043 --- [  restartedMain] o.s.s.c.ThreadPoolTaskExecutor            [] : Initializing ExecutorService
2020-11-09 22:38:56.587  INFO 87043 --- [  restartedMain] o.s.s.c.ThreadPoolTaskExecutor            [] : Initializing ExecutorService 'webHook'
2020-11-09 22:38:56.656  INFO 87043 --- [  restartedMain] c.c.f.s.GitHubAppAuthService              [] : Initializing GitHub App Authentication Service for AppId 81489 using Key file /Users/kenmcdonald/Downloads/cxflow8.pem
2020-11-09 22:38:56.759  INFO 87043 --- [  restartedMain] c.c.f.CxFlowRunner                        [] : =======BUID INFO=======
2020-11-09 22:38:56.759  INFO 87043 --- [  restartedMain] c.c.f.CxFlowRunner                        [] : cx-flow-1.6.12
2020-11-09 22:38:56.760  INFO 87043 --- [  restartedMain] c.c.f.CxFlowRunner                        [] : Time: 2020-11-10T03:38:10.079Z
2020-11-09 22:38:56.760  INFO 87043 --- [  restartedMain] c.c.f.CxFlowRunner                        [] : =======================
2020-11-09 22:38:57.027  INFO 87043 --- [  restartedMain] o.s.b.a.w.s.WelcomePageHandlerMapping     [] : Adding welcome page template: index
2020-11-09 22:38:57.585  INFO 87043 --- [  restartedMain] o.s.b.d.a.OptionalLiveReloadServer        [] : LiveReload server is running on port 35729
2020-11-09 22:38:57.590  INFO 87043 --- [  restartedMain] o.s.b.a.e.w.EndpointLinksResolver         [] : Exposing 2 endpoint(s) beneath base path '/actuator'
2020-11-09 22:38:57.811  INFO 87043 --- [  restartedMain] o.s.b.w.e.t.TomcatWebServer               [] : Tomcat started on port(s): 8080 (http) with context path ''
2020-11-09 22:38:57.815  INFO 87043 --- [  restartedMain] c.c.f.CxFlowApplication                   [] : Started CxFlowApplication in 29.845 seconds (JVM running for 35.497)

```

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
