### PR TITLE
Jira custom issue prefix feature

### DIFF
--- a/docs/Bug-Trackers-and-Feedback-Channels.md
+++ b/docs/Bug-Trackers-and-Feedback-Channels.md
@@ -1,5 +1,6 @@
 * [Understanding the Data](#data)
 * [Jira](#jira)
+  * [Label Prefix](#labelPrefix)
   * [Priorities](#priorities)
   * [Transitions](#transitions)
   * [Fields](#fields)
@@ -37,6 +38,7 @@ jira:
    token: xxxx
    project: SS
    issue-type: Application Security Bug
+   label-prefix: < CUSTOM PREFIX NAME >
    priorities:
       High: High
       Medium: Medium
@@ -76,6 +78,12 @@ jira:
        jira-field-type: label
        jira-default-value: XXXXX
 ```
+
+### <a name="labelPrefix">Label Prefix</a>
+```
+label-prefix: < CUSTOM PREFIX NAME > 
+```
+The label-prefix property is used to set a custom prefix for Jira issues. If this value is not provided then CxFlow will use the default issue prefix "CX".
 
 ### <a name="priorities">Priorities</a>
 ```

--- a/src/main/java/com/checkmarx/flow/config/JiraProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/JiraProperties.java
@@ -51,6 +51,7 @@ public class JiraProperties {
     private List<String> statusCategoryClosedName = Arrays.asList("Done");
     @Getter @Setter
     private String projectKeyScript;
+    private String labelPrefix;
 
 
     public String getUrl() {
@@ -333,6 +334,14 @@ public class JiraProperties {
 
     public void setStatusCategoryClosedName(List<String> statusCategoryClosedName) {
         this.statusCategoryClosedName = statusCategoryClosedName;
+    }
+
+    public String getLabelPrefix() {
+        return labelPrefix;
+    }
+
+    public void setLabelPrefix(String labelPrefix) {
+        this.labelPrefix = labelPrefix;
     }
 
 }

--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -311,7 +311,7 @@ public class JiraService {
             String fileUrl = ScanUtils.getFileUrl(request, issue.getFilename());
             summary = checkSummaryLength(summary);
 
-            issueBuilder.setSummary(HTMLHelper.getScanRequestIssueKeyWithDefaultProductValue(request, summary));
+            issueBuilder.setSummary(HTMLHelper.getScanRequestIssueKeyWithDefaultProductValue(request, summary, jiraProperties.getLabelPrefix()));
             issueBuilder.setDescription(this.getBody(issue, request, fileUrl));
             if (assignee != null && !assignee.isEmpty()) {
                 ComplexIssueInputFieldValue jiraAssignee = getAssignee(assignee, projectKey);
@@ -977,7 +977,7 @@ public class JiraService {
                         ? String.format(JiraConstants.JIRA_ISSUE_TITLE_KEY, issuePrefix, issue.getVulnerability(), issue.getFilename(), issuePostfix)
                         : getScaDetailsIssueTitleWithoutBranchFormat(request, issuePrefix, issuePostfix, issue);
             }
-            map.put(HTMLHelper.getScanRequestIssueKeyWithDefaultProductValue(request, key), issue);
+            map.put(HTMLHelper.getScanRequestIssueKeyWithDefaultProductValue(request, key,jiraProperties.getLabelPrefix()), issue);
         }
         return map;
     }

--- a/src/main/java/com/checkmarx/flow/utils/HTMLHelper.java
+++ b/src/main/java/com/checkmarx/flow/utils/HTMLHelper.java
@@ -103,9 +103,15 @@ public class HTMLHelper {
         return xIssueKeyValue;
     }
 
-    public static String getScanRequestIssueKeyWithDefaultProductValue(ScanRequest scanRequest, String titleToConcat) {
-        String productPrefix = scanRequest.getProduct().getProduct();
-        if (!titleToConcat.startsWith(productPrefix)) {
+    public static String getScanRequestIssueKeyWithDefaultProductValue(ScanRequest scanRequest, String titleToConcat,String labelPrefix) {
+        String productPrefix;
+        if(labelPrefix != null){
+            productPrefix = labelPrefix;
+        } else{
+            productPrefix = scanRequest.getProduct().getProduct();
+        }
+
+        if(!titleToConcat.startsWith(productPrefix)) {
             titleToConcat = productPrefix + " " + titleToConcat;
         }
         return titleToConcat;


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Added label-prefix property for JIRA which will allow user to use a custom issue prefix for their JIRA issues and if not provided it will use the default issue prefix value of "CX". 

### Testing

> Manually tested this feature 
 >  1. When a label-prefix is set Jira creates issues with the provided label-prefix for that project.
 > 2. When the label-prefix value is changed for the same project, Jira creates new issues with newly provided prefix and closes the earlier issues with older prefix name.
 > 3. When no label-prefix is provided Jira creates issues with prefix CX.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
