### PR TITLE
Base alpine used instead of one from openjdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,31 @@
-FROM openjdk:8-jre-alpine AS java8
+FROM alpine:3.14 AS java8
 
 WORKDIR app
 RUN apk update && \
     apk upgrade && \
     apk upgrade
+RUN apk add openjdk8=8.282.08-r1
 COPY build/libs/*.jar cx-flow.jar
 ENTRYPOINT ["java", "-Xms512m", "-Xmx2048m", "-Djava.security.egd=file:/dev/./urandom", "-Dspring.profiles.active=web", "-jar", "cx-flow.jar"]
 EXPOSE 8080
 
 
-FROM openjdk:11-jre-slim AS java11
+FROM alpine:3.14 AS java11
 
 WORKDIR app
-RUN apt update && \
-    apt upgrade -y
+RUN apk update && \
+    apk upgrade 
+RUN apk add openjdk11=11.0.11_p9-r0
 COPY build/libs/java11/*.jar cx-flow.jar
 ENTRYPOINT ["java", "-Xms512m", "-Xmx2048m","-Djava.security.egd=file:/dev/./urandom", "-Dspring.profiles.active=web", "-jar", "cx-flow.jar"]
 EXPOSE 8080
 
-FROM openjdk:8-jre-alpine AS cxgo8
+FROM alpine:3.14 AS cxgo8
 
 WORKDIR app
 RUN apk update && \
     apk upgrade
+RUN apk add openjdk8=8.282.08-r1
 COPY build/libs/cxgo/*.jar cx-flow.jar
 ENTRYPOINT ["java", "-Xms512m", "-Xmx2048m", "-Djava.security.egd=file:/dev/./urandom", "-Dspring.profiles.active=cxgo", "-jar", "cx-flow.jar"]
 EXPOSE 8080

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/end2end/genericendtoend/GitHubApiHandler.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/end2end/genericendtoend/GitHubApiHandler.java
@@ -16,6 +16,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 
 import io.cucumber.java.PendingException;
@@ -116,7 +117,66 @@ public class GitHubApiHandler {
         hook.setConfig(config);
         return new HttpEntity<>(hook, headers);
     }
+    
+	/**
+	 * Get a file content from a GitHub repository, Using GitHub's API <br>
+	 * 
+	 * 
+	 * @param message   the commit message
+	 * @param committer the Committer doing the commit
+	 * @param headers   must include the Authentication and content type.
+	 * @param apiUrl    the url of GitHub (can be a local server)
+	 * @param namespace usually the company or user who created the project
+	 * @param repo      the key of the repository
+	 * @param filePath  where to put place the file in the repo
+	 * @param branch    the branch to push to
+	 * @return the Json of the response
+	 * @throws JsonProcessingException indicates problem in creating the file for
+	 *                                 commit
+	 * @throws Exception               indicates an error
+	 */
+	public JSONObject getRepoContent(String message, Committer committer, HttpHeaders headers,
+			String apiUrl, String namespace, String repo, String filePath, String branch)
+			throws JsonProcessingException, Exception {
+				
+		if(StringUtils.isEmpty(branch))
+			branch = "master";
+		String path = String.format(URL_PATERN_CONTENTS, apiUrl, namespace, repo, filePath);
+		ResponseEntity<String> response = doGet(path, headers);
+		return new JSONObject(response.getBody());
+	}
 
+	/**
+	 * Delete a file from a GitHub repository, Using GitHub's API <br>
+	 * 
+	 * 
+	 * @param message   the commit message
+	 * @param committer the Committer doing the commit
+	 * @param headers   must include the Authentication and content type.
+	 * @param apiUrl    the url of GitHub (can be a local server)
+	 * @param namespace usually the company or user who created the project
+	 * @param repo      the key of the repository
+	 * @param filePath  where to put place the file in the repo
+	 * @param branch    the branch to push to
+	 * @return the Json of the response
+	 * @throws JsonProcessingException indicates problem in creating the file for
+	 *                                 commit
+	 * @throws Exception               indicates an error
+	 */
+	public JSONObject deleteRepoContent(String message, Committer committer, HttpHeaders headers,
+			String apiUrl, String namespace, String repo, String filePath, String branch)
+			throws JsonProcessingException, Exception {
+				
+		if(StringUtils.isEmpty(branch))
+			branch = "master";
+				
+		String path = String.format(URL_PATERN_CONTENTS, apiUrl, namespace, repo, filePath);
+		RestTemplate restTemplate = new RestTemplate();
+        HttpEntity<String> requestEntity = new HttpEntity<>(null, headers);
+        ResponseEntity<String> response = restTemplate.exchange(path, HttpMethod.DELETE, requestEntity, String.class);
+        return new JSONObject(response.getBody());
+	}
+	
     private JSONArray getJSONArray(String uri, HttpHeaders headers) {
         ResponseEntity<String> response = doGet(uri, headers);
         String body = response.getBody();

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/end2end/genericendtoend/Repository.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/end2end/genericendtoend/Repository.java
@@ -59,7 +59,7 @@ enum Repository {
         private GitHubApiHandler api;
 
         @Override
-        Boolean hasWebHook() {
+        Boolean hasWebHook() {        
             JSONArray hooks = api.getHooks(getHeaders(), gitHubProperties.getApiUrl(), namespace, repo);
             assertNotNull(hooks, "could not create webhook configuration");
             return !hooks.isEmpty();
@@ -144,7 +144,23 @@ enum Repository {
             committer.setName("CxFlowTestUser");
             committer.setEmail("CxFlowTestUser@checkmarx.com");
             try {
-                if (activeBranch.equals(EMPTY_STRING)){
+            	
+            	//attempt to delete a file if found
+            	try {
+            		
+            		JSONObject response = api.getRepoContent("GitHubToJira test message", committer, getHeaders(),
+                            gitHubProperties.getApiUrl(), namespace, repo, theFilePath, activeBranch);
+            		
+            		if(response != null) {
+            			JSONObject delResponse = api.deleteRepoContent("GitHubToJira test message", committer, getHeaders(),
+                                gitHubProperties.getApiUrl(), namespace, repo, theFilePath, activeBranch);
+            			log.error(theFilePath + " existed. Deleted successfully so that pre-condition works.");
+            		}            		            		
+            	}catch(Exception e) {
+            		
+            	}
+            	
+                if (activeBranch.equals(EMPTY_STRING)){                	
                     JSONObject response = api.pushFile(content, "GitHubToJira test message", committer, getHeaders(),
                             gitHubProperties.getApiUrl(), namespace, repo, theFilePath);
                     createdFilesSha.put( response.getJSONObject("content").getString("sha") , theFilePath);

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/end2end/genericendtoend/Repository.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/end2end/genericendtoend/Repository.java
@@ -179,7 +179,7 @@ enum Repository {
                     String message = "There is already a file with the specified name (" + theFilePath
                             + "). please delete the file before running the test";
                     log.error(message);
-                    throw new PreconditionViolationException(message);
+                    throw new PreconditionViolationException(message, e);
                 } else {
                     throw e;
                 }


### PR DESCRIPTION
### Description

To fix vulnerabilities reported on the docker image. 

### References

https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/602/

### Testing

Created local docker images for Java8, Java11 and Cxgo. Ran those through tools like grype and trivy. The only reported vulnerabilities are related to CxFlow library dependencies, which are related to ant and antlr. These same vulns are also reported by SCA on CxFlow library dependencies.  There is tracking bug already open on the board .

### Checklist

- [ NA] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ Y] All active GitHub checks for tests, formatting, and security are passing
- [Y ] The correct base branch is being used
