### PR TITLE
Fix for #566: Log initialization error during CxFlow startup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,9 @@ dependencies {
     compile("ch.qos.logback.contrib:logback-jackson:0.1.5")
     compile("net.logstash.logback:logstash-logback-encoder:5.2")
     compile 'org.modelmapper:modelmapper:2.3.8'
-    compile("com.checkmarx:cx-config-provider:${ConfigProviderVersion}")
+    compile("com.checkmarx:cx-config-provider:${ConfigProviderVersion}") {
+        exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
+    }
 }
 
 springBoot {

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxgo/CxGoRemoteRepoScanSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxgo/CxGoRemoteRepoScanSteps.java
@@ -46,7 +46,7 @@ import java.util.concurrent.Callable;
 public class CxGoRemoteRepoScanSteps {
 
     private static final String JIRA_PROJECT = "CT";
-    private static final String PR_COMMIT_HASH = "75380372c24c0caeeb97c104214dd448ac9e066d";
+    private static final String PR_COMMIT_HASH = "5686bbd0e2b2e9957c707ccd68ac1940512b3644";
     private static final int PULL_REQUEST_ID = 1;
     private static final String GITHUB_PROJECT_NAME = "CxGo-Integration-Tests";
     private static final String GITHUB_BRANCH = "develop";


### PR DESCRIPTION
Fixed by excluding a transitive dependency on log4j used by ConfigProvider.

Related work item: [359](https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/359/).