### PR TITLE
Fixed misplaced single quotation

### DIFF
--- a/templates/gitlab/v2/Checkmarx.gitlab-ci.yml
+++ b/templates/gitlab/v2/Checkmarx.gitlab-ci.yml
@@ -33,7 +33,7 @@ variables:
 checkmarx-scan-security-dashboard:
   stage: test
   rules:
-    - if: $CX_FLOW_BUG_TRACKER == "GitLabDashboard" && '$CI_COMMIT_BRANCH == "master"'
+    - if: '$CX_FLOW_BUG_TRACKER == "GitLabDashboard" && $CI_COMMIT_BRANCH == "master"'
   image:
     name: checkmarx/${CHECKMARX_DOCKER_IMAGE}
     entrypoint: ['']
@@ -60,7 +60,7 @@ checkmarx-scan-security-dashboard:
 checkmarx-scan:
   stage: test
   rules:
-    - if: $CX_FLOW_BUG_TRACKER != "GitLabDashboard" && '$CI_COMMIT_BRANCH == "master"'
+    - if: '$CX_FLOW_BUG_TRACKER != "GitLabDashboard" && $CI_COMMIT_BRANCH == "master"'
   image:
     name: checkmarx/${CHECKMARX_DOCKER_IMAGE}
     entrypoint: ['']


### PR DESCRIPTION
Issue with quotes cause two jobs to run in the pipelin

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ts/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

A misplaced single quote was causing two pipelines to run.

### References

N/A

### Testing

Manual GitLab tests

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used
