### PR TITLE
updated CxSBSDK version to support scascantimeout

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.5.00"
+        CxSBSDK = "0.5.01"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.5.00"
+        CxSBSDK = "0.5.01"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/docs/CxSCA-Integration.md
+++ b/docs/CxSCA-Integration.md
@@ -231,6 +231,6 @@ team: /MainTeam/SubTeam
 * Declaring not existing team or team path will be resulted with 400 BAD REQUEST error.
 
 ## <a name="scaScanTimeOut">SCA Scan Timeout</a>
-In order to set Scan TimeOut for SCA, the configuration property should be added underneath the sca configuration section:
+In order  to set Scan TimeOut for SCA, the configuration property should be added underneath the sca configuration section:
 ```
  scan-timeout: 120

--- a/docs/CxSCA-Integration.md
+++ b/docs/CxSCA-Integration.md
@@ -229,3 +229,8 @@ team: /MainTeam/SubTeam
 ```
 * In order to declare a team within a tree hierarchy, make sure to use the forward slash ('/').
 * Declaring not existing team or team path will be resulted with 400 BAD REQUEST error.
+
+## <a name="scaScanTimeOut">SCA Scan Timeout</a>
+In order to set Scan TimeOut for SCA, the configuration property should be added underneath the sca configuration section:
+```
+ scan-timeout: 120

--- a/src/main/resources/application-sca.yml
+++ b/src/main/resources/application-sca.yml
@@ -5,3 +5,4 @@ sca:
   tenant:
   username:
   password:
+  scan-timeout:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: ${PORT:8585}
+  port: ${PORT:8080}
 
 logging:
   file:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: ${PORT:8080}
+  port: ${PORT:8585}
 
 logging:
   file:


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> This PR adds scan-timeout feature in sca scanning. scan-timeout should be added in application.yml under sca. If not default timeout will be 120 mins

### Testing

> In order to test Scan TimeOut for SCA, the configuration property should be added underneath the sca configuration section.
 scan-timeout: 120

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
