### PR TITLE
Gitlab - Reduced comments notifications on pull requests + Tests

### DIFF
--- a/src/main/java/com/checkmarx/flow/controller/GitLabController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitLabController.java
@@ -312,7 +312,7 @@ public class GitLabController extends WebhookController {
     }
 
     private void setMergeEndPointUri(ObjectAttributes objectAttributes, Project proj, ScanRequest request) {
-        String mergeEndpoint = scmConfigOverrider.determineConfigApiUrl(properties, request).concat(GitLabService.MERGE_NOTE_PATH);
+        String mergeEndpoint = scmConfigOverrider.determineConfigApiUrl(properties, request).concat(GitLabService.MERGE_NOTES_PATH);
         mergeEndpoint = mergeEndpoint.replace("{id}", proj.getId().toString());
         mergeEndpoint = mergeEndpoint.replace("{iid}", objectAttributes.getIid().toString());
         request.setMergeNoteUri(mergeEndpoint);

--- a/src/main/java/com/checkmarx/flow/dto/RepoComment.java
+++ b/src/main/java/com/checkmarx/flow/dto/RepoComment.java
@@ -2,6 +2,7 @@ package com.checkmarx.flow.dto;
 
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,6 +11,7 @@ import java.util.Date;
 @Getter
 @Setter
 @AllArgsConstructor
+@Builder
 public class RepoComment {
     long id;
     String comment;

--- a/src/main/java/com/checkmarx/flow/dto/gitlab/Comment.java
+++ b/src/main/java/com/checkmarx/flow/dto/gitlab/Comment.java
@@ -1,0 +1,21 @@
+package com.checkmarx.flow.dto.gitlab;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Comment {
+
+    private long id;
+    private String body;
+    @JsonProperty("created_at")
+    private String createdAt;
+    @JsonProperty("updated_at")
+    private String updatedAt;
+}

--- a/src/main/java/com/checkmarx/flow/dto/gitlab/ObjectAttributes.java
+++ b/src/main/java/com/checkmarx/flow/dto/gitlab/ObjectAttributes.java
@@ -4,6 +4,7 @@ package com.checkmarx.flow.dto.gitlab;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Builder;
 
 import javax.validation.Valid;
 
@@ -32,6 +33,7 @@ import javax.validation.Valid;
     "action",
     "assignee"
 })
+@Builder
 public class ObjectAttributes {
 
     @JsonProperty("id")

--- a/src/main/java/com/checkmarx/flow/dto/gitlab/Project.java
+++ b/src/main/java/com/checkmarx/flow/dto/gitlab/Project.java
@@ -4,6 +4,9 @@ package com.checkmarx.flow.dto.gitlab;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
@@ -23,6 +26,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
         "ssh_url",
         "http_url"
 })
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Project {
 
     @JsonProperty("id")

--- a/src/main/java/com/checkmarx/flow/dto/gitlab/Repository.java
+++ b/src/main/java/com/checkmarx/flow/dto/gitlab/Repository.java
@@ -4,6 +4,9 @@ package com.checkmarx.flow.dto.gitlab;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
@@ -14,6 +17,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "git_http_url",
     "git_ssh_url"
 })
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Repository {
 
     @JsonProperty("name")

--- a/src/main/java/com/checkmarx/flow/dto/gitlab/User.java
+++ b/src/main/java/com/checkmarx/flow/dto/gitlab/User.java
@@ -4,6 +4,7 @@ package com.checkmarx.flow.dto.gitlab;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Builder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
@@ -11,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "username",
     "avatar_url"
 })
+@Builder
 public class User {
 
     @JsonProperty("name")

--- a/src/main/java/com/checkmarx/flow/exception/GitLabClientRuntimeException.java
+++ b/src/main/java/com/checkmarx/flow/exception/GitLabClientRuntimeException.java
@@ -6,4 +6,13 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Error communicating with GitLab API")
 public class GitLabClientRuntimeException extends RuntimeException {
+
+    public GitLabClientRuntimeException() {
+
+    }
+
+    public GitLabClientRuntimeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
 }

--- a/src/main/java/com/checkmarx/flow/service/BitBucketService.java
+++ b/src/main/java/com/checkmarx/flow/service/BitBucketService.java
@@ -429,6 +429,16 @@ public class BitBucketService extends RepoService {
     }
 
     @Override
+    public void updateComment(String commentUrl, String comment, ScanRequest scanRequest) {
+        // not implemented
+    }
+
+    @Override
+    public void addComment(ScanRequest scanRequest, String comment) {
+        // not implemented
+    }
+
+    @Override
     public List<RepoComment> getComments(ScanRequest scanRequest) {
         return Collections.emptyList();
     }

--- a/src/main/java/com/checkmarx/flow/service/GitHubService.java
+++ b/src/main/java/com/checkmarx/flow/service/GitHubService.java
@@ -120,7 +120,7 @@ public class GitHubService extends RepoService {
             sendMergeComment(request, comment);
     }
 
-    private void updateComment(String baseUrl, String comment, ScanRequest scanRequest) {
+    public void updateComment(String baseUrl, String comment, ScanRequest scanRequest) {
         log.debug("Updating exisiting comment. url: {}", baseUrl);
         log.debug("Updated comment: {}" , comment);
         HttpEntity<?> httpEntity = new HttpEntity<>(RepoIssue.getJSONComment("body",comment).toString(), createAuthHeaders(scanRequest));
@@ -200,33 +200,12 @@ public class GitHubService extends RepoService {
             return new RepoComment(id, commentBody, commentUrl, sdf.parse(createdStr), sdf.parse(updatedStr));
         }
         catch (ParseException pe) {
-            throw new GitHubClientRunTimeException("Error parsing github pull request created or updted date", pe);
+            throw new GitHubClientRunTimeException("Error parsing github pull request created or updated date", pe);
         }
     }
 
-    public void sendMergeComment(ScanRequest request, String comment) {
-        try {
-            RepoComment commentToUpdate = PullRequestCommentsHelper.getCommentToUpdate(getComments(request), comment);
-            if (commentToUpdate !=  null) {
-                log.debug("Got candidate comment to update. comment: {}", commentToUpdate.getComment());
-                if (!PullRequestCommentsHelper.shouldUpdateComment(comment, commentToUpdate.getComment())) {
-                    log.debug("sendMergeComment: Comment should not be updated");
-                    return;
-                }
-                log.debug("sendMergeComment: Going to update GitHub pull request comment");
-                updateComment(commentToUpdate.getCommentUrl(), comment, request);
-            } else {
-                log.debug("sendMergeComment: Going to create a new GitHub pull request comment");
-                addComment(request, comment);
-            }
-        }
-        catch (Exception e) {
-            // We "swallow" the exception so that the flow will not be terminated because of errors in GIT comments
-            log.error("Error while adding or updating repo pull request comment", e);
-        }
-    }
-
-    private void addComment(ScanRequest request, String comment) {
+    @Override
+    public void addComment(ScanRequest request, String comment) {
         log.debug("Adding a new comment");
         HttpEntity<?> httpEntity = new HttpEntity<>(RepoIssue.getJSONComment("body",comment).toString(), createAuthHeaders(request));
         restTemplate.exchange(request.getMergeNoteUri(), HttpMethod.POST, httpEntity, String.class);

--- a/src/main/java/com/checkmarx/flow/service/PullRequestCommentsHelper.java
+++ b/src/main/java/com/checkmarx/flow/service/PullRequestCommentsHelper.java
@@ -31,7 +31,7 @@ public class PullRequestCommentsHelper {
     }
 
     public static RepoComment getCommentToUpdate(List<RepoComment> existingComments, String newComment) {
-        CommentType commentType = getCommnetType(newComment);
+        CommentType commentType = getCommentType(newComment);
         List<RepoComment> relevantComments= getCheckmarxCommentsForType(existingComments, commentType);
         if (relevantComments.size() == 1) {
             return relevantComments.get(0);
@@ -39,7 +39,7 @@ public class PullRequestCommentsHelper {
         return null;
     }
 
-    private static CommentType getCommnetType(String comment) {
+    private static CommentType getCommentType(String comment) {
         if (isSastAndScaComment(comment)) {
             return CommentType.SCA_AND_SAST;
         }
@@ -87,7 +87,7 @@ public class PullRequestCommentsHelper {
     private static List<RepoComment> getCheckmarxCommentsForType(List<RepoComment> allComments, CommentType commentType) {
         List<RepoComment> result = new ArrayList<>();
         for (RepoComment comment: allComments) {
-            if (getCommnetType(comment.getComment()).equals(commentType)) {
+            if (getCommentType(comment.getComment()).equals(commentType)) {
                 result.add(comment);
             }
         }

--- a/src/main/java/com/checkmarx/flow/service/RepoService.java
+++ b/src/main/java/com/checkmarx/flow/service/RepoService.java
@@ -25,7 +25,7 @@ public abstract class RepoService {
 
     public abstract List<RepoComment> getComments(ScanRequest scanRequest) throws IOException;
 
-    protected void sendMergeComment(ScanRequest request, String comment){
+    public void sendMergeComment(ScanRequest request, String comment){
 
         try {
             RepoComment commentToUpdate =

--- a/src/main/java/com/checkmarx/flow/service/RepoService.java
+++ b/src/main/java/com/checkmarx/flow/service/RepoService.java
@@ -4,10 +4,12 @@ import com.checkmarx.flow.dto.RepoComment;
 import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.dto.Sources;
 import com.checkmarx.sdk.dto.sast.CxConfig;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.util.List;
 
+@Slf4j
 public abstract class RepoService {
     public abstract Sources getRepoContent(ScanRequest request);
 
@@ -17,5 +19,36 @@ public abstract class RepoService {
 
     public abstract void deleteComment(String url, ScanRequest scanRequest);
 
+    public abstract void updateComment(String commentUrl, String comment, ScanRequest scanRequest);
+
+    public abstract void addComment(ScanRequest scanRequest, String comment);
+
     public abstract List<RepoComment> getComments(ScanRequest scanRequest) throws IOException;
+
+    protected void sendMergeComment(ScanRequest request, String comment){
+
+        try {
+            RepoComment commentToUpdate =
+                    PullRequestCommentsHelper.getCommentToUpdate(getComments(request), comment);
+            if (commentToUpdate !=  null) {
+                log.debug("Got candidate comment to update. comment: {}", commentToUpdate.getComment());
+                if (!PullRequestCommentsHelper.shouldUpdateComment(comment, commentToUpdate.getComment())) {
+                    log.debug("sendMergeComment: Comment should not be updated");
+                    return;
+                }
+                log.debug("sendMergeComment: Going to update {} pull request comment",
+                          request.getRepoType());
+                updateComment(commentToUpdate.getCommentUrl(), comment, request);
+            } else {
+                log.debug("sendMergeComment: Going to create a new {} pull request comment", request.getRepoType());
+                addComment(request, comment);
+            }
+        }
+        catch (Exception e) {
+            // We "swallow" the exception so that the flow will not be terminated because of errors in GIT comments
+            log.error("Error while adding or updating {} repo pull request comment",
+                      request.getRepoType(), e);
+        }
+
+    }
 }

--- a/src/main/java/com/checkmarx/flow/service/ResultsService.java
+++ b/src/main/java/com/checkmarx/flow/service/ResultsService.java
@@ -55,7 +55,7 @@ public class ResultsService {
     public CompletableFuture<ScanResults> processScanResultsAsync(ScanRequest request, Integer projectId,
                                                                   Integer scanId, String osaScanId, FilterConfiguration filterConfiguration) throws MachinaException {
         try {
-                    
+
             CompletableFuture<ScanResults> future = new CompletableFuture<>();
             //TODO async these, and join and merge after
             ScanResults results = cxScannerService.getScannerClient().getReportContentByScanId(scanId, filterConfiguration);
@@ -122,7 +122,7 @@ public class ResultsService {
 
 
     public void processResults(ScanRequest request, ScanResults results, ScanDetails scanDetails) throws MachinaException {
-        
+
         scanDetails = Optional.ofNullable(scanDetails).orElseGet(ScanDetails::new);
         if (Boolean.FALSE.equals(cxScannerService.getProperties().getOffline())) {
             getCxFields(request, results);
@@ -185,7 +185,7 @@ public class ResultsService {
             log.info(String.format("request : %s", request));
             log.info(String.format("results : %s", results));
             log.info(String.format("projectId : %s", projectId));
-            log.info("Process completed Succesfully");
+            log.info("Process completed Successfully");
         }
     }
 
@@ -371,4 +371,3 @@ public class ResultsService {
     }
 
 }
-

--- a/src/test/resources/cucumber/features/integrationTests/pull-request-comments-update.feature
+++ b/src/test/resources/cucumber/features/integrationTests/pull-request-comments-update.feature
@@ -1,63 +1,93 @@
 @PullRequestUpdateComment @Integration
-  Feature: After scan that was initiated by pull request, CxFlow should update the PR comments, instead of creating new one.
+Feature: After scan that was initiated by pull request, CxFlow should update the PR comments, instead of creating new one.
 
-    Scenario Outline: CxFlow should create new comments on Github Pull request with scan results summary
-      Given scanner is set to "<scanner>"
-      Given source control is GitHub
-      And no comments on pull request
-      When pull request arrives to CxFlow
-      Then Wait for comments
-      And verify new comments
+  Scenario Outline: CxFlow should create new comments on Github Pull request with scan results summary
+    Given scanner is set to "<scanner>"
+    Given source control is GitHub
+    And no comments on pull request
+    When pull request arrives to CxFlow
+    Then Wait for comments
+    And verify new comments
 
-      Examples:
-        | scanner |
-        | sca     |
-        | sast    |
-        | both    |
+    Examples:
+      | scanner |
+      | sca     |
+      | sast    |
+      | both    |
 
 
-    Scenario Outline: CxFlow should update existing comments on Github Pull request with scan results summary
-      Given scanner is set to "<scanner>"
-      Given source control is GitHub
-      And no comments on pull request
-      And pull request arrives to CxFlow
-      And Wait for comments
-      And different filters configuration is set
-      When pull request arrives to CxFlow
-      Then Wait for updated comment
+  Scenario Outline: CxFlow should update existing comments on Github Pull request with scan results summary
+    Given scanner is set to "<scanner>"
+    Given source control is GitHub
+    And no comments on pull request
+    And pull request arrives to CxFlow
+    And Wait for comments
+    And different filters configuration is set
+    When pull request arrives to CxFlow
+    Then Wait for updated comment
 
-      Examples:
-        | scanner |
-        | sca    |
-        | sast   |
-        | both    |
+    Examples:
+      | scanner |
+      | sca     |
+      | sast    |
+      | both    |
 
-    Scenario Outline: CxFlow should create new comments on Github Pull request with scan results summary
-      Given scanner is set to "<scanner>"
-      Given source control is ADO
-      And no comments on pull request
-      When pull request arrives to CxFlow
-      Then Wait for comments
-      And verify new comments
+  Scenario Outline: CxFlow should create new comments on ADO Pull request with scan results summary
+    Given scanner is set to "<scanner>"
+    Given source control is ADO
+    And no comments on pull request
+    When pull request arrives to CxFlow
+    Then Wait for comments
+    And verify new comments
 
-      Examples:
-        | scanner |
-        | sca    |
-        | sast   |
-        | both    |
+    Examples:
+      | scanner |
+      | sca     |
+      | sast    |
+      | both    |
 
-    Scenario Outline: ADO Pull request arrives to CxFlow, then scan is initiated, and pull request comments should be updated.
-      Given scanner is set to "<scanner>"
-      Given source control is ADO
-      And no comments on pull request
-      And pull request arrives to CxFlow
-      And Wait for comments
-      When pull request arrives to CxFlow
-      Then Wait for comments
-      And Wait for updated comment
+  Scenario Outline: ADO Pull request arrives to CxFlow, then scan is initiated, and pull request comments should be updated.
+    Given scanner is set to "<scanner>"
+    Given source control is ADO
+    And no comments on pull request
+    And pull request arrives to CxFlow
+    And Wait for comments
+    When pull request arrives to CxFlow
+    Then Wait for comments
+    And Wait for updated comment
 
-      Examples:
-        | scanner |
-        | sca    |
-        | sast   |
-        | both    |
+    Examples:
+      | scanner |
+      | sca     |
+      | sast    |
+      | both    |
+
+  Scenario Outline: CxFlow should create new comments on Gitlab Pull request with scan results summary
+    Given scanner is set to "<scanner>"
+    Given source control is Gitlab
+    And no comments on pull request
+    When pull request arrives to CxFlow
+    Then Wait for comments
+    And verify new comments
+
+    Examples:
+      | scanner |
+      | sca     |
+      | sast    |
+      | both    |
+
+  Scenario Outline: CxFlow should update existing comments on Gitlab Pull request with scan results summary
+    Given scanner is set to "<scanner>"
+    Given source control is Gitlab
+    And no comments on pull request
+    And pull request arrives to CxFlow
+    And Wait for comments
+    And different filters configuration is set
+    When pull request arrives to CxFlow
+    Then Wait for updated comment
+
+    Examples:
+      | scanner |
+      | sca     |
+      | sast    |
+      | both    |


### PR DESCRIPTION
Description
User story 129:
https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/129

Gitlab - Reduced comments notifications on pull requests + Tests

Testing
Gitlab new scenarios covered by tests
First, create a new merge request scan (SAST, SCA, and Both), add comments, and verify they exist.
Second create a new merge request scan (SAST, SCA, and Both), add comments, and verify they exist then commit another change to the previous merge request, update comments and verify comments are updated.

Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
