### PR TITLE
[ADO 587] Link to SAST Result and Check for Empty Value In Description

### DIFF
--- a/src/main/java/com/checkmarx/flow/config/SarifProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/SarifProperties.java
@@ -29,15 +29,15 @@ public class SarifProperties {
         severityMap.put("High", "error");
         severityMap.put("Medium", "error");
         severityMap.put("Low", "warning");
-        severityMap.put("Informational", "warning");
+        severityMap.put("Information", "warning");
     }
 
     @PostConstruct
     private void loadSecuritySeverityMap() {
-        securitySeverityMap.put("High", "10.0");
-        securitySeverityMap.put("Medium", "8.0");
-        securitySeverityMap.put("Low", "5.0");
-        securitySeverityMap.put("Informational", "2.0");
+        securitySeverityMap.put("High", "7.0");
+        securitySeverityMap.put("Medium", "4.0");
+        securitySeverityMap.put("Low", "3.9");
+        securitySeverityMap.put("Information", "3.9");
     }
 
     public String getFilePath() {


### PR DESCRIPTION
- Link to SAST Result
- Correct the Mapping of Security Severity as below:
Over 9.0 is critical, 7.0 to 8.9 is high, 4.0 to 6.9 is medium and 3.9 or less is low.
- Check for empty value in Description and Line Number and populate default value.

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change.

### References

> Include supporting link to GitHub Issue/PR number

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used
