### PR TITLE
Feature for ssh support per project

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.5.04"
+        CxSBSDK = "0.5.06"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.5.03"
+        CxSBSDK = "0.5.04"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.5.04"
+        CxSBSDK = "0.5.06"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.5.03"
+        CxSBSDK = "0.5.04"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/docs/Config-As-Code.md
+++ b/docs/Config-As-Code.md
@@ -28,6 +28,7 @@ Example Config As Code:
       "branches": ["develop", "main", "master"],
       "emails": ["xxxx@checkmarx.com"],
       "bugTracker": "JIRA|GitLab|GitHub|Azure",
+      "sshKeyIdentifier": "Key of the ssh-key-list parameter present in application.yml file."
       "jira": {
         "project": "APPSEC",
         "issue_type": "Bug",

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -149,10 +149,14 @@ checkmarx:
   jira-issuetype-field: jira-issuetype
   jira-custom-field: jira-fields
   jira-assignee-field: jira-assignee
+  ssh-key: Path/of/the/private/key 
   preserve-xml: true
   url: ${checkmarx.base-url}/cxrestapi
   scan-queuing: false
   scan-queuing-timeout: 720
+  ssh-key-list:
+    repo_specific_key1: Path/of/the/private/key
+    repo_specific_key2: Path/of/the/private/key
 #WSDL Config
   portal-url: ${checkmarx.base-url}/cxwebinterface/Portal/CxWebService.asmx
   sdk-url: ${checkmarx.base-url}/cxwebinterface/SDK/CxSDKWebService.asmx
@@ -372,6 +376,8 @@ Refer to the sample configuration above for the entire yaml structure.
 | custom-state-map  |                | No  | No  | Yes      | A map of custom result state identifiers to custom result state names |
 | scan-queuing       | false | No* | Yes | No | When **True**: If a scan is active for the same project, CxFlow submits a new scan and puts in queue. When scan-queue is **False**: the CxFlow behavior is according to scan-resubmit settings. |                 |
 | scan-queuing-timeout       | 720  | No* | Yes | No | If scan-queuing is true then scan-queuing-timeout Defaults to 12h. '0' would be for waiting forever with the scan in the queue.                 |
+| ssh-key-list | | No | Yes | No | A map of sshKeyIdentifier to their actual SSH private key file path. Currently only works with GitHub.  |
+| ssh-key | | No | Yes | Yes | Holds the location of the ssh private key file when SSH method is used instead of Personal Access Token. |
 No* = Default is applied
 
 ### <a name="nine">9.0 Configuration Changes</a>
@@ -390,6 +396,7 @@ checkmarx:
    team: /CxServer/Checkmarx/CxFlow
    url: ${checkmarx.base-url}/cxrestapi
    preserve-xml: true
+   ssh-key: Path/of/the/private/key
    incremental: true
    #WSDL Config
    portal-url: ${checkmarx.base-url}/cxwebinterface/Portal/CxWebService.asmx
@@ -399,6 +406,10 @@ checkmarx:
    exclude-folders: ".git,test"
    scan-queuing: false
    scan-queuing-timeout: 720
+   ssh-key-list:
+    repo_specific_key1: Path/of/the/private/key
+    repo_specific_key2: Path/of/the/private/key
+   
 ```
 **Note:**
 * Make sure to include **version: 9.0** (or higher) and **scope:  access_control_api sast_rest_api**

--- a/src/main/java/com/checkmarx/flow/config/FlowProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/FlowProperties.java
@@ -48,6 +48,7 @@ public class FlowProperties {
     private Integer httpReadTimeout = 120000;
     private boolean listFalsePositives = false;
     private boolean scanResubmit = false;
+    private String sshKeyPath;
     private Mail mail;
     @Getter @Setter
     private boolean preserveProjectName;
@@ -320,6 +321,13 @@ public class FlowProperties {
         this.thresholds = thresholds;
     }
 
+    public void setSshkeypath(String sshKeyPath) {
+        this.sshKeyPath = sshKeyPath;
+    }
+
+    public String getSshkeypath() {
+        return sshKeyPath;
+    }
 
     public static class Mail {
         private String host;

--- a/src/main/java/com/checkmarx/flow/dto/FlowOverride.java
+++ b/src/main/java/com/checkmarx/flow/dto/FlowOverride.java
@@ -32,6 +32,8 @@ public class FlowOverride {
     public Thresholds thresholds;
     @JsonProperty("vulnerabilityScanners")
     public List<String> vulnerabilityScanners = null;
+    @JsonProperty("sshKeyIdentifier")
+    public String sshKeyIdentifier;
     
     public FlowOverride() {
     }
@@ -96,8 +98,16 @@ public class FlowOverride {
 
     public Thresholds getThresholds() { return this.thresholds;}
 
+    public void setSshKeyIdentifier(String sshKeyIdentifier) {
+        this.sshKeyIdentifier = sshKeyIdentifier;
+    }
+
+    public String getSshKeyIdentifier() {
+        return sshKeyIdentifier;
+    }
+
     public String toString() {
-        return "FlowOverride(application=" + this.getApplication() + ", branches=" + this.getBranches() + " emails=" + this.getEmails() + ", jira=" + this.getJira() + ", filters=" + this.getFilters() + "thresholds=" + this.getThresholds() + ")";
+        return "FlowOverride(application=" + this.getApplication() + ", branches=" + this.getBranches() + " emails=" + this.getEmails() + ", jira=" + this.getJira() + ", filters=" + this.getFilters() + "thresholds=" + this.getThresholds() + ", sshKeyIdentifier=" + this.getSshKeyIdentifier() +")";
     }
 
 

--- a/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
@@ -104,6 +104,10 @@ public class ScanRequest {
 
     @Getter @Setter
     private boolean disableCertificateValidation;
+    
+    //SSH Key per repo
+    @Getter @Setter
+    private String sshKeyIdentifier;
 
     public ScanRequest(ScanRequest other) {
         this.namespace = other.namespace;
@@ -145,6 +149,7 @@ public class ScanRequest {
         this.organizationId = other.organizationId;
         this.gitUrl = other.gitUrl;
         this.disableCertificateValidation = other.disableCertificateValidation;
+        this.sshKeyIdentifier = other.sshKeyIdentifier;
     }
 
     public Map<String,String> getAltFields() {

--- a/src/main/java/com/checkmarx/flow/sastscanning/ScanRequestConverter.java
+++ b/src/main/java/com/checkmarx/flow/sastscanning/ScanRequestConverter.java
@@ -222,6 +222,7 @@ public class ScanRequestConverter {
                 .withFileExclude(request.getExcludeFiles())
                 .withFolderExclude(request.getExcludeFolders())
                 .withScanConfiguration(request.getScanConfiguration())
+                .withSshKeyIdentifier(request.getSshKeyIdentifier())
                 .withClientSecret(request.getScannerApiSec());
 
         if (StringUtils.isNotEmpty(request.getBranch())) {

--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -113,6 +113,10 @@ public class ConfigurationOverrider {
             overrideJiraBugProperties(override, bt);
         }
 
+        if(!StringUtils.isEmpty(override.getSshKeyIdentifier() ) ) {
+            request.setSshKeyIdentifier(override.getSshKeyIdentifier());
+        }
+        
         request.setBugTracker(bt);
         
         Optional.ofNullable(override.getApplication())
@@ -364,11 +368,6 @@ public class ConfigurationOverrider {
             FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null);
             request.setFilter(filter);
         }
-        
-        if(!StringUtils.isEmpty(override.getSshKeyIdentifier() ) ) {
-            request.setSshKeyIdentifier(override.getSshKeyIdentifier());
-        }
-        
         return request;
     }
 

--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Service;
@@ -112,6 +113,10 @@ public class ConfigurationOverrider {
         }
 
         request.setBugTracker(bt);
+
+        if(override.getSshKeyIdentifier() != null && !override.getSshKeyIdentifier().isEmpty() ) {
+            flowProperties.setSshkeypath(override.getSshKeyIdentifier());
+        }
 
         Optional.ofNullable(override.getApplication())
                 .filter(StringUtils::isNotBlank)

--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -81,6 +81,7 @@ public class ConfigurationOverrider {
         } catch (IllegalArgumentException e) {
             log.warn("Error parsing cxFlow object from CxConfig.", e);
         }
+        
         return request;
     }
 
@@ -113,11 +114,7 @@ public class ConfigurationOverrider {
         }
 
         request.setBugTracker(bt);
-
-        if(override.getSshKeyIdentifier() != null && !override.getSshKeyIdentifier().isEmpty() ) {
-            flowProperties.setSshkeypath(override.getSshKeyIdentifier());
-        }
-
+        
         Optional.ofNullable(override.getApplication())
                 .filter(StringUtils::isNotBlank)
                 .ifPresent(a -> {
@@ -367,7 +364,11 @@ public class ConfigurationOverrider {
             FilterConfiguration filter = filterFactory.getFilter(controllerRequest, null);
             request.setFilter(filter);
         }
-
+        
+        if(!StringUtils.isEmpty(override.getSshKeyIdentifier() ) ) {
+            request.setSshKeyIdentifier(override.getSshKeyIdentifier());
+        }
+        
         return request;
     }
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> This PR adds feature to provide ssh support per project. 

### Testing

|ssh-key-list(map   in application.yml in checkmarx section):      sshtest: id_rsa      sshtest2: .ssh/pk2      sshKeyIdentifier(in cx.config): "sshtest"      ssh-key(string in application.yml in checkmarx section): empty | ssh-key-list(map in   application.yml in checkmarx section):     empty      sshKeyIdentifier(in cx.config): "sshtest"      ssh-key(string in application.yml in checkmarx section): empty | ssh-key-list(map in   application.yml in checkmarx section):     empty      sshKeyIdentifier(in cx.config): not present      ssh-key(string in application.yml in checkmarx section): .ssh/pk2 | ssh-key-list(map in   application.yml in checkmarx section):     empty      sshKeyIdentifier(in cx.config): not present      ssh-key(string in application.yml in checkmarx section): empty
-- | -- | -- | --
id_rsa ssh private key used   for scan | Exception is raised      SSH Key corresponding to the identifier configured for   the repository is not found. | pk2 ssh private key used for scan | Personal Access Token is used for scan.
### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
