### PR TITLE
added feature for exclude files

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.5.02"
+        CxSBSDK = "0.5.03"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.5.02"
+        CxSBSDK = "0.5.03"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/docs/CxSCA-Integration.md
+++ b/docs/CxSCA-Integration.md
@@ -32,6 +32,10 @@ sca:
   username: username
   password: xxxxx
   team: "/CxServer/MyTeam/SubTeam"
+  include-sources: true
+  exclude-files: "**/*.xml"
+  manifests-include-pattern: "!**/*.xml, **/*.yml"
+  fingerprints-include-pattern: "**/*.yml"
 ```
 
 To use an European tenant:
@@ -47,6 +51,10 @@ sca:
   username: username
   password: xxxxx
   team: "/CxServer/MyTeam/SubTeam"
+  include-sources: true 
+  exclude-files: "**/*.xml"
+  manifests-include-pattern: "!**/*.xml, **/*.yml"
+  fingerprints-include-pattern: "**/*.yml"
 ```
 
 ## <a name="bug">Bug-Trackers</a>
@@ -217,6 +225,13 @@ Additional configuration in SCA zip scan flow - Include source files
 ```
 includeSources: true
 ```
+
+* When includeSources is set to true cx-flow will consider all the files for scanning. If there is need to exclude files the **exclude-files** parameter is used. This parameter expects a regular expression for the files to be excluded. e.g ``` exclude-files: "**/*.xml"``` will exclude all the .xml files present in the source folder.
+
+
+* When includeSources is set to false cx-flow will consider the manifest-files and calculate fingerprint for it. If there is a need to exclude files then in this case the **manifests-include-pattern** and the **fingerprints-include-pattern** is used. These parameters also requires regular expression. e.g ``` manifests-include-pattern: **/*.xml, !**/*.yml``` will include the all the xml file and exclude all the yml files.
+  
+  **Note** The files to be excluded must begin with !. (Only applicable for manifests-include-pattern and fingerprints-include-pattern properties).
 
 ## <a name="scaProjectTeamAssignment">SCA project team assignment</a>
 SCA project team assignment with CxFlow is performing on the SCA project creation stage. In order to set a project team, the next configuration property should be added underneath the sca configuration section:

--- a/src/main/java/com/checkmarx/flow/service/AbstractASTScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/AbstractASTScanner.java
@@ -128,13 +128,15 @@ public abstract class AbstractASTScanner implements VulnerabilityScanner {
     protected abstract String getScanId(AstScaResults internalResults);
 
     private ScanParams toSdkScanParams(ScanRequest scanRequest, String pathToScan) {
-        return ScanParams.builder()
+        ScanParams scanParams = ScanParams.builder()
                 .projectName(scanRequest.getProject())
                 .sourceDir(pathToScan)
                 .scaConfig(scanRequest.getScaConfig())
                 .filterConfiguration(scanRequest.getFilter())
                 .disableCertificateValidation(scanRequest.isDisableCertificateValidation())
                 .build();
+        setScannerSpecificProperties(scanRequest,scanParams);
+        return scanParams;
     }
 
     protected abstract ScanResults toScanResults(AstScaResults internalResults);

--- a/src/main/java/com/checkmarx/flow/service/SCAScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/SCAScanner.java
@@ -14,9 +14,11 @@ import com.checkmarx.sdk.exception.CheckmarxException;
 import com.checkmarx.sdk.service.scanner.ScaScanner;
 import com.checkmarx.sdk.utils.CxRepoFileHelper;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 
@@ -53,7 +55,13 @@ public class SCAScanner extends AbstractASTScanner {
                 log.info("CxAST-SCA zip scan is enabled");
                 String scaClonedFolderPath = cxRepoFileHelper.getScaClonedRepoFolderPath(scanRequest.getRepoUrlWithAuth(), scanRequest.getExcludeFiles(), scanRequest.getBranch());
                 scanParams.setSourceDir(scaClonedFolderPath);
+            }
+            if(scanRequest.getExcludeFiles() != null) {
                 scanParams.getScaConfig().setExcludeFiles(scanRequest.getExcludeFiles());
+            } else if(scaProperties.getExcludeFiles() != null){
+                List<String> excludeFiles = new ArrayList<String>(Arrays.asList(scaProperties.getExcludeFiles().split(",")));
+                log.debug("Exclude Files list contains : {}", excludeFiles);
+                scanParams.getScaConfig().setExcludeFiles(excludeFiles);
             }
         } catch (CheckmarxException e) {
             throw new MachinaRuntimeException(e.getMessage());


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> This PR creates feature to exclude files from sca scan from CLI and Webhook

### Testing

enabled-zipped-scan:   false | enabled-zipped-scan : true     include-sources: true     exclude-files: "pom.xml, Dockerfile" | enabled-zipped-scan : true     include-sources: false     manifests-include-pattern: "**/pom.xml,   **/Dockerfile**"     fingerprints-include-pattern: "!.checkmarx/**, !**/*.yml" | enabled-zipped-scan : true     include-sources:   false     manifests-include-pattern: "**/pom.xml, !**/Dockerfile**"     fingerprints-include-pattern: "!.checkmarx/**, **/*.yml" | enabled-zipped-scan : true     include-sources:   false     manifests-include-pattern:      fingerprints-include-pattern:
-- | -- | -- | -- | --
Used   the configuration from      server for the project | a.   scanParams->scaConfig->excludeFiles = [ pom.xml, Dockerfile]     	b. converted List of excludeFiles to String (, separated)     	c. created a zip folder excluding the pom.xml file and Dockerfile | a. zipped : pom.xml and   Dockerfile and .cxsca.sig     	b. excluded docker-compose.yml and .checkmarx/config.yaml files from   fingerprint calculation | a. zipped : pom.xml and   .cxsca.sig     b. included docker-compose.yml and .github/workflows/cx.yaml files in   fingerprint calculation | Got the manifest and fingerprint   patterns from SCA server and used it.
  | enabled-zipped-scan : true     include-sources: true     exclude-files: "pom.xml, Dockerfile" | enabled-zipped-scan : true     include-sources: false     manifests-include-pattern: "**/pom.xml,   **/Dockerfile**"     fingerprints-include-pattern: "!.checkmarx/**, !**/*.yml" | enabled-zipped-scan : true     include-sources:   false     manifests-include-pattern: "**/pom.xml, !**/Dockerfile**"     fingerprints-include-pattern: "!.checkmarx/**, **/*.yml" | enabled-zipped-scan : true     include-sources:   false     below params provided in cmd     manifests-include-pattern:     "**/pom.xml, !**/Dockerfile**"      fingerprints-include-pattern:     "!.checkmarx/**, **/*.yml"
  | Excluded pom.xml and Dockerfile | a. zipped : pom.xml and   Dockerfile and .cxsca.sig     	b. excluded docker-compose.yml and .checkmarx/config.yaml files from   fingerprint calculation | a. zipped : pom.xml and   .cxsca.sig     b. included docker-compose.yml and .github/workflows/cx.yaml files in   fingerprint calculation | a. zipped : pom.xml and   .cxsca.sig     b. included docker-compose.yml and .github/workflows/cx.yaml files in   fingerprint calculation



### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
