### PR TITLE
Fix namespace/owner value for Forked Repo

### DIFF
--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -187,7 +187,7 @@ public class GitHubController extends WebhookController {
                     .product(p)
                     .project(controllerRequest.getProject())
                     .team(controllerRequest.getTeam())
-                    .namespace(repository.getOwner().getLogin().replace(" ","_"))
+                    .namespace(pullRequest.getHead().getRepo().getOwner().getLogin().replace(" ","_"))
                     .repoName(repository.getName())
                     .repoUrl(repository.getCloneUrl())
                     .repoUrlWithAuth(gitAuthUrl)

--- a/src/test/java/com/checkmarx/flow/cucumber/common/repoServiceMockers/GithubServiceMocker.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/common/repoServiceMockers/GithubServiceMocker.java
@@ -104,12 +104,15 @@ public class GithubServiceMocker implements RepoServiceMocker {
         owner.setName("");
         owner.setLogin(GITHUB_USER);
         repo.setOwner(owner);
+        Repo r = new Repo();
+        r.setOwner(owner);
         pullEvent.setRepository(repo);
         pullEvent.setAction("opened");
         PullRequest pullRequest = new PullRequest();
         pullRequest.setIssueUrl("");
         Head headBranch = new Head();
         headBranch.setRef(branchName);
+        headBranch.setRepo(r);
 
         pullRequest.setHead(headBranch);
         pullRequest.setBase(new Base());

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
@@ -188,6 +188,10 @@ public class CxConfigSteps {
         owner.setName("");
         owner.setLogin("cxflowtestuser");
         repo.setOwner(owner);
+
+        Repo r = new Repo();
+        r.setOwner(owner);
+
         pullEvent.setRepository(repo);
         pullEvent.setAction("opened");
         PullRequest pullRequest = new PullRequest();
@@ -195,6 +199,7 @@ public class CxConfigSteps {
         Head headBranch = new Head();
         headBranch.setRef(sourceBranch);
 
+        headBranch.setRepo(r);
         pullRequest.setHead(headBranch);
         pullRequest.setBase(new Base());
         pullRequest.setStatusesUrl("");

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/CxConfigBugTrackerSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfigbugtracker/CxConfigBugTrackerSteps.java
@@ -199,21 +199,25 @@ public class CxConfigBugTrackerSteps {
 
     public void buildPullRequest() {
         PullEvent pullEvent = new PullEvent();
-        Repository repo = new Repository();
-        repo.setName("CxConfigTests");
+        Repository repository = new Repository();
+        repository.setName("CxConfigTests");
 
-        repo.setCloneUrl(gitHubProperties.getUrl());
+        repository.setCloneUrl(gitHubProperties.getUrl());
         Owner owner = new Owner();
         owner.setName("");
         owner.setLogin(GITHUB_USER);
-        repo.setOwner(owner);
-        pullEvent.setRepository(repo);
+        repository.setOwner(owner);
+        pullEvent.setRepository(repository);
         pullEvent.setAction("opened");
         PullRequest pullRequest = new PullRequest();
         pullRequest.setIssueUrl("");
+
+        Repo repo = new Repo();
+        repo.setOwner(owner);
+
         Head headBranch = new Head();
         headBranch.setRef(branch);
-
+        headBranch.setRepo(repo);
         pullRequest.setHead(headBranch);
         pullRequest.setBase(new Base());
         pullRequest.setStatusesUrl("");

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/pullrequest/updatecomments/UpdatePullRequestCommentsSteps.java
@@ -403,6 +403,10 @@ public class UpdatePullRequestCommentsSteps {
         Owner owner = new Owner();
         owner.setName("");
         owner.setLogin("cxflowtestuser");
+
+        Repo r = new Repo();
+        r.setOwner(owner);
+
         repo.setOwner(owner);
         pullEvent.setRepository(repo);
         pullEvent.setAction("opened");
@@ -410,6 +414,7 @@ public class UpdatePullRequestCommentsSteps {
         pullRequest.setIssueUrl("");
         Head headBranch = new Head();
         headBranch.setRef(branchGitHub);
+        headBranch.setRepo(r);
 
         pullRequest.setHead(headBranch);
         pullRequest.setBase(new Base());


### PR DESCRIPTION

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ts/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Changing where GitHub Event grabs the Namespace (owner) value

### References

Fixes #555 

### Testing

Manual testing with forks and non-fork PRs.
E2E Tests

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
