### PR TITLE
Fix vulnerability line links in merge/pull request

### DIFF
--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -283,6 +283,7 @@ public class CxFlowRunner implements ApplicationRunner {
                     exit(1);
                 }
                 mergeNoteUri = gitLabProperties.getMergeNoteUri(projectId, mergeId);
+                repoUrl = getNonEmptyRepoUrl(namespace, repoName, repoUrl, gitLabProperties.getGitUri(namespace, repoName));
                 break;
             case BITBUCKETPULL:
             case bitbucketserverpull:

--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -269,6 +269,7 @@ public class CxFlowRunner implements ApplicationRunner {
                     exit(1);
                 }
                 mergeNoteUri = gitHubProperties.getMergeNoteUri(namespace, repoName, mergeId);
+                repoUrl = getNonEmptyRepoUrl(namespace, repoName, repoUrl, gitHubProperties.getGitUri(namespace, repoName));
                 break;
             case GITLABMERGE:
             case gitlabmerge:

--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -476,6 +476,7 @@ public class CxFlowRunner implements ApplicationRunner {
         log.info("Initiating scan using Checkmarx git clone");
         request.setRepoType(repoType);
         log.info("Git url: {}", gitUrl);
+
         request.setBranch(branch);
         request.setRepoUrl(gitUrl);
         request.setRepoUrlWithAuth(gitAuthUrl);


### PR DESCRIPTION
### Description

when executing cxflow via command line, and using pull/merge request as bug-tracker, vulnerabilities lines not filled and pointing to null.
Fixed by adding repo url to scan request so cxflow can calculate the correct link

### References

Fix issue #527 

### Testing

CxFlow CLI-Integration-Tests

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
