### PR TITLE
preset override issue fix

### DIFF
--- a/src/main/java/com/checkmarx/flow/service/AbstractVulnerabilityScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/AbstractVulnerabilityScanner.java
@@ -273,7 +273,7 @@ public abstract class AbstractVulnerabilityScanner implements VulnerabilityScann
         try {
             String effectiveProjectName = projectNameGenerator.determineProjectName(request);
             request.setProject(effectiveProjectName);
-
+            overrideScanPreset(request);
             File zipFile = ZipUtils.zipToTempFile(path, flowProperties.getZipExclude());
             ScanDetails details = executeCxScan(request, zipFile);
             results = getScanResults(request, details.getProjectId(), details.getScanId());

--- a/src/main/java/com/checkmarx/flow/service/SastScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/SastScanner.java
@@ -90,6 +90,25 @@ public class SastScanner extends AbstractVulnerabilityScanner {
             exit(3);
         }
     }
+
+    /**
+     * This method sets scan preset override parameter.
+     * If webhook parameter preset is given then method will sets  scan preset override to true
+     * If setting-override parameter is true then preset value will be taken from application.yml file.
+     * 1st preference will be given to webhook parameter preset value and then value present in application.yml file.
+     * @param scanRequest
+     */
+    @Override
+    protected void overrideScanPreset(ScanRequest scanRequest) {
+        if (StringUtils.isNotEmpty(scanRequest.getScanPreset())) {
+            scanRequest.setScanPresetOverride(true);
+        }else{
+            if(cxProperties.getSettingsOverride()) {
+                scanRequest.setScanPresetOverride(true);
+            }
+            scanRequest.setScanPreset(getCxPropertiesBase().getScanPreset());
+        }
+    }
     /**
      * Process Projects in batch mode - JIRA ONLY
      */


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> If webhook parameter preset is given then feature will sets  scan preset override to true and depending on the setting- 
    override parameter value preset value will be overridden.
    1st preference will be given to webhook parameter preset value and then value present in application.yml file.

### Testing

> Test Case No. | Settings-override value in application.yml | Webhook Parameter | Existing Preset on SAST server | ScanPreset variable value In application.yml | Result(value of preset in SAST server after scan)
-- | -- | -- | -- | -- | --
1 | false | Not set | Mobile | FISMA | Mobile
2 | true | Not Set | Mobile | FISMA | FISMA
3 | true | ?preset= Default | FISMA | Mobile | Default
4 | false | ?preset= FISMA | Default | Mobile | Default
