### PR TITLE
Passing GitLab group path as organization ID to ReposManager

### DIFF
--- a/src/main/java/com/checkmarx/flow/controller/ADOController.java
+++ b/src/main/java/com/checkmarx/flow/controller/ADOController.java
@@ -150,7 +150,7 @@ public class ADOController extends AdoControllerBase {
                     .excludeFiles(controllerRequest.getExcludeFiles())
                     .bugTracker(bt)
                     .filter(filter)
-                    .organizationName(determineNamespace(resourceContainers))
+                    .organizationId(determineNamespace(resourceContainers))
                     .gitUrl(gitUrl)
                     .build();
 
@@ -264,7 +264,7 @@ public class ADOController extends AdoControllerBase {
                     .excludeFiles(controllerRequest.getExcludeFiles())
                     .bugTracker(bt)
                     .filter(filter)
-                    .organizationName(determineNamespace(resourceContainers))
+                    .organizationId(determineNamespace(resourceContainers))
                     .gitUrl(gitUrl)
                     .build();
 
@@ -290,7 +290,7 @@ public class ADOController extends AdoControllerBase {
         return getSuccessMessage();
     }
 
-    private Boolean isDeleteBranchEvent(Resource resource){
+    private boolean isDeleteBranchEvent(Resource resource){
         if (resource.getRefUpdates().size() == 1){
             String newBranchRef = resource.getRefUpdates().get(0).getNewObjectId();
 
@@ -301,7 +301,7 @@ public class ADOController extends AdoControllerBase {
             return false;
         }
 
-        int refCount = Optional.ofNullable(resource.getRefUpdates().size()).orElse(0);
+        int refCount = resource.getRefUpdates().size();
         log.warn("unexpected number of refUpdates in push event: {}", refCount);
 
         return false;

--- a/src/main/java/com/checkmarx/flow/controller/GitHubController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitHubController.java
@@ -204,7 +204,7 @@ public class GitHubController extends WebhookController {
                     .excludeFiles(controllerRequest.getExcludeFiles())
                     .bugTracker(bt)
                     .filter(filter)
-                    .organizationName(getSubStringBefore(repository))
+                    .organizationId(getOrganizationid(repository))
                     .gitUrl(gitUrl)
                     .build();
 
@@ -341,7 +341,7 @@ public class GitHubController extends WebhookController {
                     .excludeFiles(controllerRequest.getExcludeFiles())
                     .bugTracker(bt)
                     .filter(filter)
-                    .organizationName(getSubStringBefore(repository))
+                    .organizationId(getOrganizationid(repository))
                     .gitUrl(gitUrl)
                     .build();
 
@@ -374,13 +374,8 @@ public class GitHubController extends WebhookController {
         return getSuccessMessage();
     }
 
-    /**
-     * Gets a substring before the first occurrence of the separator
-     * e.g. 'cxflowtestuser/VB_3845' will results with 'cxflowtestuser'
-     * @param repository
-     * @return
-     */
-    private String getSubStringBefore(Repository repository) {
+    private String getOrganizationid(Repository repository) {
+        // E.g. "cxflowtestuser/VB_3845" ==> "cxflowtestuser"
         return StringUtils.substringBefore(repository.getFullName(), "/");
     }
 

--- a/src/main/java/com/checkmarx/flow/controller/GitLabController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitLabController.java
@@ -142,7 +142,7 @@ public class GitLabController extends WebhookController {
                     .excludeFiles(controllerRequest.getExcludeFiles())
                     .bugTracker(bt)
                     .filter(filter)
-                    .organizationName(getProjectNamespace(proj))
+                    .organizationId(getOrganizationId(proj))
                     .gitUrl(gitUrl)
                     .build();
 
@@ -245,7 +245,7 @@ public class GitLabController extends WebhookController {
                     .excludeFiles(controllerRequest.getExcludeFiles())
                     .bugTracker(bt)
                     .filter(filter)
-                    .organizationName(getProjectNamespace(proj))
+                    .organizationId(getOrganizationId(proj))
                     .gitUrl(gitUrl)
                     .build();
 
@@ -284,8 +284,13 @@ public class GitLabController extends WebhookController {
         return getSuccessMessage();
     }
 
-    private String getProjectNamespace(Project proj) {
-        return proj.getNamespace().replace(" ","_");
+    private String getOrganizationId(Project proj) {
+        // Cannot use the 'namespace' field here, because it's for display only and won't work in GitLab API calls.
+        // pathWithNamespace may look like the following, depending on project location:
+        //      my-username/personal-project
+        //      my-group/sample-project
+        //      my-group/my-subgroup/sample-project
+        return StringUtils.substringBefore(proj.getPathWithNamespace(), "/");
     }
 
     private String setUserEmail(@RequestBody PushEvent body, BugTracker.Type bugType, Project proj, ScanRequest request, List<String> emails, String commitEndpoint) {

--- a/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
@@ -81,10 +81,15 @@ public class ScanRequest {
     private ASTConfig astConfig;
 
     @Getter @Setter
-    private String clientSec;
+    private String scannerApiSecret;
 
+    /**
+     * 'Organization' here means the top-most level of project hierarchy.
+     * E.g. if SCM supports several levels of hierarchy, path to the project may look like org1/suborg/my-project.
+     * In such case the value of organizationId should be 'org1'.
+     */
     @Getter @Setter
-    private String organizationName;
+    private String organizationId;
 
     @Getter @Setter
     private String gitUrl;
@@ -125,8 +130,8 @@ public class ScanRequest {
         this.scaConfig = other.scaConfig;
         this.astConfig = other.astConfig;
         this.thresholds = other.thresholds;
-        this.clientSec = other.clientSec;
-        this.organizationName = other.organizationName;
+        this.scannerApiSecret = other.scannerApiSecret;
+        this.organizationId = other.organizationId;
         this.gitUrl = other.gitUrl;
     }
 

--- a/src/main/java/com/checkmarx/flow/sastscanning/ScanRequestConverter.java
+++ b/src/main/java/com/checkmarx/flow/sastscanning/ScanRequestConverter.java
@@ -118,8 +118,8 @@ public class ScanRequestConverter {
     }
 
     private String determineOwnerId(ScanRequest request, String team) throws CheckmarxException {
-        return (request.getClientSec() != null)
-                ? scannerClient.getTeamIdByClientSecret(team, request.getClientSec())
+        return (request.getScannerApiSecret() != null)
+                ? scannerClient.getTeamIdByClientSecret(team, request.getScannerApiSecret())
                 : scannerClient.getTeamId(team);
     }
 
@@ -222,7 +222,7 @@ public class ScanRequestConverter {
                 .withFileExclude(request.getExcludeFiles())
                 .withFolderExclude(request.getExcludeFolders())
                 .withScanConfiguration(request.getScanConfiguration())
-                .withClientSecret(request.getClientSec());
+                .withClientSecret(request.getScannerApiSecret());
 
         if (StringUtils.isNotEmpty(request.getBranch())) {
             params.withBranch(Constants.CX_BRANCH_PREFIX.concat(request.getBranch()));

--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -267,7 +267,7 @@ public class ConfigurationOverrider {
     private void applyCxGoDynamicConfig(Map<String, String> overrideReport, ScanRequest request)  {
         if (cxIntegrationsProperties.isReadMultiTenantConfiguration()) {
             String scmType = request.getRepoType().getRepository().toLowerCase();
-            String organizationName = request.getOrganizationName();
+            String organizationName = request.getOrganizationId();
 
             /*
                 When ADO is the SCM event trigger, the Repos-Manager expects to get 'azure' in the URL path
@@ -296,9 +296,9 @@ public class ConfigurationOverrider {
             Optional.ofNullable(cxgoConfig.getCxgoSecret())
                     .filter(StringUtils::isNotEmpty)
                     .ifPresent(secret -> {
-                        request.setClientSec(secret);
-                        log.info("Using client secret from {}", className);
-                        overrideReport.put("clientSecret", "<actually it's a secret>");
+                        request.setScannerApiSecret(secret);
+                        log.info("Using scanner API secret from {}", className);
+                        overrideReport.put("scannerApiSecret", "<actually it's a secret>");
                     });
             Optional.ofNullable(cxgoConfig.getScmAccessToken())
                     .filter(StringUtils::isNotEmpty)

--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -264,10 +264,9 @@ public class ConfigurationOverrider {
         }
     }
 
-    private void applyCxGoDynamicConfig(Map<String, String> overrideReport, ScanRequest request)  {
+    private void applyCxGoDynamicConfig(Map<String, String> overrideReport, ScanRequest request) {
         if (cxIntegrationsProperties.isReadMultiTenantConfiguration()) {
             String scmType = request.getRepoType().getRepository().toLowerCase();
-            String organizationName = request.getOrganizationId();
 
             /*
                 When ADO is the SCM event trigger, the Repos-Manager expects to get 'azure' in the URL path
@@ -277,13 +276,15 @@ public class ConfigurationOverrider {
                 scmType = "azure";
             }
 
-            CxGoConfigFromWebService cxgoConfig = reposManagerService.getCxGoDynamicConfig(scmType, organizationName);
-            
-            if(cxgoConfig == null){
-               log.error("Multi Tenant mode: missing CxGo configuration in Repos Manager Service. Working with Multi Tenant = false ");
-               return;
+            CxGoConfigFromWebService cxgoConfig = reposManagerService.getCxGoDynamicConfig(
+                    scmType,
+                    request.getOrganizationId());
+
+            if (cxgoConfig == null) {
+                log.error("Multi Tenant mode: missing CxGo configuration in Repos Manager Service. Working with Multi Tenant = false ");
+                return;
             }
-            
+
             String className = CxGoConfigFromWebService.class.getSimpleName();
             log.info("Applying {} configuration.", className);
             Optional.ofNullable(cxgoConfig.getTeam())

--- a/src/main/java/com/checkmarx/flow/service/ReposManagerService.java
+++ b/src/main/java/com/checkmarx/flow/service/ReposManagerService.java
@@ -33,10 +33,10 @@ public class ReposManagerService {
         cxGoConfigUrlPattern = cxIntegrationsProperties.getUrl() + "/%s/orgs/%s/tenantConfig";
     }
 
-    public CxGoConfigFromWebService getCxGoDynamicConfig(String scmType, String orgName) {
+    public CxGoConfigFromWebService getCxGoDynamicConfig(String scmType, String orgId) {
         if (StringUtils.isNotEmpty(cxIntegrationsProperties.getUrl())) {
-            String urlPath = String.format(cxGoConfigUrlPattern, scmType, encoder(orgName));
-            log.info("Overriding Cx-Go configuration for SCM type: {} and organization name: {}", scmType, orgName);
+            String urlPath = String.format(cxGoConfigUrlPattern, scmType, urlEncode(orgId));
+            log.info("Overriding Cx-Go configuration for SCM type: {} and organization ID: {}", scmType, orgId);
             ResponseEntity<CxGoConfigFromWebService> responseEntity;
             try {
                 responseEntity = restTemplate.getForEntity(urlPath, CxGoConfigFromWebService.class);
@@ -49,7 +49,7 @@ public class ReposManagerService {
         }
     }
 
-    private String encoder(String orgName) {
+    private static String urlEncode(String orgName) {
         try {
             return URLEncoder.encode(orgName, StandardCharsets.UTF_8.toString());
         } catch (UnsupportedEncodingException e) {

--- a/src/test/java/com/checkmarx/flow/cucumber/component/cxintegrations/CxIntegrationSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/cxintegrations/CxIntegrationSteps.java
@@ -52,7 +52,7 @@ public class CxIntegrationSteps {
 
     @Then("scanRequest is getting populated with cx-go new configuration")
     public void validateCxGoConfigurationOverride() {
-        Assert.assertEquals(CLIENT_SECRET, scanRequest.getClientSec());
+        Assert.assertEquals(CLIENT_SECRET, scanRequest.getScannerApiSecret());
         Assert.assertEquals(TEAM, scanRequest.getTeam());
         Assert.assertTrue(scanRequest.getRepoUrlWithAuth().contains(SCM_ACCESS_TOKEN));
     }
@@ -72,7 +72,7 @@ public class CxIntegrationSteps {
     private ScanRequest initScanRequest() {
         return ScanRequest.builder()
                 .repoType(ScanRequest.Repository.GITHUB)
-                .organizationName("organization-test")
+                .organizationId("organization-test")
                 .gitUrl("https://www.github.com")
                 .build();
     }


### PR DESCRIPTION
### Description

When a GitLab webhook request arrives, CxFlow now uses the `project.path_with_namespace` field from the request to extract organization ID and send it to ReposManager. Previously the `project.namespace` field was used. This was problematic, since the  `project.namespace` field is only intended for display purposes.

Example: suppose project.path_with_namespace is `group1/subgroup1/my-project`
Then organization ID sent to ReposManager will be `group1`

### References

User story [364](https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/364/). 

### Testing

Tested manually with 
- project inside a top-level group
- project inside a subgroup
- group and project names containing spaces

In the future, cxIntegrations.feature should be expanded to include these tests.

