### PR TITLE
Prevent ConcurrentModificationException error while execute batch mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
 
   sonar:
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:11-jdk
     steps:
       - checkout
       - run:

--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -40,6 +40,7 @@ import java.net.URISyntaxException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @Service
@@ -64,7 +65,7 @@ public class JiraService {
     private List<String> currentClosedIssuesList = new ArrayList<>();
 
     //Map used to store/retrieve custom field values
-    private Map<String, Map<String, String>> customFields = new HashMap<>();
+    private final ConcurrentHashMap<String, Map<String, String>> customFields = new ConcurrentHashMap<>();
 
     private static final String LABEL_FIELD_TYPE = "labels";
     private static final String SECURITY_FIELD_TYPE = "security";


### PR DESCRIPTION
### Description

On batch mode CxFlow attempting to modify a map on multiple threads to add the custom_fields for Jira into it. Since they are all using the same Jira service, The code is trying to modify data on multiple threads with no protection.

### References

https://github.com/checkmarx-ltd/cx-flow/issues/603

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
