### PR TITLE
Support on-premise SCMs in CxIntegrations calls

### DIFF
--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -267,20 +267,11 @@ public class ConfigurationOverrider {
 
     private void applyCxGoDynamicConfig(Map<String, String> overrideReport, ScanRequest request) {
         if (cxIntegrationsProperties.isReadMultiTenantConfiguration()) {
-            String scmType = request.getRepoType().getRepository().toLowerCase();
+            String orgId = Optional.ofNullable(request.getOrganizationId())
+                    .orElseThrow(() -> new MachinaRuntimeException(
+                            "Organization id is missing for SCM: " + request.getRepoType().getRepository()));
 
-            /*
-                When ADO is the SCM event trigger, the Repos-Manager expects to get 'azure' in the URL path
-                rather than 'ado'. Was decided to make the change here rather than the other services
-             */
-            if (scmType.equalsIgnoreCase(ScanRequest.Repository.ADO.getRepository())) {
-                scmType = "azure";
-            }
-
-            CxGoConfigFromWebService cxgoConfig = reposManagerService.getCxGoDynamicConfig(
-                    scmType,
-                    Optional.ofNullable(request.getOrganizationId())
-                            .orElseThrow(() -> new MachinaRuntimeException("Organization id is missing for SCM: " + request.getRepoType().getRepository())));
+            CxGoConfigFromWebService cxgoConfig = reposManagerService.getCxGoDynamicConfig(request.getGitUrl(), orgId);
 
             if (cxgoConfig == null) {
                 log.error("Multi Tenant mode: missing CxGo configuration in Repos Manager Service. Working with Multi Tenant = false ");

--- a/src/main/java/com/checkmarx/flow/service/ReposManagerService.java
+++ b/src/main/java/com/checkmarx/flow/service/ReposManagerService.java
@@ -23,20 +23,20 @@ public class ReposManagerService {
     private final RestTemplate restTemplate;
     private final CxIntegrationsProperties cxIntegrationsProperties;
 
-    private String cxGoConfigUrlPattern;
+    private final String cxGoConfigUrlPattern;
 
     public ReposManagerService(@Qualifier("flowRestTemplate") RestTemplate restTemplate,
                                CxIntegrationsProperties cxIntegrationsProperties) {
         this.restTemplate = restTemplate;
         this.cxIntegrationsProperties = cxIntegrationsProperties;
 
-        cxGoConfigUrlPattern = cxIntegrationsProperties.getUrl() + "/%s/orgs/%s/tenantConfig";
+        cxGoConfigUrlPattern = cxIntegrationsProperties.getUrl() + "/cxFlowConfig?orgId=%s&repoUrl=%s";
     }
 
-    public CxGoConfigFromWebService getCxGoDynamicConfig(String scmType, String orgId) {
+    public CxGoConfigFromWebService getCxGoDynamicConfig(String repoGitUrl, String orgId) {
         if (StringUtils.isNotEmpty(cxIntegrationsProperties.getUrl())) {
-            String urlPath = String.format(cxGoConfigUrlPattern, scmType, urlEncode(orgId));
-            log.info("Overriding Cx-Go configuration for SCM type: {} and organization ID: {}", scmType, orgId);
+            log.info("Overriding CxGo configuration for the '{}' repo and '{}' organization.", repoGitUrl, orgId);
+            String urlPath = String.format(cxGoConfigUrlPattern, urlEncode(repoGitUrl), urlEncode(orgId));
             ResponseEntity<CxGoConfigFromWebService> responseEntity;
             try {
                 responseEntity = restTemplate.getForEntity(urlPath, CxGoConfigFromWebService.class);

--- a/src/main/java/com/checkmarx/flow/service/ReposManagerService.java
+++ b/src/main/java/com/checkmarx/flow/service/ReposManagerService.java
@@ -2,7 +2,6 @@ package com.checkmarx.flow.service;
 
 import com.checkmarx.flow.config.CxIntegrationsProperties;
 import com.checkmarx.flow.config.external.CxGoConfigFromWebService;
-import com.checkmarx.flow.exception.MachinaRuntimeException;
 import com.checkmarx.flow.exception.ReposManagerException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -12,48 +11,38 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-
 @Service
 @Slf4j
 public class ReposManagerService {
+    private static final String CXFLOW_CONFIG_TEMPLATE = "/cxFlowConfig?repoUrl={repoUrl}&orgId={orgId}";
 
     private final RestTemplate restTemplate;
     private final CxIntegrationsProperties cxIntegrationsProperties;
-
-    private final String cxGoConfigUrlPattern;
 
     public ReposManagerService(@Qualifier("flowRestTemplate") RestTemplate restTemplate,
                                CxIntegrationsProperties cxIntegrationsProperties) {
         this.restTemplate = restTemplate;
         this.cxIntegrationsProperties = cxIntegrationsProperties;
-
-        cxGoConfigUrlPattern = cxIntegrationsProperties.getUrl() + "/cxFlowConfig?orgId=%s&repoUrl=%s";
     }
 
     public CxGoConfigFromWebService getCxGoDynamicConfig(String repoGitUrl, String orgId) {
-        if (StringUtils.isNotEmpty(cxIntegrationsProperties.getUrl())) {
-            log.info("Overriding CxGo configuration for the '{}' repo and '{}' organization.", repoGitUrl, orgId);
-            String urlPath = String.format(cxGoConfigUrlPattern, urlEncode(repoGitUrl), urlEncode(orgId));
-            ResponseEntity<CxGoConfigFromWebService> responseEntity;
-            try {
-                responseEntity = restTemplate.getForEntity(urlPath, CxGoConfigFromWebService.class);
-            } catch (HttpClientErrorException e) {
-                throw new ReposManagerException("HttpClientErrorException: " + e.getMessage());
-            }
-            return responseEntity.getBody();
+        String apiBaseUrl = cxIntegrationsProperties.getUrl();
+        if (StringUtils.isNotEmpty(apiBaseUrl)) {
+            String fullUrlTemplate = apiBaseUrl + CXFLOW_CONFIG_TEMPLATE;
+            log.info("Overriding CxGo configuration for the '{}' organization and repo URL: {}", repoGitUrl, orgId);
+            return getConfigResponse(repoGitUrl, orgId, fullUrlTemplate);
         } else {
-            throw new ReposManagerException("Repos-manager cannot be reached. URL is blank or empty");
+            throw new ReposManagerException("ReposManager cannot be reached. URL is blank or empty");
         }
     }
 
-    private static String urlEncode(String orgName) {
+    private CxGoConfigFromWebService getConfigResponse(String repoGitUrl, String orgId, String urlTemplate) {
+        ResponseEntity<CxGoConfigFromWebService> responseEntity;
         try {
-            return URLEncoder.encode(orgName, StandardCharsets.UTF_8.toString());
-        } catch (UnsupportedEncodingException e) {
-            throw new MachinaRuntimeException("Error while trying to encode input: " + orgName + " with error message: " + e.getMessage());
+            responseEntity = restTemplate.getForEntity(urlTemplate, CxGoConfigFromWebService.class, repoGitUrl, orgId);
+        } catch (HttpClientErrorException e) {
+            throw new ReposManagerException("HttpClientErrorException: " + e.getMessage());
         }
+        return responseEntity.getBody();
     }
 }

--- a/src/main/java/com/checkmarx/flow/service/ReposManagerService.java
+++ b/src/main/java/com/checkmarx/flow/service/ReposManagerService.java
@@ -29,7 +29,7 @@ public class ReposManagerService {
         String apiBaseUrl = cxIntegrationsProperties.getUrl();
         if (StringUtils.isNotEmpty(apiBaseUrl)) {
             String fullUrlTemplate = apiBaseUrl + CXFLOW_CONFIG_TEMPLATE;
-            log.info("Overriding CxGo configuration for the '{}' organization and repo URL: {}", repoGitUrl, orgId);
+            log.info("Overriding CxGo configuration for the '{}' organization. Repo URL: {}", orgId, repoGitUrl);
             return getConfigResponse(repoGitUrl, orgId, fullUrlTemplate);
         } else {
             throw new ReposManagerException("ReposManager cannot be reached. URL is blank or empty");


### PR DESCRIPTION
### Description

Previously, to get CxGo config from CxIntegrations, the following data was sent to the CxIntegrations API: 
- SCM type ("gitlab", "bitbucket" etc.)
- SCM organization id

Now, on-premise SCM support was added to CxIntegrations. This means that we no longer can send SCM type to CxIntegrations. E.g. there can be several "bitbuckets". Instead, we are now sending
- repository URL, as used in 'git clone'
- SCM organization id - same as previously

Using these 2 parameters, CxIntegrations can figure out which SCM instance CxFlow is asking about.

### References

Work item [366](https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/366/).
Depends on [this PR](https://github.com/checkmarx-ltd/Integrations-ReposManager/pull/35).

### Testing

Tested manually with several kinds of cloud-based SCMs. It's not possible to test the new functionality with on-prem SCM versions yet.