### PR TITLE
Support SCA Results in GitLab Security Dashboard

### DIFF
--- a/src/main/java/com/checkmarx/flow/config/GitLabProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/GitLabProperties.java
@@ -11,6 +11,11 @@ public class GitLabProperties extends RepoProperties {
 
     private static final String MERGE_NOTE = "%s/projects/%s/merge_requests/%s/notes";
 
+    private String sastFilePath = "./gl-sast-report.json";
+    
+    private String scaFilePath = "./gl-dependency-scanning-report.json";
+
+
     public String getGitUri(String namespace, String repo){
         String format = "%s/%s/%s.git";
         return String.format(format, getUrl(), namespace, repo);
@@ -19,5 +24,21 @@ public class GitLabProperties extends RepoProperties {
 
     public String getMergeNoteUri(String projectId, String mergeId){
         return String.format(MERGE_NOTE, this.getApiUrl(), projectId, mergeId);
+    }
+
+    public String getSastFilePath() {
+        return sastFilePath;
+    }
+
+    public void setSastFilePath(String sastFilePath) {
+        this.sastFilePath = sastFilePath;
+    }
+
+    public String getScaFilePath() {
+        return scaFilePath;
+    }
+
+    public void setScaFilePath(String scaFilePath) {
+        this.scaFilePath = scaFilePath;
     }
 }

--- a/src/main/java/com/checkmarx/flow/custom/GitLabSecurityDashboard.java
+++ b/src/main/java/com/checkmarx/flow/custom/GitLabSecurityDashboard.java
@@ -7,65 +7,164 @@ import com.checkmarx.flow.exception.MachinaException;
 import com.checkmarx.flow.service.FilenameFormatter;
 import com.checkmarx.flow.utils.ScanUtils;
 import com.checkmarx.sdk.dto.ScanResults;
+import com.checkmarx.sdk.dto.ast.SCAResults;
+import com.cx.restclient.ast.dto.sca.report.Finding;
+import com.cx.restclient.ast.dto.sca.report.Package;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import java.util.ArrayList;
-import java.util.List;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
 
 @Service("GitLabDashboard")
 @RequiredArgsConstructor
 @Slf4j
 public class GitLabSecurityDashboard extends ImmutableIssueTracker {
     private static final String ISSUE_FORMAT = "%s @ %s : %d";
-
+    private static final String CHECKMARX = "Checkmarx";
     private final GitLabProperties properties;
     private final FlowProperties flowProperties;
     private final FilenameFormatter filenameFormatter;
 
     @Override
-    public void init(ScanRequest request, ScanResults results) throws MachinaException {
-        fileInit(request, results, properties.getFilePath(), filenameFormatter, log);
+    public void init(ScanRequest request, ScanResults results){
+        log.info("In the GitLab Security Dashboard Init method");
     }
 
     @Override
     public void complete(ScanRequest request, ScanResults results) throws MachinaException {
-        log.info("Finalizing Dashboard output");
+        deleteFilesifExist(properties.getSastFilePath(),properties.getScaFilePath());
+        if(results.getXIssues() != null) {
+            log.info("Finalizing SAST Dashboard output");
+            fileInit(request, results, properties.getSastFilePath(), filenameFormatter, log);
+            getSastResultsDashboard(request,results);
+        }
+        if(results.getScaResults() != null) {
+            log.info("Finalizing SCA Dashboard output");
+            fileInit(request, results, properties.getScaFilePath(), filenameFormatter, log);
+            getScaResultsDashboard(request,results);
+
+        }
+    }
+
+    private void deleteFilesifExist(String sastFilePath, String scaFilePath) {
+        try {
+            Files.deleteIfExists(Paths.get(sastFilePath));
+            Files.deleteIfExists(Paths.get(scaFilePath));
+        }
+        catch (IOException e) {
+            log.error("Issue deleting existing files {} or {}", sastFilePath,scaFilePath, e);
+        }
+
+    }
+
+    private void getScaResultsDashboard(ScanRequest request, ScanResults results) throws MachinaException {
         List<Vulnerability> vulns = new ArrayList<>();
-        Scanner scanner = Scanner.builder().build();
-        results.getXIssues().forEach( issue ->
-            issue.getDetails().forEach( (k,v) -> {
-                Vulnerability vuln = Vulnerability.builder()
-                        .category("sast")
-                        .id(issue.getVulnerability().concat(":").concat(issue.getFilename()).concat(":").concat(k.toString()))
-                        .cve(issue.getVulnerability().concat(":").concat(issue.getFilename()).concat(":").concat(k.toString()))
-                        .name(issue.getVulnerability())
-                        .message(String.format(ISSUE_FORMAT, issue.getVulnerability(), issue.getFilename(), k))
-                        .description(issue.getVulnerability())
-                        .severity(issue.getSeverity())
-                        .confidence(issue.getSeverity())
-                        .solution(issue.getLink())
+        Scanner scanner = Scanner.builder().id("Checkmarx-SCA").name("Checkmarx-SCA").build();
+        List<Finding> findings = results.getScaResults().getFindings();
+        List<Package> packages = new ArrayList<>(results.getScaResults()
+                .getPackages());
+        Map<String, Package> map = new HashMap<>();
+        for (Package p : packages) map.put(p.getId(), p);
+        for (Finding finding:findings){
+            // for each finding, get the associated package list.
+            // for each object of the associated list, check the occurences of locations
+            // if multiple locations exist, construct multiple objects.
+            // if only single location exist, construct single object
+            Package indPackage = map.get(finding.getPackageId());
+            for(String loc : indPackage.getLocations()) {
+                vulns.add(Vulnerability.builder()
+                        .category("dependency_scanning")
+                        .id(UUID.nameUUIDFromBytes(finding.getPackageId().concat("@").concat(loc).concat(":").concat(finding.getCveName()).getBytes()).toString())
+                        .name(finding.getPackageId().concat("@").concat(loc).concat(":").concat(finding.getCveName()))
+                        .message(finding.getPackageId().concat("@").concat(loc).concat(":").concat(finding.getCveName()))
+                        .description(finding.getDescription())
+                        .severity(String.valueOf(finding.getSeverity()))
+                        .confidence(String.valueOf(finding.getSeverity()))
+                        .solution(finding.getFixResolutionText())
+                        .location(Location.builder().file(loc).dependency(Dependency.builder().pkg(Name.builder().dependencyname(finding.getPackageId()).build()).version(finding.getPackageId().split("-")[finding.getPackageId().split("-").length-1]).build()).build())
+                        .identifiers(getScaIdentifiers(results.getScaResults(),finding))
                         .scanner(scanner)
-                        .identifiers(getIdentifiers(issue))
-                        .location(
-                                Location.builder()
-                                        .file(issue.getFilename())
-                                        .startLine(k)
-                                        .endLine(k)
-                                        .build()
-                        )
-                        .build();
-                vulns.add(vuln);
-            })
+                        .build());
+            }
+
+        }
+        SecurityDashboard report  = SecurityDashboard.builder()
+                .vulnerabilities(vulns)
+                .build();
+
+        writeJsonOutput(request, report, log);
+    }
+
+    private List<Identifier> getScaIdentifiers(SCAResults results, Finding finding) {
+        List<Identifier> identifiers = new ArrayList<>();
+        identifiers.add(
+                Identifier.builder()
+                        .type("checkmarx_finding")
+                        .name(CHECKMARX.concat("-").concat(finding.getPackageId()))
+                        .value(CHECKMARX.concat("-").concat(finding.getPackageId()))
+                        .url(results.getWebReportLink())
+                        .build()
+        );
+        if (!finding.getReferences().isEmpty()) {
+            for(String reference:finding.getReferences()){
+                identifiers.add(
+                        Identifier.builder()
+                                .type("cve")
+                                .name(finding.getCveName() != null ? finding.getCveName().concat("(").concat(reference).concat(")") : reference)
+                                .value(finding.getCveName() != null ? finding.getCveName().concat("(").concat(reference).concat(")") : reference)
+                                .url(reference)
+                                .build()
+                );
+            }
+        }
+
+        return identifiers;
+    }
+
+
+
+
+    private void getSastResultsDashboard(ScanRequest request, ScanResults results) throws MachinaException {
+        List<Vulnerability> vulns = new ArrayList<>();
+        Scanner scanner = Scanner.builder().id("Checkmarx-SAST").name("Checkmarx-SAST").build();
+        results.getXIssues().forEach( issue ->
+                issue.getDetails().forEach( (k,v) -> {
+                    Vulnerability vuln = Vulnerability.builder()
+                            .category("sast")
+                            .id(issue.getVulnerability().concat(":").concat(issue.getFilename()).concat(":").concat(k.toString()))
+                            .cve(issue.getVulnerability().concat(":").concat(issue.getFilename()).concat(":").concat(k.toString()))
+                            .name(issue.getVulnerability())
+                            .message(String.format(ISSUE_FORMAT, issue.getVulnerability(), issue.getFilename(), k))
+                            .description(issue.getVulnerability())
+                            .severity(issue.getSeverity())
+                            .confidence(issue.getSeverity())
+                            .solution(issue.getLink())
+                            .scanner(scanner)
+                            .identifiers(getIdentifiers(issue))
+                            .location(
+                                    Location.builder()
+                                            .file(issue.getFilename())
+                                            .startLine(k)
+                                            .endLine(k)
+                                            .build()
+                            )
+                            .build();
+                    vulns.add(vuln);
+                })
         );
         SecurityDashboard report  = SecurityDashboard.builder()
                 .vulnerabilities(vulns)
                 .build();
 
         writeJsonOutput(request, report, log);
+
     }
 
     private List<Identifier> getIdentifiers(ScanResults.XIssue issue){
@@ -141,10 +240,10 @@ public class GitLabSecurityDashboard extends ImmutableIssueTracker {
     public static class Scanner {
         @JsonProperty("id")
         @Builder.Default
-        public String id = "Checkmarx";
+        public String id = CHECKMARX;
         @JsonProperty("name")
         @Builder.Default
-        public String name = "Checkmarx";
+        public String name = CHECKMARX;
     }
 
     @Data
@@ -166,11 +265,21 @@ public class GitLabSecurityDashboard extends ImmutableIssueTracker {
         public Dependency dependency;
     }
 
+
     @Data
     @Builder
     public static class Dependency {
         @JsonProperty("package")
         public Object pkg;
+        @JsonProperty("version")
+        public String version;
+    }
+
+    @Data
+    @Builder
+    public static class Name {
+        @JsonProperty("name")
+        public String dependencyname;
     }
 
     @Data

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/ast/scans/AstRemoteRepoScanSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/ast/scans/AstRemoteRepoScanSteps.java
@@ -81,7 +81,7 @@ public class AstRemoteRepoScanSteps {
  
     @Before("@ASTRemoteRepoScan")
     public void init() {
-        astProperties.setApiUrl("http://ec2-3-249-195-18.eu-west-1.compute.amazonaws.com");
+        astProperties.setApiUrl("http://ec2-63-35-211-169.eu-west-1.compute.amazonaws.com");
 
         ScaCommonSteps.initSCAConfig(scaProperties);
         resultsServiceMock = mock(ResultsService.class);

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cli/ast/AstCliSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cli/ast/AstCliSteps.java
@@ -77,7 +77,7 @@ public class AstCliSteps  {
         log.info("reset sca filters");
         scaProperties.setFilterSeverity(Collections.emptyList());
 
-        astProperties.setApiUrl("http://ec2-3-249-195-18.eu-west-1.compute.amazonaws.com");
+        astProperties.setApiUrl("http://ec2-63-35-211-169.eu-west-1.compute.amazonaws.com");
         astProperties.setPreset("Checkmarx Default");
         astProperties.setIncremental("false");
     }


### PR DESCRIPTION
Added changes to populate the Dependency scanning vulnerabilities from SCA in GitLab Security Dashboard.
All the vulnerabilities are shown as Dependency Scanning component and also in the Dependency List Tab

![DependencyScanning](https://user-images.githubusercontent.com/72423211/98960014-e09bbe00-24d1-11eb-9672-3e0b76b566b2.JPG)
![DependencyList](https://user-images.githubusercontent.com/72423211/98960033-e5f90880-24d1-11eb-9772-153fc0ce67e4.JPG)
