### PR TITLE
Enable project-level custom fields

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.5.06"
+        CxSBSDK = "0.5.07"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.5.05"
+        CxSBSDK = "0.5.06"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.5.06"
+        CxSBSDK = "0.5.07"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/docs/Config-As-Code.md
+++ b/docs/Config-As-Code.md
@@ -1,6 +1,6 @@
 # Config as Code
 The presence of a cx.config file in the root of the source repository is used to drive/override project/scanning configuration within CxFlow
-### **Note: Currently only implemented for GitHub, GitLab, Bitbucket Server, Bitbucket Cloud and Azure DevOps, for WebHook execution.**
+### **Note: Currently implemented for GitHub, GitLab, Bitbucket Server, Bitbucket Cloud and Azure DevOps, for WebHook execution, and for local source scanning in batch mode.**
 
 * [Current Overrides](#current)
 * [Automated Code Profiling](#automatedcodeprofiling)
@@ -78,7 +78,6 @@ Example Config As Code:
 ```
 
 ## <a name="automatedcodeprofiling">Automated Code Profiling</a>
-Again, Config As Code is currently only implemented GitHub and GitLab Webhook execution
 
 [[/Images/automatedWorkflow1.png|Automated code profiling workflow diagram]]
 [[/Images/automatedWorkflow2.png|Automated code profiling swim lane diagram]]

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -381,7 +381,7 @@ Refer to the sample configuration above for the entire yaml structure.
 | custom-state-map  |                | No  | No  | Yes      | A map of custom result state identifiers to custom result state names |
 | scan-queuing       | false | No* | Yes | No | When **True**: If a scan is active for the same project, CxFlow submits a new scan and puts in queue. When scan-queue is **False**: the CxFlow behavior is according to scan-resubmit settings. |                 |
 | scan-queuing-timeout       | 720  | No* | Yes | No | If scan-queuing is true then scan-queuing-timeout Defaults to 12h. '0' would be for waiting forever with the scan in the queue.                 |
-| settings-override | false          | No  | No  | Yes      | Must be set to `true` if overriding preset, engine configuration or file/folder exclusions for an existing project |
+| settings-override | false          | No  | No  | Yes      | Must be set to `true` if overriding preset, engine configuration, file/folder exclusions, or project-level custom fields for an existing project |
 | ssh-key-list | | No | Yes | No | A map of sshKeyIdentifier to their actual SSH private key file path. Currently only works with GitHub.  |
 | ssh-key | | No | Yes | Yes | Holds the location of the ssh private key file when SSH method is used instead of Personal Access Token. |
 No* = Default is applied

--- a/docs/Execution.md
+++ b/docs/Execution.md
@@ -72,6 +72,7 @@ CxFlow can be integrated via command line using several ways. The table below li
 | `--offline` | If this flag is raised, the Checkmarx instance is not contacted.  This means that no issue description is provided and Checkmarx custom fields cannot be used |
 | `--blocksysexit` | Optional: Mainly for build/test purposes. Avoid `System.exit()` in the code and exit with java exception |
 | `--alt-project` | Name of the project in ADO. This parameter is required in addition to cx-project parameter. |
+| `--project-custom-field` | Specify a project-level custom field to be set if a project is created or the `checkmarx.settings-override` property is set. The custom field are specified as *name:value* (i.e., the field name cannot include a colon). This option may be specified multiple times to set multiple fields. |
 ## <a name="parse">Parse</a>
 
 ```

--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -13,6 +13,7 @@ import com.checkmarx.sdk.config.Constants;
 import com.checkmarx.sdk.config.CxPropertiesBase;
 import com.checkmarx.sdk.dto.ScanResults;
 import com.checkmarx.sdk.dto.filtering.FilterConfiguration;
+import com.checkmarx.sdk.dto.sast.CxConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import lombok.RequiredArgsConstructor;
@@ -30,8 +31,11 @@ import javax.annotation.PostConstruct;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.file.FileSystems;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -196,6 +200,7 @@ public class CxFlowRunner implements ApplicationRunner {
         boolean usingBitBucketServer = args.containsOption("bbs");
         boolean disableCertificateValidation = args.containsOption("trust-cert");
         CxPropertiesBase cxProperties = cxScannerService.getProperties();
+        Map<String, String> projectCustomFields = makeCustomFieldMap(args.getOptionValues("project-custom-field"));
 
         if (((ScanUtils.empty(namespace) && ScanUtils.empty(repoName) && ScanUtils.empty(branch)) &&
                 ScanUtils.empty(application)) && !args.containsOption(BATCH_OPTION) && !args.containsOption(IAST_OPTION)) {
@@ -351,6 +356,7 @@ public class CxFlowRunner implements ApplicationRunner {
                 .altFields(altFields)
                 .forceScan(force)
                 .disableCertificateValidation(disableCertificateValidation)
+                .cxFields(projectCustomFields)
                 .build();
 
         if (projectId != null) {
@@ -555,7 +561,11 @@ public class CxFlowRunner implements ApplicationRunner {
             log.error("Please provide --cx-project to define the project in Checkmarx");
             exit(ExitCode.ARGUMENT_NOT_PROVIDED);
         }
-        ScanResults scanResults = runOnActiveScanners(scanner -> scanner.scanCli(request, "cxFullScan", new File(path)));
+        CxConfig cxConfig = getCxConfigOverride(path, "cx.config");
+        request = configOverrider.overrideScanRequestProperties(cxConfig, request);
+        // A lambda rquires a final or effectively final parameter
+        ScanRequest finalRequest = request;
+        ScanResults scanResults = runOnActiveScanners(scanner -> scanner.scanCli(finalRequest, "cxFullScan", new File(path)));
         processResults(request, scanResults);
     }
 
@@ -619,5 +629,47 @@ public class CxFlowRunner implements ApplicationRunner {
         } catch (MachinaRuntimeException e) {
             throw (ExitThrowable) (e.getCause());
         }
+    }
+
+    /**
+     * Converts a List of Strings representing one or more custom fields to
+     * a Map. Each String is expected to be of the form "name:value".
+     *
+     * @param values a List of Strings representing custom fields
+     * @return a Map of custom fields (or null if values is null)
+     */
+    private Map<String, String> makeCustomFieldMap(List<String> values) {
+        if (values != null) {
+            Map<String, String> customFields = new HashMap<>();
+            for (String value : values) {
+                String[] nvp = value.split(":", 2);
+                if (nvp.length == 2) {
+                    customFields.put(nvp[0], nvp[1]);
+                } else {
+                    log.warn("{}: invalid project custom field", value);
+                }
+            }
+            return customFields;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Load a config-as-code file from the specified directory.
+     *
+     * @param path the path of the directory containing the config-as-code file
+     * @param name the name of the config-as-code file
+     * @return the config-as-code configuration
+     */
+    private CxConfig getCxConfigOverride(String path, String name) {
+        log.debug("getCxConfigOverride: path: {}", path);
+        CxConfig config = null;
+        File file = FileSystems.getDefault().getPath(path, name).toFile();
+        if (file.exists()) {
+            log.debug("Loading config-as-code from {}", file);
+            config = com.checkmarx.sdk.utils.ScanUtils.getConfigAsCode(file);
+        }
+        return config;
     }
 }

--- a/src/main/java/com/checkmarx/flow/sastscanning/ScanRequestConverter.java
+++ b/src/main/java/com/checkmarx/flow/sastscanning/ScanRequestConverter.java
@@ -222,7 +222,8 @@ public class ScanRequestConverter {
                 .withFileExclude(request.getExcludeFiles())
                 .withFolderExclude(request.getExcludeFolders())
                 .withScanConfiguration(request.getScanConfiguration())
-                .withClientSecret(request.getScannerApiSec());
+                .withClientSecret(request.getScannerApiSec())
+                .withCustomFields(request.getCxFields());
 
         if (StringUtils.isNotEmpty(request.getBranch())) {
             params.withBranch(Constants.CX_BRANCH_PREFIX.concat(request.getBranch()));

--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -242,6 +242,7 @@ public class ConfigurationOverrider {
                 overrideReport.put("scan configuration", scanConfiguration);
             });
         });
+        override.map(CxConfig::getCustomFields).ifPresent(s -> request.setCxFields(s));
         overrideUsingConfigProvider(override, overrideReport, request);
     }
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR enables support for project-level custom fields. Project-level custom fields can be specified either on the command line, using the new --project-custom-field command line option, or via the cx.config config-as-code file (which is now also used in batch mode when processing local source code.

### References

Aha!: https://checkmarx1.aha.io/features/SDLC-301
GitHub: https://github.com/checkmarx-ltd/cx-flow/issues/730

### Testing

I have written a Python test harness which tests the following three scenarios using both command line arguments and the cx.config config-as-code file:

- project does not already exist (in which case it is created and the project-level custom fields are set)
- project already exists and the `checkmarx.settings-override` property is not set (the existing project-level custom fields are *not* updated)
- project already exists and the `checkmarx.settings-override` property is set (the existing project-level custom fields *are* updated)

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
