### PR TITLE
Custom Jira Summary feature

### DIFF
--- a/docs/Bug-Trackers-and-Feedback-Channels.md
+++ b/docs/Bug-Trackers-and-Feedback-Channels.md
@@ -5,6 +5,7 @@
   * [Transitions](#transitions)
   * [Fields](#fields)
   * [Assigning tickets to a user](#assigningTickets)
+  * [Configuring the Jira Issue Summary](#issueSummaryFormat)
 * [Custom Bug trackers](#custom)
 * [Azure DevOps Work Items](#azure)
 * [GitLab Issues](#gitlab)
@@ -52,6 +53,8 @@ jira:
       - In Review
    closed-status:
       - Done
+   sast-issue-summary-format: "[VULNERABILITY] in [PROJECT] with severity [SEVERITY] @ [FILENAME]"
+   sast-issue-summary-branch-format: "[VULNERABILITY] in [PROJECT] with severity [SEVERITY] @ [FILENAME][[BRANCH]]"
    fields:
 #    - type: cx #[ cx | static | result ]
 #      name: Platform # cx custom field name | cwe, category, severity, application, *project*, repo-name, branch, repo-url, namespace, recommendations, loc, site, issueLink, filename, language
@@ -155,6 +158,28 @@ Jira tickets can be assigned to a user when they are created. This can be achiev
 * As a webhook url parameter - The url parameter 'assignee' can be appended to the url in the webhook configuration and a user's email address to whom the tickets should be assigned, is provided as the value of the parameter.
 
   E.g - http​&#65279;://companyname.checkmarx.com?assignee=someUsersEmail@&#65279;xyz.com
+
+### <a name="issueSummaryFormat">Configuring the Jira Issue Summary</a>
+
+The sast-issue-summary-format and sast-issue-summary-branch-format properties can be used to configure the issue summary of the issues that CxFlow creates in Jira for vulnerabilities detected by CxSAST. The following substitutions are performed on the properties’ values to generate the issue summary:
+
+**[BASENAME]** → The basename of the file in which the vulnerabilities were found
+
+**[BRANCH]** → The value of the `--branch` command line option
+
+**[FILENAME]** → The full path of the file in which the vulnerabilities were found
+
+**[POSTFIX]** → The issue summary’s suffix (as specified by the Jira issue-postfix property)
+
+**[PREFIX]** → The issue summary’s prefix (as specified by the Jira issue-prefix property)
+
+**[PROJECT]** → The Checkmarx project
+
+**[SEVERITY]** → The severity of the vulnerability
+
+**[VULNERABILTY]** → The vulnerability
+
+The default Jira issue summary format (for CxSAST issues) is `[PREFIX][VULNERABILITY] @ [FILENAME][POSTFIX]` (`[PREFIX][VULNERABILITY] @ [FILENAME] [[BRANCH]][POSTFIX]` if the `--branch` command line option has been used).
 
 ## <a name="custom">Custom Bug Trackers</a>
 Refer to the [development section](https://github.com/checkmarx-ltd/cx-flow/wiki/Development) for the implementation approach.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -227,6 +227,8 @@ jira:
      - In Review
   closed-status:
      - Done
+  sast-issue-summary-format: "[VULNERABILITY] in [PROJECT] with severity [SEVERITY] @ [FILENAME]"
+  sast-issue-summary-branch-format: "[VULNERABILITY] in [PROJECT] with severity [SEVERITY] @ [FILENAME][[BRANCH]]"
   fields:
      - type: result
        name: application

--- a/src/main/java/com/checkmarx/flow/config/JiraProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/JiraProperties.java
@@ -52,6 +52,8 @@ public class JiraProperties {
     @Getter @Setter
     private String projectKeyScript;
     private String labelPrefix;
+    private String sastIssueSummaryFormat = "[PREFIX][VULNERABILITY] @ [FILENAME][POSTFIX]";
+    private String sastIssueSummaryBranchFormat = "[PREFIX][VULNERABILITY] @ [FILENAME] [[BRANCH]][POSTFIX]";
 
 
     public String getUrl() {
@@ -342,6 +344,18 @@ public class JiraProperties {
 
     public void setLabelPrefix(String labelPrefix) {
         this.labelPrefix = labelPrefix;
+    }
+
+    public String getSastIssueSummaryFormat() { return this.sastIssueSummaryFormat; }
+
+    public void setSastIssueSummaryFormat(String sastIssueSummaryFormat) {
+        this.sastIssueSummaryFormat = sastIssueSummaryFormat;
+    }
+
+    public String getSastIssueSummaryBranchFormat() { return this.sastIssueSummaryBranchFormat; }
+
+    public void setSastIssueSummaryBranchFormat(String sastIssueSummaryBranchFormat) {
+        this.sastIssueSummaryBranchFormat = sastIssueSummaryBranchFormat;
     }
 
 }

--- a/src/main/java/com/checkmarx/flow/constants/JiraConstants.java
+++ b/src/main/java/com/checkmarx/flow/constants/JiraConstants.java
@@ -9,8 +9,6 @@ public class JiraConstants {
     public static final int JIRA_MAX_DESCRIPTION = 32760;
 
     public static final int MAX_RESULTS_ALLOWED = 1000000;
-    public static final String JIRA_ISSUE_TITLE_KEY_WITH_BRANCH = "%s%s @ %s [%s]%s";
-    public static final String JIRA_ISSUE_TITLE_KEY = "%s%s @ %s%s";
     public static final String JIRA_ISSUE_BODY_WITH_BRANCH = "*%s* issue exists @ *%s* in branch *%s*";
     public static final String JIRA_ISSUE_BODY = "*%s* issue exists @ *%s*";
 }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> This pull request adds the ability to specify, via configuration, the format of the Jira issue summary for Jira issues raised for SAST results. The Jira issue summary acts as an implicit grouping operator for SAST results; this change allows users to change this grouping. The concrete use case is a customer who wants separate Jira issues for results with different severities (the customer's triage process includes changing the result severity). A hard-coded version of this change, in a custom build of CxFlow, as been running in production for the last four months or so. The aim is to migrate this customer to a core version of CxFlow.

### Testing
Manually tested 
1. When the new parameters for jira summary are  provided the jira issue summary are created with Vulnerability in Project with severity @ filename. if the branch format is not selected.
2. When the branch format is given the jira issue summary is created with Vulnerability in Project with severity @ filename branchname.
3. When the FILENAME is used the entire path to file is added in the issue summary whereas when BASENAME is used only the filename is added in summary.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
