### PR TITLE
Log4j 2.16.0 uptake in java8 and java11 build gradle

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -129,9 +129,9 @@ dependencies {
     compile("org.jasypt:jasypt:1.9.3")
     compileJava.dependsOn(processResources)
 
-    compile("org.apache.logging.log4j:log4j-core:2.15.0")
-    compile("org.apache.logging.log4j:log4j-slf4j-impl:2.15.0")
-    compile("org.apache.logging.log4j:log4j-api:2.15.0")
+    compile("org.apache.logging.log4j:log4j-core:2.16.0")
+    compile("org.apache.logging.log4j:log4j-slf4j-impl:2.16.0")
+    compile("org.apache.logging.log4j:log4j-api:2.16.0")
     compile("javax.persistence:javax.persistence-api:2.2")
 }
 

--- a/build-11.gradle
+++ b/build-11.gradle
@@ -63,7 +63,11 @@ dependencies {
     compile group: 'com.beust', name: 'jcommander', version: '1.78'
     compile('org.apache.ant:ant:1.10.10')
 	compile('org.springframework.boot:spring-boot-starter-actuator')
-	compile('org.springframework.boot:spring-boot-starter-web')
+	compile('org.springframework.boot:spring-boot-starter-web'){
+	    exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
+        exclude group: 'org.apache.logging.log4j', module: 'log4j-api'
+        exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
+	}
     compile('org.springframework.boot:spring-boot-starter-aop')
     compile('org.springframework.boot:spring-boot-starter-validation')
     compile("com.github.checkmarx-ltd:cx-spring-boot-sdk:${CxSBSDK}") {
@@ -111,6 +115,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-java:${cucumberVersion}")
     testImplementation("io.cucumber:cucumber-junit:${cucumberVersion}")
     testImplementation("io.cucumber:cucumber-spring:${cucumberVersion}")
+    testImplementation("com.github.java-json-tools:json-patch:1.11")
     testImplementation( "org.junit.jupiter:junit-jupiter-api:${junitVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${junitVersion}")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine:${junitVersion}")
@@ -124,6 +129,9 @@ dependencies {
     compile("org.jasypt:jasypt:1.9.3")
     compileJava.dependsOn(processResources)
 
+    compile("org.apache.logging.log4j:log4j-core:2.15.0")
+    compile("org.apache.logging.log4j:log4j-slf4j-impl:2.15.0")
+    compile("org.apache.logging.log4j:log4j-api:2.15.0")
     compile("javax.persistence:javax.persistence-api:2.2")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,9 @@ dependencies {
     compile('org.springframework.boot:spring-boot-starter-actuator')
     compile('org.springframework.boot:spring-boot-starter-web'){
         exclude group: 'org.apache.ant', module: 'ant'
+        exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
+        exclude group: 'org.apache.logging.log4j', module: 'log4j-api'
+        exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
     }
     
     compile('org.springframework.boot:spring-boot-starter-aop')
@@ -144,9 +147,13 @@ dependencies {
     compile 'org.modelmapper:modelmapper:2.4.0'
     compile("com.checkmarx:cx-config-provider:${ConfigProviderVersion}") {
         exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
-        exclude group: 'org.apache.logging.log4j', module: 'log4j-api'		    
+        exclude group: 'org.apache.logging.log4j', module: 'log4j-api'
+        exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
+        		    
     }
+    compile("org.apache.logging.log4j:log4j-core:2.15.0")
     compile("org.apache.logging.log4j:log4j-slf4j-impl:2.15.0")
+    compile("org.apache.logging.log4j:log4j-api:2.15.0")
     compile("javax.persistence:javax.persistence-api:2.2")
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -151,9 +151,9 @@ dependencies {
         exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
         		    
     }
-    compile("org.apache.logging.log4j:log4j-core:2.15.0")
-    compile("org.apache.logging.log4j:log4j-slf4j-impl:2.15.0")
-    compile("org.apache.logging.log4j:log4j-api:2.15.0")
+    compile("org.apache.logging.log4j:log4j-core:2.16.0")
+    compile("org.apache.logging.log4j:log4j-slf4j-impl:2.16.0")
+    compile("org.apache.logging.log4j:log4j-api:2.16.0")
     compile("javax.persistence:javax.persistence-api:2.2")
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,10 @@ dependencies {
     compile group: 'com.beust', name: 'jcommander', version: '1.78'
     compile('org.apache.ant:ant:1.10.10')
     compile('org.springframework.boot:spring-boot-starter-actuator')
-    compile('org.springframework.boot:spring-boot-starter-web')
+    compile('org.springframework.boot:spring-boot-starter-web'){
+        exclude group: 'org.apache.ant', module: 'ant'
+    }
+    
     compile('org.springframework.boot:spring-boot-starter-aop')
     compile('org.springframework.boot:spring-boot-starter-validation')
     compile("com.github.checkmarx-ltd:cx-spring-boot-sdk:${CxSBSDK}") {
@@ -141,8 +144,9 @@ dependencies {
     compile 'org.modelmapper:modelmapper:2.4.0'
     compile("com.checkmarx:cx-config-provider:${ConfigProviderVersion}") {
         exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
+        exclude group: 'org.apache.logging.log4j', module: 'log4j-api'		    
     }
-
+    compile("org.apache.logging.log4j:log4j-slf4j-impl:2.15.0")
     compile("javax.persistence:javax.persistence-api:2.2")
 
 }

--- a/src/main/java/com/checkmarx/flow/service/AbstractVulnerabilityScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/AbstractVulnerabilityScanner.java
@@ -37,6 +37,7 @@ import static com.checkmarx.flow.exception.ExitThrowable.exit;
 import static com.checkmarx.sdk.config.Constants.UNKNOWN;
 import static com.checkmarx.sdk.config.Constants.UNKNOWN_INT;
 
+//Common implementation for SAST/Go scan
 @Service
 @Slf4j
 @RequiredArgsConstructor


### PR DESCRIPTION
### Description

This PR fixes Log4j CVE in CxFlow for both java8 and java 11 version of cxflow artifact.

### References

CVE-2021-44228

### Testing
1. Verified that cxflow functionality working
2. Scanned cxflow for both java8 build.gradle and build-11.gradle
Java11 - https://sca.checkmarx.net/#/projects/812d6aa9-3ce5-49df-bc31-7a6bd2858fb6/reports/32613414-d4c4-46fb-82c8-34f9245c9e7b/packages/all
Java 8 - https://sca.checkmarx.net/#/projects/2202e81a-67c0-40c3-95cf-cf34bb223659/reports/704befdb-44dc-4890-8467-4ca20ca5397f/packages/all

### Checklist

- [NA ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [Y] All active GitHub checks for tests, formatting, and security are passing
- [Y ] The correct base branch is being used
