### PR TITLE
Add scan comment sample script

### DIFF
--- a/docs/External-Scripts.md
+++ b/docs/External-Scripts.md
@@ -9,7 +9,7 @@ String cxProject = "script-prefix-" + request.getBranch() + "-" + request.getHas
 return cxProject
 ```
 The resulting project name will look like this: `script-prefix-master-fa907029c049b781f961e452a375d606402102a6`.
-For more information about the `getHash()` property, see the `hash` field documentation in [ScanRequest object](https://github.com/checkmarx-ltd/cx-flow/blob/develop/src/main/java/com/checkmarx/flow/dto/ScanRequest.java).
+For more information about the `getHash()` property, see the `hash` field documentation in [ScanRequest object](../src/main/java/com/checkmarx/flow/dto/ScanRequest.java).
 
 * [Project script](#projectScript)
 * [Team script](#teamScript)
@@ -27,7 +27,7 @@ checkmarx:
   project-script: ...\CheckProject.groovy
 ```
 
-* Script input: [ScanRequest object](https://github.com/checkmarx-ltd/cx-flow/blob/develop/src/main/java/com/checkmarx/flow/dto/ScanRequest.java)
+* Script input: [ScanRequest object](../src/main/java/com/checkmarx/flow/dto/ScanRequest.java)
 * Return value: String
 
 
@@ -41,7 +41,7 @@ checkmarx:
   team-script: ...\CheckTeam.groovy
 ```
 
-* Script input: [ScanRequest object](https://github.com/checkmarx-ltd/cx-flow/blob/develop/src/main/java/com/checkmarx/flow/dto/ScanRequest.java)
+* Script input: [ScanRequest object](../src/main/java/com/checkmarx/flow/dto/ScanRequest.java)
 * Return value: String
 
 
@@ -56,7 +56,7 @@ cx-flow:
 ```
 
 * Script input: 
-  * [ScanRequest object](https://github.com/checkmarx-ltd/cx-flow/blob/develop/src/main/java/com/checkmarx/flow/dto/ScanRequest.java)
+  * [ScanRequest object](../src/main/java/com/checkmarx/flow/dto/ScanRequest.java)
   * List<String> branches
 
 * Return value: String
@@ -72,7 +72,7 @@ cx-flow:
   comment-script: ...\Checkcomment.groovy
 ```
 
-* Script input: [ScanRequest object](https://github.com/checkmarx-ltd/cx-flow/blob/develop/src/main/java/com/checkmarx/flow/dto/ScanRequest.java)
+* Script input: [ScanRequest object](../src/main/java/com/checkmarx/flow/dto/ScanRequest.java)
 * Return value: String
 * Script example: [ScanComment.groovy](../src/main/resources/samples/ScanComment.groovy)
 
@@ -126,6 +126,6 @@ jira:
   project-key-script: ...\CheckProjectKey.groovy
 ```
 
-* Script input: [ScanRequest object](https://github.com/checkmarx-ltd/cx-flow/blob/develop/src/main/java/com/checkmarx/flow/dto/ScanRequest.java)
+* Script input: [ScanRequest object](../src/main/java/com/checkmarx/flow/dto/ScanRequest.java)
 * Return value: String
-* Script example: [JiraProjectKey.groovy](https://github.com/checkmarx-ltd/cx-flow/blob/develop/src/main/resources/samples/JiraProjectKey.groovy)
+* Script example: [JiraProjectKey.groovy](../src/main/resources/samples/JiraProjectKey.groovy)

--- a/docs/External-Scripts.md
+++ b/docs/External-Scripts.md
@@ -51,7 +51,7 @@ checkmarx:
 * To enable this flow add the following property to cxflow configuration (you can use any file name): 
 
 ```yaml
-checkmarx:
+cx-flow:
   branch-script: ...\CheckBranch.groovy
 ```
 

--- a/docs/External-Scripts.md
+++ b/docs/External-Scripts.md
@@ -74,6 +74,7 @@ cx-flow:
 
 * Script input: [ScanRequest object](https://github.com/checkmarx-ltd/cx-flow/blob/develop/src/main/java/com/checkmarx/flow/dto/ScanRequest.java)
 * Return value: String
+* Script example: [ScanComment.groovy](../src/main/resources/samples/ScanComment.groovy)
 
 ### <a name="filterFindings">Use a Script to Filter Findings</a>
 

--- a/src/main/resources/samples/ScanComment.groovy
+++ b/src/main/resources/samples/ScanComment.groovy
@@ -4,7 +4,11 @@ import groovyx.net.http.HTTPBuilder
 
 def repoUrl = request.getRepoUrl()
 def branch = request.getBranch()
+//When using webhooks to read the commit hash, use this:
 def commitId = request.getHash()
+//When using SCM automated workflows, comment the line above and uncomment the 2 lines below so the hash is not null (example is for Github Actions):
+// def env = System.getenv()
+// def commitId = env['GITHUB_SHA']
 
 String scanComment = "Repo: $repoUrl | Branch: $branch | Commit ID: $commitId"
 

--- a/src/main/resources/samples/ScanComment.groovy
+++ b/src/main/resources/samples/ScanComment.groovy
@@ -1,0 +1,13 @@
+@Grab(group='org.codehaus.groovy.modules.http-builder', module='http-builder', version='0.7' )
+
+import groovyx.net.http.HTTPBuilder
+
+def repoUrl = request.getRepoUrl()
+def branch = request.getBranch()
+def commitId = request.getHash()
+
+String scanComment = "Repo: $repoUrl | Branch: $branch | Commit ID: $commitId"
+
+println "INFO : Scanning code from $scanComment"
+
+return scanComment


### PR DESCRIPTION
### Description

Add `ScanComment.groovy` sample script to add repo URL, branch and commit id/hash to the scan-comment.
Update `docs/External-Scripts.md` markdown file to use relative links so the files point to the branches documentation.
Fix wrong configuration property for `branch-script`, it's now corrected to `cx-flow.branch-script` instead of `checkmarx.branch-script`.

### References

N/A

### Testing

This change was tested with CxFlow's server running with the sample Groovy file on the server root directory and observing CxSAST scan comments being changed after scans triggered through CxFlow.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
