### PR TITLE
Fix colon not allowed in JIRA issue label

### DIFF
--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -673,7 +673,7 @@ public class JiraService {
                             String[] l = StringUtils.split(value, ",");
                             list = new ArrayList<>();
                             for (String x : l) {
-                                list.add(x.replaceAll("[^a-zA-Z0-9-_]+", "_"));
+                                list.add(x.replaceAll("[^a-zA-Z0-9:-_]+", "_"));
                             }
 
                             if (!ScanUtils.empty(list)) {


### PR DESCRIPTION
### Description

Fix colon ':' char being replaced by an underscore '_' when setting a JIRA label field, this can affect the ability of setting values in a label with colons.

### References

N/A

### Testing

This change was tested using a JIRA field of 'static' type, using `jira-default-value` as a list of labels like the ones applied to the `Labels` JIRA issue field.

### References

Described in #800.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
