### PR TITLE
Pr enable scan level custom fields

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.5.07"
+        CxSBSDK = "0.5.09"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.5.07"
+        CxSBSDK = "0.5.09"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.3.5.RELEASE'

--- a/docs/Config-As-Code.md
+++ b/docs/Config-As-Code.md
@@ -74,6 +74,14 @@ Example Config As Code:
         "status": ["Confirmed", "New"]
       }
     }
+  },
+  "customFields": {
+    "field1": "value1",
+    "field2": "value2"
+  },
+  "scanCustomFields": {
+    "field3": "value3",
+    "field4": "value4"
   }
 }
 ```

--- a/docs/Execution.md
+++ b/docs/Execution.md
@@ -72,7 +72,8 @@ CxFlow can be integrated via command line using several ways. The table below li
 | `--offline` | If this flag is raised, the Checkmarx instance is not contacted.  This means that no issue description is provided and Checkmarx custom fields cannot be used |
 | `--blocksysexit` | Optional: Mainly for build/test purposes. Avoid `System.exit()` in the code and exit with java exception |
 | `--alt-project` | Name of the project in ADO. This parameter is required in addition to cx-project parameter. |
-| `--project-custom-field` | Specify a project-level custom field to be set if a project is created or the `checkmarx.settings-override` property is set. The custom field are specified as *name:value* (i.e., the field name cannot include a colon). This option may be specified multiple times to set multiple fields. |
+| `--project-custom-field` | Specify a project-level custom field to be set if a project is created or the `checkmarx.settings-override` property is set. The custom field is specified as *name:value* (i.e., the field name cannot include a colon). This option may be specified multiple times to set multiple fields. |
+| `--scan-custom-field` | Specify a scan-level custom field. The custom field is specified as *name:value* (i.e., the field name cannot include a colon). This option may be specified multiple times to set multiple fields. |
 ## <a name="parse">Parse</a>
 
 ```

--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -201,6 +201,7 @@ public class CxFlowRunner implements ApplicationRunner {
         boolean disableCertificateValidation = args.containsOption("trust-cert");
         CxPropertiesBase cxProperties = cxScannerService.getProperties();
         Map<String, String> projectCustomFields = makeCustomFieldMap(args.getOptionValues("project-custom-field"));
+        Map<String, String> scanCustomFields = makeCustomFieldMap(args.getOptionValues("scan-custom-field"));
 
         if (((ScanUtils.empty(namespace) && ScanUtils.empty(repoName) && ScanUtils.empty(branch)) &&
                 ScanUtils.empty(application)) && !args.containsOption(BATCH_OPTION) && !args.containsOption(IAST_OPTION)) {
@@ -357,6 +358,7 @@ public class CxFlowRunner implements ApplicationRunner {
                 .forceScan(force)
                 .disableCertificateValidation(disableCertificateValidation)
                 .cxFields(projectCustomFields)
+                .scanFields(scanCustomFields)
                 .build();
 
         if (projectId != null) {

--- a/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
@@ -30,6 +30,7 @@ public class ScanRequest {
     private String altFields;
 
     private Map<String, String> cxFields;
+    private Map<String, String> scanFields;
     private String site;
 
     /**
@@ -116,6 +117,7 @@ public class ScanRequest {
         this.team = other.team;
         this.project = other.project;
         this.cxFields = other.cxFields;
+        this.scanFields = other.scanFields;
 		this.altProject = other.altProject;
         this.altFields = other.altFields;
         this.site = other.site;

--- a/src/main/java/com/checkmarx/flow/sastscanning/ScanRequestConverter.java
+++ b/src/main/java/com/checkmarx/flow/sastscanning/ScanRequestConverter.java
@@ -224,7 +224,8 @@ public class ScanRequestConverter {
                 .withScanConfiguration(request.getScanConfiguration())
                 .withSshKeyIdentifier(request.getSshKeyIdentifier())
                 .withClientSecret(request.getScannerApiSec())
-                .withCustomFields(request.getCxFields());
+                .withCustomFields(request.getCxFields())
+                .withScanCustomFields(request.getScanFields());
 
         if (StringUtils.isNotEmpty(request.getBranch())) {
             params.withBranch(Constants.CX_BRANCH_PREFIX.concat(request.getBranch()));

--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -249,6 +249,7 @@ public class ConfigurationOverrider {
             });
         });
         override.map(CxConfig::getCustomFields).ifPresent(s -> request.setCxFields(s));
+        override.map(CxConfig::getScanCustomFields).ifPresent(s -> request.setScanFields(s));
         overrideUsingConfigProvider(override, overrideReport, request);
     }
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR adds support for scan-level custom fields to CxFlow. Scan-level custom fields can be specified either via the command line, using the new `--scan-custom-field` option, or via a `cx.config` config-as-code file.

### References

Aha! entry: https://checkmarx1.aha.io/features/SDLC-350
GitHub issue: https://github.com/checkmarx-ltd/cx-flow/issues/873

### Testing

I have tested this using a bespoke test harness written in Python. I will push the test framework to GitHub (under james-bostock-cx) once I have the PR id.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
