### PR TITLE
Fixed bug 335: Cx-Go SCM tickets are always opened with 'new' status

### DIFF
--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -294,7 +294,7 @@ public class JiraService {
             String fileUrl = ScanUtils.getFileUrl(request, issue.getFilename());
             summary = checkSummaryLength(summary);
 
-            issueBuilder.setSummary(request.getProduct().getProduct() + " " + summary);
+            issueBuilder.setSummary(HTMLHelper.getScanRequestIssueKeyWithDefaultProductValue(request, summary));
             issueBuilder.setDescription(this.getBody(issue, request, fileUrl));
             if (assignee != null && !assignee.isEmpty()) {
                     String accountId = getAssignee(assignee, projectKey);
@@ -936,7 +936,7 @@ public class JiraService {
                         ? String.format(JiraConstants.JIRA_ISSUE_TITLE_KEY, issuePrefix, issue.getVulnerability(), issue.getFilename(), issuePostfix)
                         : getScaDetailsIssueTitleWithoutBranchFormat(request, issuePrefix, issuePostfix, issue);
             }
-            map.put(request.getProduct().getProduct() + " " + key, issue);
+            map.put(HTMLHelper.getScanRequestIssueKeyWithDefaultProductValue(request, key), issue);
         }
         return map;
     }

--- a/src/main/java/com/checkmarx/flow/utils/HTMLHelper.java
+++ b/src/main/java/com/checkmarx/flow/utils/HTMLHelper.java
@@ -95,7 +95,20 @@ public class HTMLHelper {
     }
 
     public static String getScanRequestIssueKeyWithDefaultProductValue(ScanRequest scanRequest, IssueTracker issueTracker, ScanResults.XIssue resultIssue) {
-        return scanRequest.getProduct().getProduct() + " " + issueTracker.getXIssueKey(resultIssue, scanRequest);
+        String xIssueKeyValue = issueTracker.getXIssueKey(resultIssue, scanRequest);
+        String productPrefix = scanRequest.getProduct().getProduct();
+        if (!xIssueKeyValue.startsWith(productPrefix)) {
+            xIssueKeyValue = productPrefix + " " + xIssueKeyValue;
+        }
+        return xIssueKeyValue;
+    }
+
+    public static String getScanRequestIssueKeyWithDefaultProductValue(ScanRequest scanRequest, String titleToConcat) {
+        String productPrefix = scanRequest.getProduct().getProduct();
+        if (!titleToConcat.startsWith(productPrefix)) {
+            titleToConcat = productPrefix + " " + titleToConcat;
+        }
+        return titleToConcat;
     }
 
     private static void addFlowSummarySection(ScanResults results, RepoProperties properties, StringBuilder body, ScanRequest request) {

--- a/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
+++ b/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
@@ -362,14 +362,14 @@ public class ScanUtils {
   
 
     private static String getCustomScaSummaryIssueKey(ScanRequest request, ScanResults.ScaDetails scaDetails) {
-        return String.format(SCATicketingConstants.SCA_SUMMARY_CUSTOM_ISSUE_KEY, scaDetails.getFinding().getSeverity(),
+        return String.format(SCATicketingConstants.SCA_SUMMARY_CUSTOM_ISSUE_KEY, HTMLHelper.getScanRequestIssueKeyWithDefaultProductValue(request, String.valueOf(scaDetails.getFinding().getSeverity())),
                 scaDetails.getFinding().getScore(), scaDetails.getFinding().getId(),
                 scaDetails.getVulnerabilityPackage().getName(),
                 scaDetails.getVulnerabilityPackage().getVersion(), request.getRepoName(), request.getBranch());
     }
 
     private static String getCustomScaSummaryIssueKeyWithoutBranch(ScanRequest request, ScanResults.ScaDetails scaDetails) {
-        return String.format(SCATicketingConstants.SCA_SUMMARY_CUSTOM_ISSUE_KEY_WITHOUT_BRANCH, scaDetails.getFinding().getSeverity(),
+        return String.format(SCATicketingConstants.SCA_SUMMARY_CUSTOM_ISSUE_KEY_WITHOUT_BRANCH, HTMLHelper.getScanRequestIssueKeyWithDefaultProductValue(request, String.valueOf(scaDetails.getFinding().getSeverity())),
                 scaDetails.getFinding().getScore(), scaDetails.getFinding().getId(),
                 scaDetails.getVulnerabilityPackage().getName(),
                 scaDetails.getVulnerabilityPackage().getVersion(), request.getRepoName());


### PR DESCRIPTION
### Description

> Fixed bug 335: Cx-Go SCM tickets are always opened with 'new' status

### References

> https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/335

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
