### PR TITLE
False positive handling for SCA

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.5.03"
+        CxSBSDK = "0.5.04"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.5.03"
+        CxSBSDK = "0.5.04"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
+++ b/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
@@ -168,11 +168,13 @@ public class ScanUtils {
                     List<Finding> findingsListBySeverity = getFindingsListBySeverity(findings, s);
                     Map<String, List<Finding>> packageMap = findingsListBySeverity.stream()
                             .collect(Collectors.groupingBy(f-> f.getId() + f.getPackageId()));
+                    
                     packageMap.forEach((k,v) -> {
                         ScanResults.XIssue issue = ScanResults.XIssue.builder()
                                 .groupBySeverity(false)
                                 .build();
                         issue.setScaDetails(getScaDetailsListBySeverity(scaResults, v));
+                        issue.setFalsePositiveCount(getFalsePositiveCount(v));
                         issueList.add(issue);
                     });
                 });
@@ -553,6 +555,13 @@ public class ScanUtils {
         return scaDetailsList;
     }
 
+    private static int getFalsePositiveCount(List<Finding> v) {
+    	
+    	long falsePositiveCount = v.stream().filter(f-> f.isIgnored()).collect(Collectors.counting());
+        	
+        return (int)falsePositiveCount;
+    }
+    
 
     public static String getStringWithEncodedCharacter(String str)
     {


### PR DESCRIPTION
### Description
This PR Fixes AB#605 . SCA reported vulnerabilities that are marked ignored in SCA, were still considered as valid/open vulnerabilities.  CxFlow JIRA handling supported handling of FALSE positives for SAST but not for SCA. Most logic is same. The missing part of SCA specific logic to count false positives and to check if all findings in a issue are false positives. 
Now, CxFlow closes the JIRA issue if the corresponding vulnerability received in SCA report is marked ignored.


### References

ADO WorkItem AB#605

### Testing
Perform SCA scan on a project with JIRA as bug tracker . Issues will be created for vulnerabilities reported.
Triage vulnerabilities in SCA to mark some of them ignored.
Perform SCA scan again on same project. 
Validated that JIRA issues corresponding to the ignored vulnerabilities are marked as closed in JIRA by CxFlow.

### Checklist

- [ NA] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [Y ] All active GitHub checks for tests, formatting, and security are passing
- [ Y] The correct base branch is being used
