### PR TITLE
Upgrade SDK version to 0.4.77: Support SCA scan with cx-origin header

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.4.76"
+        CxSBSDK = "0.4.77"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.4.76"
+        CxSBSDK = "0.4.77"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'


### PR DESCRIPTION
### Description

> Upgrade SDK version to 0.4.77: Support SCA scan with cx-origin header

### References

> [User Story URL](https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/495)

### Testing
Manual testing were performed and new scan header has being validated by Fadi from SCA. 

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
