### PR TITLE
fix null pointer exception when SCA version is null

### DIFF
--- a/src/main/java/com/checkmarx/flow/utils/HTMLHelper.java
+++ b/src/main/java/com/checkmarx/flow/utils/HTMLHelper.java
@@ -188,8 +188,14 @@ public class HTMLHelper {
     }
 
     private static String extractPackageVersionFromFindings(SCAResults r, Finding f) {
-        return r.getPackages().stream().filter(p -> p.getId().equals(f.getPackageId())).map(Package::getVersion)
-                .findFirst().orElse("");
+        try {
+            return r.getPackages().stream().filter(p -> p.getId().equals(f.getPackageId())).map(Package::getVersion)
+                    .findFirst().orElse("");
+        }
+        catch (Exception e) {
+            log.warn("failed to extract package version from SCA finding - {}", f.toString());
+            return "EMPTY";
+        }
     }
 
     private static void setSCAMDBody(String branch, StringBuilder body, List<ScanResults.ScaDetails> scaDetails) {


### PR DESCRIPTION


### Description
Fixing null pointer exception when CxGo SCA results finding doesn't have version field



