### PR TITLE
scan preset override issue fix 

### DIFF
--- a/src/main/java/com/checkmarx/flow/service/AbstractVulnerabilityScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/AbstractVulnerabilityScanner.java
@@ -273,7 +273,7 @@ public abstract class AbstractVulnerabilityScanner implements VulnerabilityScann
         try {
             String effectiveProjectName = projectNameGenerator.determineProjectName(request);
             request.setProject(effectiveProjectName);
-
+            overrideScanPreset(request);
             File zipFile = ZipUtils.zipToTempFile(path, flowProperties.getZipExclude());
             ScanDetails details = executeCxScan(request, zipFile);
             results = getScanResults(request, details.getProjectId(), details.getScanId());

--- a/src/main/java/com/checkmarx/flow/service/SastScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/SastScanner.java
@@ -90,6 +90,26 @@ public class SastScanner extends AbstractVulnerabilityScanner {
             exit(3);
         }
     }
+
+    /**
+     * This method sets scan preset override parameter.
+     * If in webhook preset is given then method will set scan preset override to true
+     * If setting-override parameter is true then preset value will be taken from application.yml file.
+     * 1st preference will be given to webhook parameter preset value and then value present in application.yml file.
+     * @param scanRequest
+     */
+    @Override
+    protected void overrideScanPreset(ScanRequest scanRequest) {
+        if (StringUtils.isNotEmpty(scanRequest.getScanPreset())) {
+            scanRequest.setScanPresetOverride(true);
+        }else{
+            if(cxProperties.getSettingsOverride()) {
+                scanRequest.setScanPresetOverride(true);
+            }
+            scanRequest.setScanPreset(getCxPropertiesBase().getScanPreset());
+        }
+    }
+
     /**
      * Process Projects in batch mode - JIRA ONLY
      */


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
This PR solves the issue of scanPreset override. SAST uses the newer version of the API where user can pass preset in the payload and if the SettingsOverride value is false it does not override value of the preset in database but uses the preset in payload to run the scan. CxFlow uses the older version of the API and in order to use the preset in payload it must be updated in the database. If settingsOverride is false then CxFlow will use the preset in the database and discard the preset in the payload and if settingsOverride is true then it will update the preset in database with the preset in the payload and then use the preset to run the scan.

### Testing
Test results in web mode
Test Case   No. | settings-override value | webhook Parameter | Existing Preset on SAST server | ScanPreset variable value In   application.yml | Result(value of preset in SAST   server after scan)
-- | -- | -- | -- | -- | --
1 | FALSE | Not set | Checkmarx Default | FISMA | Checkmarx Default
2 | TRUE | Not Set | Checkmarx Default | FISMA | FISMA
3 | TRUE | preset= Default | FISMA | Mobile | Default
4 | FALSE | preset= FISMA | Default | Mobile | Default

Test results in CLI mode
Test Case   No. | --checkmarx.settings-override value from CLI | CLI --preset Parameter | Existing Preset on SAST server | ScanPreset variable value In   application.yml | Result(value of preset in SAST   server after scan)
-- | -- | -- | -- | -- | --
1 | FALSE | Not set | Mobile | FISMA | Default
2 | TRUE | Not Set | Mobile | FISMA | FISMA
3 | TRUE | preset= Default | FISMA | Mobile | Default
4 | FALSE | preset= FISMA | Default | Mobile | Default

### Checklist

- [NA ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ x ] The correct base branch is being used
