### PR TITLE
Support SCA project teams assignment

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.4.79"
+        CxSBSDK = "0.4.80"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.4.79"
+        CxSBSDK = "0.4.80"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/docs/Integration-with-CxSCA.md
+++ b/docs/Integration-with-CxSCA.md
@@ -5,6 +5,7 @@
 * [Configuration As Code](#configurationascode)
 * [SCA Scans From Command Line](#commandline)
 * [SCA ZIP Folder Scan](#zipFolderScan)
+* [SCA Project Team Assignment](#scaProjectTeamAssignment)
 
 ## <a name="configuration">Configuration</a>
 CxSCA scans can be triggered based on WebHooks using CxFlow. 
@@ -180,3 +181,31 @@ In order to change the default CxFlow SCA scan behaviour and to perform a SCA ZI
 ```
 enabledZipScan: true
 ```
+
+## <a name="scaProjectTeamAssignment">SCA project team assignment</a>
+SCA project team assignment with CxFlow is performing on the SCA project creation stage. In order to set a project team, the next configuration property should be added underneath the sca configuration section:
+```
+team: /CxServer/MyTeam
+```
+* In order to declare a team within a tree hierarchy, make sure to use the forward slash ('/').
+* Declaring not existing team or team path will be resulted with 400 BAD REQUEST error.
+
+## <a name="scaProjectTeamAssignment">SCA project team assignment</a>
+SCA project team assignment with CxFlow is performing on the SCA project creation stage. In order to set a project team, the next configuration property should be added underneath the sca configuration section:
+```
+team: /CxServer/MyTeam
+```
+* In order to declare a team within a tree hierarchy, make sure to use the forward slash ('/').
+* Declaring not existing team or team path will be resulted with 400 BAD REQUEST error.
+
+## <a name="scaProjectTeamAssignment">SCA project team assignment</a>
+SCA project team assignment with CxFlow is performing on the SCA project creation stage. In order to set a project team, the next configuration property should be added underneath the sca configuration section:
+```
+teamForNewProjects: /team
+```
+Or within a tree hierarchy:
+```
+teamForNewProjects: /MainTeam/SubTeam
+```
+* In order to declare a team within a tree hierarchy, make sure to use the forward slash ('/').
+* Declaring not existing team or team path will be resulted with 400 BAD REQUEST error.

--- a/docs/Integration-with-CxSCA.md
+++ b/docs/Integration-with-CxSCA.md
@@ -185,22 +185,6 @@ enabledZipScan: true
 ## <a name="scaProjectTeamAssignment">SCA project team assignment</a>
 SCA project team assignment with CxFlow is performing on the SCA project creation stage. In order to set a project team, the next configuration property should be added underneath the sca configuration section:
 ```
-team: /CxServer/MyTeam
-```
-* In order to declare a team within a tree hierarchy, make sure to use the forward slash ('/').
-* Declaring not existing team or team path will be resulted with 400 BAD REQUEST error.
-
-## <a name="scaProjectTeamAssignment">SCA project team assignment</a>
-SCA project team assignment with CxFlow is performing on the SCA project creation stage. In order to set a project team, the next configuration property should be added underneath the sca configuration section:
-```
-team: /CxServer/MyTeam
-```
-* In order to declare a team within a tree hierarchy, make sure to use the forward slash ('/').
-* Declaring not existing team or team path will be resulted with 400 BAD REQUEST error.
-
-## <a name="scaProjectTeamAssignment">SCA project team assignment</a>
-SCA project team assignment with CxFlow is performing on the SCA project creation stage. In order to set a project team, the next configuration property should be added underneath the sca configuration section:
-```
 teamForNewProjects: /team
 ```
 Or within a tree hierarchy:

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/sca_scanner/teams/RunSCATeamsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/sca_scanner/teams/RunSCATeamsSteps.java
@@ -1,0 +1,12 @@
+package com.checkmarx.flow.cucumber.integration.sca_scanner.teams;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(plugin = { "pretty", "summary", "html:build/cucumber/integration/sca", "json:build/cucumber/integration/sca/cucumber.json" },
+        features = "src/test/resources/cucumber/features/integrationTests/sca/teams.feature",
+        tags = "not @Skip")
+public class RunSCATeamsSteps {
+}

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/sca_scanner/teams/SCATeamsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/sca_scanner/teams/SCATeamsSteps.java
@@ -1,0 +1,126 @@
+package com.checkmarx.flow.cucumber.integration.sca_scanner.teams;
+
+import com.checkmarx.flow.CxFlowApplication;
+import com.checkmarx.flow.config.FlowProperties;
+import com.checkmarx.flow.cucumber.integration.sca_scanner.ScaCommonSteps;
+import com.checkmarx.flow.service.SCAScanner;
+import com.checkmarx.flow.service.ScaConfigurationOverrider;
+import com.checkmarx.sdk.config.RestClientConfig;
+import com.checkmarx.sdk.config.ScaProperties;
+import com.checkmarx.sdk.dto.RemoteRepositoryInfo;
+import com.checkmarx.sdk.dto.sca.ScaConfig;
+import com.checkmarx.sdk.dto.sca.Project;
+import com.checkmarx.sdk.exception.CxHTTPClientException;
+import com.checkmarx.sdk.utils.scanner.client.ScaClientHelper;
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
+import org.junit.Assert;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.IOException;
+import java.rmi.Remote;
+import java.util.Collections;
+import java.util.List;
+
+@SpringBootTest(classes = {CxFlowApplication.class})
+@Slf4j
+public class SCATeamsSteps extends ScaCommonSteps {
+
+    private static final String PROJECT_NAME = "Team-Test-Project";
+    private final ScaProperties scaProperties;
+
+    private ScaClientHelper scaClientHelper;
+    private String projectId;
+    private int errorStatusCode;
+
+    public SCATeamsSteps(FlowProperties flowProperties, SCAScanner scaScanner,
+                         ScaConfigurationOverrider scaConfigOverrider, ScaProperties scaProperties) {
+        super(flowProperties, scaScanner, scaConfigOverrider);
+        this.scaProperties = scaProperties;
+        this.scaClientHelper = new ScaClientHelper(createRestClientConfig(), log, scaProperties);
+    }
+
+    @After()
+    public void cleanUp() throws IOException {
+        if (StringUtils.isNotEmpty(projectId)) {
+            scaClientHelper.deleteProjectById(projectId);
+        }
+    }
+
+    @Before()
+    public void init() throws IOException {
+        initSCAConfig(scaProperties);
+        scaClientHelper.init();
+        deleteProjectIfAlreadyExists();
+    }
+
+    @Given("scanner is SCA")
+    public void setScanner() {
+        flowProperties.setEnabledVulnerabilityScanners(Collections.singletonList(ScaProperties.CONFIG_PREFIX));
+    }
+
+    @When("creating a new project with associated {string} value")
+    public void createNewProjectTeam(String team) throws IOException {
+        if (team.equals("null")) {
+            team = null;
+        }
+        scaProperties.setTeamForNewProjects(team);
+        try {
+            projectId = scaClientHelper.createRiskManagementProject(PROJECT_NAME);
+        } catch (CxHTTPClientException e) {
+            errorStatusCode = e.getStatusCode();
+        }
+    }
+
+    @Then("project assignedTeams returned value is {string}")
+    public void validateAssignedTeam(String expectedAssignedTeam) throws IOException {
+        String actualTeam;
+        Project projectDetails = scaClientHelper.getProjectDetailsByProjectId(projectId);
+        List<String> assignedTeams = projectDetails.getAssignedTeams();
+
+        if (assignedTeams.isEmpty()) {
+            actualTeam = "";
+            actualTeam = "";
+        } else {
+            actualTeam = assignedTeams.get(0);
+        }
+
+        Assert.assertEquals(expectedAssignedTeam, actualTeam);
+    }
+
+    @Then("bad request error is expected to be thrown")
+    public void validateNotExistsTeam() {
+        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, errorStatusCode);
+    }
+
+
+    private void deleteProjectIfAlreadyExists() throws IOException {
+        String projectId = scaClientHelper.createRiskManagementProject(PROJECT_NAME);
+        if (StringUtils.isNotEmpty(projectId)) {
+            scaClientHelper.deleteProjectById(projectId);
+        }
+    }
+
+    private RestClientConfig createRestClientConfig() {
+        ScaConfig scaConfig = new ScaConfig();
+        scaConfig.setTenant(scaProperties.getTenant());
+        scaConfig.setApiUrl(scaProperties.getApiUrl());
+        scaConfig.setUsername(scaProperties.getUsername());
+        scaConfig.setPassword(scaProperties.getPassword());
+        scaConfig.setAccessControlUrl(scaProperties.getAccessControlUrl());
+        scaConfig.setRemoteRepositoryInfo(new RemoteRepositoryInfo());
+
+        RestClientConfig restClientConfig = new RestClientConfig();
+        restClientConfig.setScaConfig(scaConfig);
+        restClientConfig.setProjectName(PROJECT_NAME);
+
+        return restClientConfig;
+    }
+}

--- a/src/test/resources/cucumber/features/integrationTests/sca/teams.feature
+++ b/src/test/resources/cucumber/features/integrationTests/sca/teams.feature
@@ -1,0 +1,22 @@
+Feature: Cx-Flow SCA teams tests
+
+  Scenario Outline: Create project team and validated returned assignedTeams value
+    Given scanner is SCA
+    When creating a new project with associated "<team>" value
+    Then project assignedTeams returned value is "<returned_value>"
+
+    # empty team -> team: (team does exists, but without any value)
+    # team = null -> team property doesn't exists in configuration
+
+    Examples:
+      | team             | returned_value   |
+      |                  |                  |
+      | null             |                  |
+      | /CxServer        | /CxServer        |
+      | /CxServer/MyTeam | /CxServer/MyTeam |
+
+
+  Scenario: Create project without existing team
+    Given scanner is SCA
+    When creating a new project with associated "no_exists_team" value
+    Then bad request error is expected to be thrown


### PR DESCRIPTION
### Description

> Support SCA project teams assignment when a new project is being created.

### References

> [User Story](https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/495)

### Testing

> Both positive & negative integration tests were added. The positive tests validate the new team assignment and the negative one validates an error is getting occur while trying to assign not existing team to a project.

### Checklist

- [X] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
