### PR TITLE
fix engine configuration override

### DIFF
--- a/src/main/java/com/checkmarx/flow/sastscanning/ScanRequestConverter.java
+++ b/src/main/java/com/checkmarx/flow/sastscanning/ScanRequestConverter.java
@@ -48,15 +48,23 @@ public class ScanRequestConverter {
 
     private void setScanConfiguration(ScanRequest scanRequest, Integer projectId) {
         if (entityExists(projectId)) {
-            log.debug("Scan request will contain scan configuration of the existing project.");
-            CxScanSettings scanSettings = scannerClient.getScanSettingsDto(projectId);
-            if (scanSettings != null && scanSettings.getEngineConfigurationId() != null) {
-                Integer configId = scanSettings.getEngineConfigurationId();
-                String configName = scannerClient.getScanConfigurationName(configId);
-                log.debug("Using scan configuration ID: {}, name: '{}'.", configId, configName);
-                scanRequest.setScanConfiguration(configName);
-            } else {
-                log.warn("Unable to retrieve scan settings for the existing project (ID {}).", projectId);
+
+            if (!ScanUtils.empty(scanRequest.getScanConfiguration())){
+                String scanConfiguration = scanRequest.getScanConfiguration();
+                log.debug("overriding scan configuration with '{}'", scanConfiguration);
+                scanRequest.setScanConfiguration(scanConfiguration);
+            }
+            else{
+                log.debug("Scan request will contain scan configuration of the existing project.");
+                CxScanSettings scanSettings = scannerClient.getScanSettingsDto(projectId);
+                if (scanSettings != null && scanSettings.getEngineConfigurationId() != null) {
+                    Integer configId = scanSettings.getEngineConfigurationId();
+                    String configName = scannerClient.getScanConfigurationName(configId);
+                    log.debug("Using scan configuration ID: {}, name: '{}'.", configId, configName);
+                    scanRequest.setScanConfiguration(configName);
+                } else {
+                    log.warn("Unable to retrieve scan settings for the existing project (ID {}).", projectId);
+                }
             }
         } else {
             log.debug("Project doesn't exist. Scan configuration from the global config will be used.");

--- a/src/main/java/com/checkmarx/flow/sastscanning/ScanRequestConverter.java
+++ b/src/main/java/com/checkmarx/flow/sastscanning/ScanRequestConverter.java
@@ -50,9 +50,7 @@ public class ScanRequestConverter {
         if (entityExists(projectId)) {
 
             if (!ScanUtils.empty(scanRequest.getScanConfiguration())){
-                String scanConfiguration = scanRequest.getScanConfiguration();
-                log.debug("overriding scan configuration with '{}'", scanConfiguration);
-                scanRequest.setScanConfiguration(scanConfiguration);
+                log.debug("overriding scan configuration with '{}'", scanRequest.getScanConfiguration());
             }
             else{
                 log.debug("Scan request will contain scan configuration of the existing project.");

--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -236,6 +236,10 @@ public class ConfigurationOverrider {
                 request.setExcludeFiles(Arrays.asList(sf.split(",")));
                 overrideReport.put("exclude files", sf);
             });
+            Optional.ofNullable(s.getEngineConfiguration()).ifPresent(scanConfiguration -> {
+                request.setScanConfiguration(scanConfiguration);
+                overrideReport.put("scan configuration", scanConfiguration);
+            });
         });
         overrideUsingConfigProvider(override, overrideReport, request);
     }


### PR DESCRIPTION

### Description

Fixing scan configuration override

Expected behavior:
when adding 'engineConfiguration' value to config-as-code file, CxFlow should override global configuration and use value from config file

### References

Fix: #549
see Config as code [wiki page](https://github.com/checkmarx-ltd/cx-flow/wiki/Config-As-Code)

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
