### PR TITLE
Added a test scenario for severity filter

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.4.91"
+        CxSBSDK = "0.4.92"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.4.91"
+        CxSBSDK = "0.4.92"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/src/test/java/com/checkmarx/flow/cucumber/component/parse/LoadingSastResultsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/parse/LoadingSastResultsSteps.java
@@ -105,6 +105,13 @@ public class LoadingSastResultsSteps {
         testContext.setBaseFilenames(baseFilenames);
     }
 
+    @Given("^(?:input has one vulnerability type with \"Low\" severity" +
+            "|input has one finding with this vulnerability type" +
+            "|user has overridden the severity of this specific finding with the \"High\" value)$")
+    public void inputHasOneLow() {
+        testContext.setInputFilename("1-finding-custom-severity.xml");
+    }
+
     private List<String> getSastResultsHavingReferenceReports() throws IOException, URISyntaxException {
         Set<String> sampleSastResults = getResourceFilenames(Constants.SAMPLE_SAST_RESULTS_DIR,
                 TestContext.SAST_RESULT_EXTENSION);

--- a/src/test/java/com/checkmarx/flow/cucumber/component/parse/RunningCxFlowSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/parse/RunningCxFlowSteps.java
@@ -53,7 +53,7 @@ public class RunningCxFlowSteps {
     }
 
     @When("running CxFlow with command line: {string}")
-    public void runningCxFlowWithCommandLineCommandLine(String commandLine) {
+    public void runningCxFlowWithCommandLine(String commandLine) {
         Throwable exception = null;
         try {
             TestUtils.runCxFlow(testContext.getCxFlowRunner(), commandLine);

--- a/src/test/java/com/checkmarx/flow/cucumber/component/parse/VerifyingCxFlowReportSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/parse/VerifyingCxFlowReportSteps.java
@@ -35,7 +35,7 @@ public class VerifyingCxFlowReportSteps {
         verifySummaryFieldCount(report.getSummary(), 0);
     }
 
-    @Then("CxFlow report is generated with {} issues")
+    @Then("CxFlow report is generated with {} issue(s)")
     public void reportIsGeneratedWithNIssues(int expectedIssueCount) throws IOException {
         CxFlowReport report = CxFlowReport.parse(testContext);
         JsonNode issues = report.getIssues();

--- a/src/test/java/com/checkmarx/flow/cucumber/component/parse/VerifyingCxFlowReportSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/parse/VerifyingCxFlowReportSteps.java
@@ -39,7 +39,7 @@ public class VerifyingCxFlowReportSteps {
     public void reportIsGeneratedWithNIssues(int expectedIssueCount) throws IOException {
         CxFlowReport report = CxFlowReport.parse(testContext);
         JsonNode issues = report.getIssues();
-        assertEquals(expectedIssueCount, issues.size());
+        assertEquals("Unexpected issue count in CxFlow response.", expectedIssueCount, issues.size());
     }
 
     @And("each issue contains {} results and the same number of details")
@@ -74,7 +74,7 @@ public class VerifyingCxFlowReportSteps {
         }
     }
 
-    @And("issue severities are: {}")
+    @And("^(?:the issue severity is|issue severities are:) (.+)$")
     public void issueSeveritiesAre(String severities) throws IOException {
         String[] expectedSeverities = TestsParseUtils.parseCSV(severities).toArray(String[]::new);
 

--- a/src/test/resources/cucumber/data/cxflow-reference-reports/2-findings-different-severity.json
+++ b/src/test/resources/cucumber/data/cxflow-reference-reports/2-findings-different-severity.json
@@ -1,82 +1,59 @@
 {
-  "projectId": "6",
-  "team": "CxServer",
-  "project": "some-example",
-  "link": "http://CX-FLOW-CLEAN/CxWebClient/ViewerMain.aspx?scanid=1000026&projectid=6",
-  "files": "1",
-  "loc": "268",
-  "scanType": "Full",
-  "additionalDetails": {
-    "flow-summary": {
-      "High": 1,
-      "Medium": 1
-    },
-    "scanId": "1000026",
-    "scanStartDate": "Sunday, January 19, 2020 2:40:11 AM"
-  },
-  "xissues": [
-    {
-      "vulnerability": "SQL_Injection",
-      "vulnerabilityStatus": "TO VERIFY",
-      "similarityId": "-1987639889",
-      "cwe": "89",
-      "description": "",
-      "language": "Java",
-      "severity": "High",
-      "link": "http://CX-FLOW-CLEAN/CxWebClient/ViewerMain.aspx?scanid=1000026&projectid=6&pathid=4",
-      "filename": "DOS_Login.java",
-      "falsePositiveCount": 0,
-      "details": {
-        "88": {
-          "falsePositive": false,
-          "codeSnippet": "\t    username = s.getParser().getRawParameter(USERNAME);",
-          "comment": ""
+    "projectId": "6",
+    "team": "CxServer",
+    "project": "some-example",
+    "link": "http://CX-FLOW-CLEAN/CxWebClient/ViewerMain.aspx?scanid=1000026&projectid=6",
+    "files": "1",
+    "loc": "268",
+    "scanType": "Full",
+    "additionalDetails": {
+        "flow-summary": {
+            "High": 1
         },
-        "89": {
-          "falsePositive": false,
-          "codeSnippet": "\t    password = s.getParser().getRawParameter(PASSWORD);",
-          "comment": ""
+        "scanId": "1000026",
+        "scanStartDate": "Sunday, January 19, 2020 2:40:11 AM"
+    },
+    "xissues": [{
+            "vulnerability": "SQL_Injection",
+            "vulnerabilityStatus": "TO VERIFY",
+            "similarityId": "-1987639889",
+            "cwe": "89",
+            "description": "",
+            "language": "Java",
+            "severity": "High",
+            "link": "http://CX-FLOW-CLEAN/CxWebClient/ViewerMain.aspx?scanid=1000026&projectid=6&pathid=4",
+            "filename": "DOS_Login.java",
+            "falsePositiveCount": 0,
+            "details": {
+                "88": {
+                    "falsePositive": false,
+                    "codeSnippet": "\t    username = s.getParser().getRawParameter(USERNAME);",
+                    "comment": ""
+                }
+            },
+            "additionalDetails": {
+                "CodeBashingLesson": "https://cxa.codebashing.com/courses/",
+                "recommendedFix": "http://CX-FLOW-CLEAN/CxWebClient/ScanQueryDescription.aspx?queryID=594&queryVersionCode=56142311&queryTitle=SQL_Injection",
+                "categories": "PCI DSS v3.2;PCI DSS (3.2) - 6.5.1 - Injection flaws - particularly SQL injection,OWASP Top 10 2013;A1-Injection,FISMA 2014;System And Information Integrity,NIST SP 800-53;SI-10 Information Input Validation (P1),OWASP Top 10 2017;A1-Injection,OWASP Mobile Top 10 2016;M7-Client Code Quality",
+                "results": [{
+                        "sink": {
+                            "file": "DOS_Login.java",
+                            "line": "114",
+                            "column": "45",
+                            "object": "executeQuery"
+                        },
+                        "state": "0",
+                        "source": {
+                            "file": "DOS_Login.java",
+                            "line": "88",
+                            "column": "46",
+                            "object": "getRawParameter"
+                        }
+                    }
+                ]
+            },
+            "allFalsePositive": false
         }
-      },
-      "additionalDetails": {
-        "recommendedFix": "http://CX-FLOW-CLEAN/CxWebClient/ScanQueryDescription.aspx?queryID=594&queryVersionCode=56142311&queryTitle=SQL_Injection",
-        "categories": "PCI DSS v3.2;PCI DSS (3.2) - 6.5.1 - Injection flaws - particularly SQL injection,OWASP Top 10 2013;A1-Injection,FISMA 2014;System And Information Integrity,NIST SP 800-53;SI-10 Information Input Validation (P1),OWASP Top 10 2017;A1-Injection,OWASP Mobile Top 10 2016;M7-Client Code Quality",
-        "results": [
-          {
-            "sink": {
-              "file": "DOS_Login.java",
-              "line": "114",
-              "column": "45",
-              "object": "executeQuery"
-            },
-            "state": "0",
-            "source": {
-              "file": "DOS_Login.java",
-              "line": "88",
-              "column": "46",
-              "object": "getRawParameter"
-            }
-          },
-          {
-            "sink": {
-              "file": "DOS_Login.java",
-              "line": "114",
-              "column": "45",
-              "object": "executeQuery"
-            },
-            "state": "0",
-            "source": {
-              "file": "DOS_Login.java",
-              "line": "89",
-              "column": "46",
-              "object": "getRawParameter"
-            }
-          }
-        ],
-        "CodeBashingLesson" : "https://cxa.codebashing.com/courses/"
-      },
-      "allFalsePositive": false
-    }
-  ],
-  "sastResults": false
+    ],
+    "sastResults": false
 }

--- a/src/test/resources/cucumber/data/sample-sast-results/1-finding-custom-severity.xml
+++ b/src/test/resources/cucumber/data/sample-sast-results/1-finding-custom-severity.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CxXMLResults InitiatorName="user1" Owner="user@local" ScanId="2078391" ProjectId="29811" ProjectName="testProject" TeamFullPathOnReportDate="CxServer" DeepLink="http://test.local/CxWebClient/ViewerMain.aspx?scanid=2078391&amp;projectid=29811" ScanStart="Wednesday, February 19, 2020 2:32:25 PM" Preset="Checkmarx Default" ScanTime="00h:02m:29s" LinesOfCodeScanned="233" FilesScanned="5" ReportCreationTime="Monday, March 1, 2021 3:55:57 PM" Team="CxServer" CheckmarxVersion="9.0.0.3299" ScanComments="" ScanType="Full" SourceOrigin="LocalPath" Visibility="Public">
+    <Query id="600" categories="NIST SP 800-53;SC-5 Denial of Service Protection (P1)" cweId="404" name="Improper_Resource_Shutdown_or_Release" group="Java_Low_Visibility" Severity="Low" Language="Java" LanguageHash="1621858418163027" LanguageChangeDate="2019-10-22T00:00:00.0000000" SeverityIndex="1" QueryPath="Java\Cx\Java Low Visibility\Improper Resource Shutdown or Release Version:1" QueryVersionCode="56205902">
+        <Result NodeId="20783910010" FileName="folder1/file1.java" Status="New" Line="61" Column="25" FalsePositive="False" Severity="High" AssignToUser="" state="0" Remark="admin admin testProject, [Monday, March 1, 2021 3:54:35 PM]: Changed severity to High" DeepLink="http://test.local/CxWebClient/ViewerMain.aspx?scanid=2078391&amp;projectid=29811&amp;pathid=10" SeverityIndex="3">
+            <Path ResultId="2078391" PathId="10" SimilarityId="-1750851115">
+                <PathNode>
+                    <FileName>folder1/file1.java</FileName>
+                    <Line>61</Line>
+                    <Column>25</Column>
+                    <NodeId>1</NodeId>
+                    <Name>FileReader</Name>
+                    <Type></Type>
+                    <Length>3</Length>
+                    <Snippet>
+                        <Line>
+                            <Number>61</Number>
+                            <Code>        FileReader fr = new FileReader(fileName);</Code>
+                        </Line>
+                    </Snippet>
+                </PathNode>
+                <PathNode>
+                    <FileName>folder1/file1.java</FileName>
+                    <Line>61</Line>
+                    <Column>20</Column>
+                    <NodeId>2</NodeId>
+                    <Name>fr</Name>
+                    <Type></Type>
+                    <Length>2</Length>
+                    <Snippet>
+                        <Line>
+                            <Number>61</Number>
+                            <Code>        FileReader fr = new FileReader(fileName);</Code>
+                        </Line>
+                    </Snippet>
+                </PathNode>
+            </Path>
+        </Result>
+    </Query>
+</CxXMLResults>

--- a/src/test/resources/cucumber/features/componentTests/parse.feature
+++ b/src/test/resources/cucumber/features/componentTests/parse.feature
@@ -80,6 +80,17 @@ Feature: Parsing SAST results
     Then CxFlow report is generated with 2 issues
     And issue severities are: High, Critical
 
+  Scenario: Parsing SAST findings with customized severity
+  By default, finding severity is the same as the severity of its vulnerability type.
+  However, users are able to override severity for a specific finding.
+  Make sure that, while filtering, we use finding severity (and not its vulnerability type severity).
+    Given input has one vulnerability type with "Low" severity
+    And input has one finding with this vulnerability type
+    And user has overridden the severity of this specific finding with the "High" value
+    When parsing the input with severity filter: High
+    Then CxFlow report is generated with 1 issue
+    And the issue severity is High
+
   Scenario: Verify that generated reports match corresponding reference reports
     Given reference CxFlow reports are available for specific inputs
     When parsing each of these inputs


### PR DESCRIPTION
### Description

Added a test scenario that checks if we use the right severity during filtering.

### References

Work item [531](https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/531/).

The new scenario verifies a CxSDK change, as of https://github.com/checkmarx-ltd/checkmarx-spring-boot-java-sdk/pull/99.

### Testing

The new scenario was added to test\resources\cucumber\features\componentTests\parse.feature
