### PR TITLE
fix for ado pr status stuck on waiting

### DIFF
--- a/src/main/java/com/checkmarx/flow/service/ADOService.java
+++ b/src/main/java/com/checkmarx/flow/service/ADOService.java
@@ -166,7 +166,10 @@ public class ADOService {
             Integer projectId = Integer.parseInt(results.getProjectId());
             String url = request.getAdditionalMetadata("statuses_url");
             String statusId = request.getAdditionalMetadata("status_id");
-            String threadUrl = request.getMergeNoteUri().concat("/").concat(request.getAdditionalMetadata("ado_thread_id"));
+            String threadUrl = null;
+            if(request.getAdditionalMetadata("ado_thread_id") != null){
+                threadUrl = request.getMergeNoteUri().concat("/").concat(request.getAdditionalMetadata("ado_thread_id"));
+            }
             if(statusId == null){
                 log.warn("No status Id found, skipping status update");
                 return;
@@ -198,7 +201,9 @@ public class ADOService {
             if(projectId == -1){
                 log.debug("SAST scan could not be processed due to some error. Creating status of failed to {}", url);
                 createStatus("failed", "Checkmarx Scan could not be processed.", url, results.getLink(), request);
-                createThreadStatus(CLOSED,threadUrl,request);
+                if(threadUrl != null) {
+                    createThreadStatus(CLOSED, threadUrl, request);
+                }
                 return;
             }
 
@@ -207,12 +212,16 @@ public class ADOService {
             if(!isMergeAllowed){
                 log.debug("Creating status of failed to {}", url);
                 createStatus("failed", "Checkmarx Scan Completed", url, results.getLink(), request);
-                createThreadStatus(CLOSED,threadUrl,request);
+                if(threadUrl != null) {
+                    createThreadStatus(CLOSED, threadUrl, request);
+                }
             }
             else{
                 log.debug("Creating status of succeeded to {}", url);
                 createStatus("succeeded", "Checkmarx Scan Completed", url, results.getLink(), request);
-                createThreadStatus(RESOLVED,threadUrl,request);
+                if(threadUrl != null) {
+                    createThreadStatus(RESOLVED, threadUrl, request);
+                }
             }
         }
     }

--- a/src/main/java/com/checkmarx/flow/service/BugTrackerEventTrigger.java
+++ b/src/main/java/com/checkmarx/flow/service/BugTrackerEventTrigger.java
@@ -121,6 +121,7 @@ public class BugTrackerEventTrigger {
 
             case ADOPULL:
                 adoService.sendMergeComment(scanRequest, SCAN_NOT_SUBMITTED_MESSAGE);
+                adoService.startBlockMerge(scanRequest);
                 adoService.endBlockMerge(scanRequest, scanResults, new ScanDetails());
                 break;
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> This PR solves the issue of ADO PR status stuck on wait if a PR is created for a project for which there is already a scan running. 

### Testing

>1.If scan is running for a project and a PR is opened for same project
a.	 a thread is created with message “Scan not submitted to Checkmarx due to existing Active scan for the same project.” And its status is changed from “Active” to “Closed”. 
>b.	And the status of the PR is changed to Failed with message “Checkmarx scan could not be processed”.	If update is made to the same PR and if a scan is not running for the project
>c.	 a scan will be initialized and then based on the result of the scan the Status of the PR is changed from Failed to either “Succeeded” with message “Checkmarx scan completed or “Failed” checkmarx scan completed
>2.	If a PR is opened for a project and the scan is initialized, and if the  
a.	PR is updated a thread is created with message “Scan not submitted to Checkmarx due to existing Active scan for the same project” and its status is changed from “Active” to “Closed”
b.	After the scan initially running for the PR is finished the status of the PR is updated based on the result of the scan


### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
