### PR TITLE
Support include source files option for SCA zip scan

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.4.86"
+        CxSBSDK = "0.4.87"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.4.84"
+        CxSBSDK = "0.4.86"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.4.86"
+        CxSBSDK = "0.4.87"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.4.84"
+        CxSBSDK = "0.4.86"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/docs/Integration-with-CxSCA.md
+++ b/docs/Integration-with-CxSCA.md
@@ -195,6 +195,11 @@ In order to change the default CxFlow SCA scan behaviour and to perform a SCA ZI
 ```
 enabledZipScan: true
 ```
+Additional configuration in SCA zip scan flow - Include source files
+* Default value set to false, In order to change the default CxFlow SCA zip scan behaviour, the next configuration property should be added underneath the sca configuration section:
+```
+includeSources: true
+```
 
 ## <a name="scaProjectTeamAssignment">SCA project team assignment</a>
 SCA project team assignment with CxFlow is performing on the SCA project creation stage. In order to set a project team, the next configuration property should be added underneath the sca configuration section:

--- a/src/main/java/com/checkmarx/flow/service/SCAScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/SCAScanner.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 public class SCAScanner extends AbstractASTScanner {
 
     private final ScaProperties scaProperties;
-    private CxRepoFileHelper cxRepoFileHelper;
+    private final CxRepoFileHelper cxRepoFileHelper;
 
     public SCAScanner(ScaScanner scaClient, FlowProperties flowProperties, BugTrackerEventTrigger bugTrackerEventTrigger,
                       ScaProperties scaProperties) {
@@ -51,8 +51,9 @@ public class SCAScanner extends AbstractASTScanner {
         try {
             if (scaProperties.isEnabledZipScan()) {
                 log.info("CxAST-SCA zip scan is enabled");
-                String scaZipFolderPath = cxRepoFileHelper.getScaZipFolderPath(scanRequest.getRepoUrlWithAuth(), scanRequest.getExcludeFiles(), scanRequest.getBranch());
-                scanParams.setZipPath(scaZipFolderPath);
+                String scaClonedFolderPath = cxRepoFileHelper.getScaClonedRepoFolderPath(scanRequest.getRepoUrlWithAuth(), scanRequest.getExcludeFiles(), scanRequest.getBranch());
+                scanParams.setSourceDir(scaClonedFolderPath);
+                scanParams.getScaConfig().setExcludeFiles(scanRequest.getExcludeFiles());
             }
         } catch (CheckmarxException e) {
             throw new MachinaRuntimeException(e.getMessage());

--- a/src/main/java/com/checkmarx/flow/service/ScaConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ScaConfigurationOverrider.java
@@ -150,7 +150,7 @@ public class ScaConfigurationOverrider {
     }
 
     private static void addToReport(ScaConfig config, Map<String, String> report) {
-        report.put("accessControlUrl", config.getAccessControlUrl());
+        report.put(ACCESS_CONTROL_URL, config.getAccessControlUrl());
         report.put(API_URL, config.getApiUrl());
         report.put(APP_URL, config.getAppUrl());
         report.put(TENANT, config.getTenant());

--- a/src/main/java/com/checkmarx/flow/service/ScaConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ScaConfigurationOverrider.java
@@ -24,6 +24,17 @@ import java.util.Optional;
 public class ScaConfigurationOverrider {
     private static final ModelMapper modelMapper = new ModelMapper();
 
+    private static final String ACCESS_CONTROL_URL = "accessControlUrl";
+    private static final String API_URL = "apiUrl";
+    private static final String APP_URL = "appUrl";
+    private static final String TENANT = "tenant";
+    private static final String THRESHOLDS_SEVERITY = "thresholdsSeverity";
+    private static final String THRESHOLDS_SCORE = "thresholdsScore";
+    private static final String INCLUDE_SOURCES = "includeSources";
+
+    private static final String FILTER_SCORE = "filterScore";
+    private static final String FILTER_SEVERITY = "filterSeverity";
+
     private final ScaProperties scaProperties;
     private final ScaFilterFactory scaFilterFactory;
 
@@ -61,32 +72,37 @@ public class ScaConfigurationOverrider {
 
         sca.map(Sca::getAccessControlUrl).ifPresent(accessControlUrl -> {
             scaConfig.setAccessControlUrl(accessControlUrl);
-            overrideReport.put("accessControlUrl", accessControlUrl);
+            overrideReport.put(ACCESS_CONTROL_URL, accessControlUrl);
         });
 
         sca.map(Sca::getApiUrl).ifPresent(apiUrl -> {
             scaConfig.setApiUrl(apiUrl);
-            overrideReport.put("apiUrl", apiUrl);
+            overrideReport.put(API_URL, apiUrl);
         });
 
         sca.map(Sca::getAppUrl).ifPresent(appUrl -> {
             scaConfig.setAppUrl(appUrl);
-            overrideReport.put("appUrl", appUrl);
+            overrideReport.put(APP_URL, appUrl);
         });
 
         sca.map(Sca::getTenant).ifPresent(tenant -> {
             scaConfig.setTenant(tenant);
-            overrideReport.put("tenant", tenant);
+            overrideReport.put(TENANT, tenant);
         });
 
         sca.map(Sca::getThresholdsSeverity).ifPresent(thresholdsSeverity -> {
             scaConfig.setThresholdsSeverityDirectly(thresholdsSeverity);
-            overrideReport.put("thresholdsSeverity", ScanUtils.convertMapToString(thresholdsSeverity));
+            overrideReport.put(THRESHOLDS_SEVERITY, ScanUtils.convertMapToString(thresholdsSeverity));
         });
 
         sca.map(Sca::getThresholdsScore).ifPresent(thresholdsScore -> {
             scaConfig.setThresholdsScore(thresholdsScore);
-            overrideReport.put("thresholdsScore", String.valueOf(thresholdsScore));
+            overrideReport.put(THRESHOLDS_SCORE, String.valueOf(thresholdsScore));
+        });
+
+        sca.map(Sca::isIncludeSources).ifPresent(includeSources -> {
+            scaConfig.setIncludeSources(includeSources);
+            overrideReport.put(INCLUDE_SOURCES, String.valueOf(includeSources));
         });
 
         overrideSeverityFilters(request, sca, overrideReport);
@@ -100,7 +116,7 @@ public class ScaConfigurationOverrider {
         override.map(Sca::getFilterScore).ifPresent(score -> {
             Filter filterFromOverride = scaFilterFactory.getScoreFilter(score);
             if (replaceFiltersOfType(request, Collections.singletonList(filterFromOverride), Filter.Type.SCORE)) {
-                overrideReport.put("filterScore", String.valueOf(filterFromOverride));
+                overrideReport.put(FILTER_SCORE, String.valueOf(filterFromOverride));
             }
         });
     }
@@ -109,7 +125,7 @@ public class ScaConfigurationOverrider {
         override.map(Sca::getFilterSeverity).ifPresent(severities -> {
             List<Filter> filtersFromOverride = scaFilterFactory.getSeverityFilters(severities);
             if (replaceFiltersOfType(request, filtersFromOverride, Filter.Type.SEVERITY)) {
-                overrideReport.put("filterSeverity", severities.toString());
+                overrideReport.put(FILTER_SEVERITY, severities.toString());
             }
         });
     }
@@ -135,10 +151,10 @@ public class ScaConfigurationOverrider {
 
     private static void addToReport(ScaConfig config, Map<String, String> report) {
         report.put("accessControlUrl", config.getAccessControlUrl());
-        report.put("apiUrl", config.getApiUrl());
-        report.put("appUrl", config.getAppUrl());
-        report.put("tenant", config.getTenant());
-        report.put("thresholdsSeverity", ScanUtils.convertMapToString(config.getThresholdsSeverity()));
-        report.put("thresholdsScore", String.valueOf(config.getThresholdsScore()));
+        report.put(API_URL, config.getApiUrl());
+        report.put(APP_URL, config.getAppUrl());
+        report.put(TENANT, config.getTenant());
+        report.put(THRESHOLDS_SEVERITY, ScanUtils.convertMapToString(config.getThresholdsSeverity()));
+        report.put(THRESHOLDS_SCORE, String.valueOf(config.getThresholdsScore()));
     }
 }


### PR DESCRIPTION
### Description

Additional configuration in SCA zip scan flow - Include source files

Default value set to false, In order to change the default CxFlow SCA zip scan behavior this property, should be added underneath the SCA configuration section:
includeSources: true

### Checklist

- [X] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
