### PR TITLE
Fix SCA open, update & close tickets mechanism

### DIFF
--- a/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
@@ -81,7 +81,7 @@ public class ScanRequest {
     private ASTConfig astConfig;
 
     @Getter @Setter
-    private String scannerApiSecret;
+    private String scannerApiSec;
 
     /**
      * 'Organization' here means the top-most level of project hierarchy.
@@ -130,7 +130,7 @@ public class ScanRequest {
         this.scaConfig = other.scaConfig;
         this.astConfig = other.astConfig;
         this.thresholds = other.thresholds;
-        this.scannerApiSecret = other.scannerApiSecret;
+        this.scannerApiSec = other.scannerApiSec;
         this.organizationId = other.organizationId;
         this.gitUrl = other.gitUrl;
     }

--- a/src/main/java/com/checkmarx/flow/sastscanning/ScanRequestConverter.java
+++ b/src/main/java/com/checkmarx/flow/sastscanning/ScanRequestConverter.java
@@ -118,8 +118,8 @@ public class ScanRequestConverter {
     }
 
     private String determineOwnerId(ScanRequest request, String team) throws CheckmarxException {
-        return (request.getScannerApiSecret() != null)
-                ? scannerClient.getTeamIdByClientSecret(team, request.getScannerApiSecret())
+        return (request.getScannerApiSec() != null)
+                ? scannerClient.getTeamIdByClientSecret(team, request.getScannerApiSec())
                 : scannerClient.getTeamId(team);
     }
 
@@ -222,7 +222,7 @@ public class ScanRequestConverter {
                 .withFileExclude(request.getExcludeFiles())
                 .withFolderExclude(request.getExcludeFolders())
                 .withScanConfiguration(request.getScanConfiguration())
-                .withClientSecret(request.getScannerApiSecret());
+                .withClientSecret(request.getScannerApiSec());
 
         if (StringUtils.isNotEmpty(request.getBranch())) {
             params.withBranch(Constants.CX_BRANCH_PREFIX.concat(request.getBranch()));

--- a/src/main/java/com/checkmarx/flow/service/CodeBashingService.java
+++ b/src/main/java/com/checkmarx/flow/service/CodeBashingService.java
@@ -86,7 +86,7 @@ public class CodeBashingService {
         return String.format("%s-%s-%s", cwe, language, queryId);
     }
 
-    public void addCodebashingUrlToIssue(ScanResults.XIssue xIssue){
+    void addCodebashingUrlToIssue(ScanResults.XIssue xIssue){
         String mapKey = xIssue.getCwe();
         if(validateXIssueFields(xIssue) && codebashingProperties.getTenantBaseUrl() != null) {
             mapKey = buildMapKey(xIssue.getCwe(), xIssue.getLanguage(), xIssue.gerQueryId());
@@ -104,7 +104,10 @@ public class CodeBashingService {
             xIssue.getAdditionalDetails().put(FlowConstants.CODE_BASHING_LESSON, flowProperties.getCodebashUrl());
         }
 
-        log.debug("added codebashing lesson {} to xIssue: {}", xIssue.getAdditionalDetails().get(FlowConstants.CODE_BASHING_LESSON), mapKey);
+        Object lesson = xIssue.getAdditionalDetails().get(FlowConstants.CODE_BASHING_LESSON);
+        if (lesson != null) {
+            log.debug("added codebashing lesson {} to xIssue: {}", lesson, mapKey);
+        }
     }
 
     private HttpHeaders createAuthHeaders(){

--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -299,9 +299,9 @@ public class ConfigurationOverrider {
             Optional.ofNullable(cxgoConfig.getCxgoToken())
                     .filter(StringUtils::isNotEmpty)
                     .ifPresent(secret -> {
-                        request.setScannerApiSecret(secret);
+                        request.setScannerApiSec(secret);
                         log.info("Using scanner API secret from {}", className);
-                        overrideReport.put("scannerApiSecret", "<actually it's a secret>");
+                        overrideReport.put("scannerApiSec", "<actually it's a secret>");
                     });
             Optional.ofNullable(cxgoConfig.getScmAccessToken())
                     .filter(StringUtils::isNotEmpty)

--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -948,19 +948,25 @@ public class JiraService {
     private String getScaDetailsIssueTitleFormat(ScanRequest request, String issuePrefix, String issuePostfix, ScanResults.XIssue issue) {
         ScanResults.ScaDetails scaDetails = issue.getScaDetails().get(0);
 
+        String currentPackageVersion = ScanUtils.getCurrentPackageVersion(scaDetails.getVulnerabilityPackage().getName());
+        String packagePathWithoutCurrentVersion = ScanUtils.removePackageCurrentVersionFromPath(scaDetails.getVulnerabilityPackage().getName(), currentPackageVersion);
+
         return String.format(SCATicketingConstants.SCA_JIRA_ISSUE_KEY, issuePrefix, scaDetails.getFinding().getSeverity(),
-        scaDetails.getFinding().getScore(), scaDetails.getFinding().getId(),
-        scaDetails.getVulnerabilityPackage().getName(),
-        scaDetails.getVulnerabilityPackage().getVersion(), request.getRepoName(), request.getBranch(), issuePostfix);
+                scaDetails.getFinding().getScore(), scaDetails.getFinding().getId(),
+                packagePathWithoutCurrentVersion,
+                currentPackageVersion, request.getRepoName(), request.getBranch(), issuePostfix);
     }
 
     private String getScaDetailsIssueTitleWithoutBranchFormat(ScanRequest request, String issuePrefix, String issuePostfix, ScanResults.XIssue issue) {
         ScanResults.ScaDetails scaDetails = issue.getScaDetails().get(0);
 
+        String currentPackageVersion = ScanUtils.getCurrentPackageVersion(scaDetails.getVulnerabilityPackage().getName());
+        String packagePathWithoutCurrentVersion = ScanUtils.removePackageCurrentVersionFromPath(scaDetails.getVulnerabilityPackage().getName(), currentPackageVersion);
+
         return String.format(SCATicketingConstants.SCA_JIRA_ISSUE_KEY_WITHOUT_BRANCH, issuePrefix, scaDetails.getFinding().getSeverity(),
                 scaDetails.getFinding().getScore(), scaDetails.getFinding().getId(),
-                scaDetails.getVulnerabilityPackage().getName(),
-                scaDetails.getVulnerabilityPackage().getVersion(), request.getRepoName(), issuePostfix);
+                packagePathWithoutCurrentVersion,
+                currentPackageVersion, request.getRepoName(), issuePostfix);
     }
 
     private String getBody(ScanResults.XIssue issue, ScanRequest request, String fileUrl) {
@@ -1121,11 +1127,12 @@ public class JiraService {
             ScanResults.ScaDetails scaDetails = s.stream().findAny().get();
 
             scaDetailsMap.put("Vulnerability ID", scaDetails.getFinding().getId());
-            scaDetailsMap.put("Package Name", scaDetails.getVulnerabilityPackage().getName());
+            String currentPackageVersion = ScanUtils.getCurrentPackageVersion(scaDetails.getVulnerabilityPackage().getName());
+            scaDetailsMap.put("Package Name", ScanUtils.removePackageCurrentVersionFromPath(scaDetails.getVulnerabilityPackage().getName(), currentPackageVersion));
             scaDetailsMap.put("Severity", scaDetails.getFinding().getSeverity().name());
             scaDetailsMap.put("CVSS Score", String.valueOf(scaDetails.getFinding().getScore()));
             scaDetailsMap.put("Publish Date", scaDetails.getFinding().getPublishDate());
-            scaDetailsMap.put("Current Package Version", scaDetails.getVulnerabilityPackage().getVersion());
+            scaDetailsMap.put("Current Package Version", currentPackageVersion);
             Optional.ofNullable(scaDetails.getFinding().getFixResolutionText()).ifPresent(f ->
                 scaDetailsMap.put("Remediation Upgrade Recommendation", f)
 

--- a/src/main/java/com/checkmarx/flow/utils/HTMLHelper.java
+++ b/src/main/java/com/checkmarx/flow/utils/HTMLHelper.java
@@ -231,7 +231,7 @@ public class HTMLHelper {
             scaDetailsMap.put("**Severity", any.getFinding().getSeverity().name());
             scaDetailsMap.put("**CVSS Score", String.valueOf(any.getFinding().getScore()));
             scaDetailsMap.put("**Publish Date", any.getFinding().getPublishDate());
-            scaDetailsMap.put("**Current Package Version", any.getVulnerabilityPackage().getVersion());
+            scaDetailsMap.put("**Current Package Version", ScanUtils.getCurrentPackageVersion(any.getVulnerabilityPackage().getName()));
             Optional.ofNullable(any.getFinding().getFixResolutionText())
                     .ifPresent(f -> scaDetailsMap.put("**Remediation Upgrade Recommendation", f)
 
@@ -366,7 +366,7 @@ public class HTMLHelper {
             scaDetailsMap.put("<b>Severity", any.getFinding().getSeverity().name());
             scaDetailsMap.put("<b>CVSS Score", String.valueOf(any.getFinding().getScore()));
             scaDetailsMap.put("<b>Publish Date", any.getFinding().getPublishDate());
-            scaDetailsMap.put("<b>Current Package Version", any.getVulnerabilityPackage().getVersion());
+            scaDetailsMap.put("<b>Current Package Version", ScanUtils.getCurrentPackageVersion(any.getVulnerabilityPackage().getName()));
             Optional.ofNullable(any.getFinding().getFixResolutionText())
                     .ifPresent(f -> scaDetailsMap.put("<b>Remediation Upgrade Recommendation", f)
 

--- a/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
+++ b/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
@@ -362,31 +362,39 @@ public class ScanUtils {
   
 
     private static String getCustomScaSummaryIssueKey(ScanRequest request, ScanResults.ScaDetails scaDetails) {
+        String currentPackageVersion = getCurrentPackageVersion(scaDetails.getVulnerabilityPackage().getName());
+
         return String.format(SCATicketingConstants.SCA_SUMMARY_CUSTOM_ISSUE_KEY, HTMLHelper.getScanRequestIssueKeyWithDefaultProductValue(request, String.valueOf(scaDetails.getFinding().getSeverity())),
                 scaDetails.getFinding().getScore(), scaDetails.getFinding().getId(),
-                scaDetails.getVulnerabilityPackage().getName(),
-                scaDetails.getVulnerabilityPackage().getVersion(), request.getRepoName(), request.getBranch());
+                removePackageCurrentVersionFromPath(scaDetails.getVulnerabilityPackage().getName(), currentPackageVersion),
+                currentPackageVersion, request.getRepoName(), request.getBranch());
     }
 
     private static String getCustomScaSummaryIssueKeyWithoutBranch(ScanRequest request, ScanResults.ScaDetails scaDetails) {
+        String currentPackageVersion = getCurrentPackageVersion(scaDetails.getVulnerabilityPackage().getName());
+
         return String.format(SCATicketingConstants.SCA_SUMMARY_CUSTOM_ISSUE_KEY_WITHOUT_BRANCH, HTMLHelper.getScanRequestIssueKeyWithDefaultProductValue(request, String.valueOf(scaDetails.getFinding().getSeverity())),
                 scaDetails.getFinding().getScore(), scaDetails.getFinding().getId(),
-                scaDetails.getVulnerabilityPackage().getName(),
-                scaDetails.getVulnerabilityPackage().getVersion(), request.getRepoName());
+                removePackageCurrentVersionFromPath(scaDetails.getVulnerabilityPackage().getName(), currentPackageVersion),
+                currentPackageVersion, request.getRepoName());
     }
 
     private static String getJiraScaSummaryIssueKey(ScanRequest request, String issuePrefix, String issuePostfix, Finding detailsFindings, Package vulnerabilityPackage) {
+        String currentPackageVersion = getCurrentPackageVersion(vulnerabilityPackage.getName());
+
         return String.format(SCATicketingConstants.SCA_JIRA_ISSUE_KEY, issuePrefix, detailsFindings.getSeverity(),
                 detailsFindings.getScore(), detailsFindings.getId(),
-                vulnerabilityPackage.getName(),
-                vulnerabilityPackage.getVersion(), request.getRepoName(), request.getBranch(), issuePostfix);
+                removePackageCurrentVersionFromPath(vulnerabilityPackage.getName(), currentPackageVersion),
+                currentPackageVersion, request.getRepoName(), request.getBranch(), issuePostfix);
     }
 
     private static String getJiraScaSummaryIssueKeyWithoutBranch(ScanRequest request, String issuePrefix, String issuePostfix, Finding detailsFindings, Package vulnerabilityPackage) {
+        String currentPackageVersion = getCurrentPackageVersion(vulnerabilityPackage.getName());
+
         return String.format(SCATicketingConstants.SCA_JIRA_ISSUE_KEY_WITHOUT_BRANCH, issuePrefix, detailsFindings.getSeverity(),
                 detailsFindings.getScore(), detailsFindings.getId(),
-                vulnerabilityPackage.getName(),
-                vulnerabilityPackage.getVersion(), request.getRepoName(), issuePostfix);
+                removePackageCurrentVersionFromPath(vulnerabilityPackage.getName(), currentPackageVersion),
+                currentPackageVersion, request.getRepoName(), issuePostfix);
     }
 
 
@@ -592,5 +600,13 @@ public class ScanUtils {
         return map.keySet().stream()
                 .map(key -> key + "=" + map.get(key))
                 .collect(Collectors.joining(", ", "{", "}"));
+    }
+
+    public static String removePackageCurrentVersionFromPath(String packageName, String currentPackageVersion) {
+        return packageName.replace("-" + currentPackageVersion, "");
+    }
+
+    public static String getCurrentPackageVersion(String packageName) {
+        return StringUtils.substringAfterLast(packageName, "-");
     }
 }

--- a/src/test/java/com/checkmarx/flow/cucumber/component/cxintegrations/CxIntegrationSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/cxintegrations/CxIntegrationSteps.java
@@ -52,7 +52,7 @@ public class CxIntegrationSteps {
 
     @Then("scanRequest is getting populated with cx-go new configuration")
     public void validateCxGoConfigurationOverride() {
-        Assert.assertEquals(CLIENT_SECRET, scanRequest.getScannerApiSecret());
+        Assert.assertEquals(CLIENT_SECRET, scanRequest.getScannerApiSec());
         Assert.assertEquals(TEAM, scanRequest.getTeam());
         Assert.assertTrue(scanRequest.getRepoUrlWithAuth().contains(SCM_ACCESS_TOKEN));
     }

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/sca_scanner/bugtrackers/ado/ScaIssuesCreationSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/sca_scanner/bugtrackers/ado/ScaIssuesCreationSteps.java
@@ -76,10 +76,11 @@ public class ScaIssuesCreationSteps {
         resultsService.processResults(getBasicScanRequest(), scanResults, null);
     }
 
-    @Then("new 8 tickets should be created")
+    @Then("new 5 tickets should be created")
+    // Expects total of 5 tickets since there are multiple medium: Cx65603961-769c tickets that considered as one ticket
     public void ticketsCreationValidation() throws IOException {
         Assert.assertEquals("Azure new SCA results tickets number is not as expected",
-                8, azureDevopsClient.getIssueCount());
+                5, azureDevopsClient.getIssueCount());
     }
 
     private ScanRequest getBasicScanRequest() {

--- a/src/test/resources/cucumber/features/integrationTests/sca/scanResultsProcessing.feature
+++ b/src/test/resources/cucumber/features/integrationTests/sca/scanResultsProcessing.feature
@@ -60,7 +60,7 @@ Feature: Cx-Flow SCA Integration permutation tests
     Given scan initiator is SCA
     And bug tracker is Azure
     When publishing new known unfiltered SCA results with 8 findings including 2 high and 6 medium vulnerabilities
-    Then new 8 tickets should be created
+    Then new 5 tickets should be created
 
   @SCA_Resolve_Issue
   Scenario: Resolve an open vulnerability and check status updates to closed


### PR DESCRIPTION
### Description

> This bug fixes a scenario when SCA has multiple identical packages name path, which one package has a fix version and the other one doesn't have. cx-flow gets the package name within the results, and since there are more than 1 identical package, it picks one of them. The inconsistency with the package's version causes cx-flow relate the result differently each time when it tries to update/close a ticket.

Example:
![image](https://user-images.githubusercontent.com/23239410/105158214-67929580-5b16-11eb-8d2f-80c84fac331b.png)

### References

> [Bug-issue](https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/487)

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
