### PR TITLE
Support for providing Min-Max Heap size for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,37 @@
 FROM alpine:3.14 AS java8
 
+ENV JAVA_OPTS="-Xms512m -Xmx2048m"
+
 WORKDIR app
 RUN apk update && \
     apk upgrade && \
     apk upgrade
 RUN apk add openjdk8=8.302.08-r2 --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
 COPY build/libs/*.jar cx-flow.jar
-ENTRYPOINT ["java", "-Xms512m", "-Xmx2048m", "-Djava.security.egd=file:/dev/./urandom", "-Dspring.profiles.active=web", "-jar", "cx-flow.jar"]
+ENTRYPOINT exec java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -Dspring.profiles.active=web -jar cx-flow.jar
 EXPOSE 8080
 
 
 FROM alpine:3.14 AS java11
+
+ENV JAVA_OPTS="-Xms512m -Xmx2048m"
 
 WORKDIR app
 RUN apk update && \
     apk upgrade 
 RUN apk add openjdk11=11.0.13_p8-r0 --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
 COPY build/libs/java11/*.jar cx-flow.jar
-ENTRYPOINT ["java", "-Xms512m", "-Xmx2048m","-Djava.security.egd=file:/dev/./urandom", "-Dspring.profiles.active=web", "-jar", "cx-flow.jar"]
+ENTRYPOINT exec java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -Dspring.profiles.active=web -jar cx-flow.jar
 EXPOSE 8080
 
 FROM alpine:3.14 AS cxgo8
+
+ENV JAVA_OPTS="-Xms512m -Xmx2048m"
 
 WORKDIR app
 RUN apk update && \
     apk upgrade
 RUN apk add openjdk8=8.302.08-r2 --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
 COPY build/libs/cxgo/*.jar cx-flow.jar
-ENTRYPOINT ["java", "-Xms512m", "-Xmx2048m", "-Djava.security.egd=file:/dev/./urandom", "-Dspring.profiles.active=cxgo", "-jar", "cx-flow.jar"]
+ENTRYPOINT exec java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -Dspring.profiles.active=cxgo -jar cx-flow.jar
 EXPOSE 8080

--- a/docs/Execution.md
+++ b/docs/Execution.md
@@ -19,7 +19,7 @@ The CxFlow docker images on Docker Hub [checkmarx/cx-flow](https://hub.docker.co
 
 ```
 docker pull checkmarx/cx-flow
-docker run --env-file=.checkmarx --name=cx-flow --detach -p <host port>:8080 checkmarx/cx-flow
+docker run -e JAVA_OPTS="Specify JVM options here" --env-file=.checkmarx --name=cx-flow --detach -p <host port>:8080 checkmarx/cx-flow
 ```
 
 The env-file provides the necessary overrides during the bootstrap process - urls, credentials, etc - sample below.


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR provides the support to give JVM options for Heap Memory Size using the JAVA_OPTS ENV variable. If it is not provided then a default value of Xms512m and Xmx2048m will be used.

### References

> Include supporting link to GitHub Issue/PR number

### Testing

When   JAVA_OPTS not provided      during docker run | When JAVA_OPTS="-Xms512m   -Xmx9216m"      was provided durnig docker run | When   JAVA_OPTS="-XshowSettings:vm"      was provided during docker run
-- | -- | --
Default Values of Max Min Heap is used. | Provided Min and Max Heap is used. | Estimated Heap Size is used.
Min.   Heap Size: 512.00M      Max. Heap Size: 2.00G | Min. Heap Size: 512.00M     Max. Heap Size: 9.00G | Max. Heap Size (Estimated): 5.53G

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
