### PR TITLE
Fix/shard fixes

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.4.64"
+        CxSBSDK = "0.4.65"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.4.64"
+        CxSBSDK = "0.4.65"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/src/main/java/com/checkmarx/flow/sastscanning/ScanRequestConverter.java
+++ b/src/main/java/com/checkmarx/flow/sastscanning/ScanRequestConverter.java
@@ -109,7 +109,7 @@ public class ScanRequestConverter {
         return ownerId;
     }
 
-    private void setShardPropertiesIfExists(ScanRequest request, String fullTeamName) {
+    public void setShardPropertiesIfExists(ScanRequest request, String fullTeamName) {
         if (cxProperties.getEnableShardManager()) {
             ShardSession shard = sessionTracker.getShardSession();
             shard.setTeam(fullTeamName);

--- a/src/main/java/com/checkmarx/flow/service/AbstractVulnerabilityScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/AbstractVulnerabilityScanner.java
@@ -113,6 +113,8 @@ public abstract class AbstractVulnerabilityScanner implements VulnerabilityScann
             scanComment += (";" + scanRequest.getNamespace() + ";");
             scanComment += (scanRequest.getApplication() + ";");
             scanComment += (scanRequest.getBranch() + ";");
+            scanComment += (scanRequest.getProject() + ";");
+            scanComment += (scanRequest.getTeam() + ";");
             scanComment += (scanRequest.getMergeNoteUri() + ";");
             scanComment += (scanRequest.getAdditionalMetadata("statuses_url") + ";");
             BugTracker bt = scanRequest.getBugTracker();


### PR DESCRIPTION
This is a fix for two race conditions in Shard Manager. These changes should not affect code that do not use Shard Manager.

The first race condition occurred due to the way Shard Manager was reading the scan ID associated with the the current job. The scan ID was being determined by intercepting system console logs, this worked most of the time but in about 5% of the situations an improper scan ID would be fetched from the log. The new version is much simpler and tracks the scan ID through the Log4j mechanism CxFlow uses.

There was a second race condition that occurred when the Groovy scripts tried to update project and team counts in the database. The previous code us SQL to make the updates and it was possible for two transactions to interfere with each other. The new version uses atomic stored procedures to complete the update actions. The update requires the stored procedures to be created in the Postgres database engine and the documentation for that is in the Shard Manager section of the CxFlow wiki. The database updates are currently only valid for Postgres and will need to be ported to SQL Server and MySQL if required.