### PR TITLE
Shard Report fix

### DIFF
--- a/src/main/java/com/checkmarx/flow/controller/FlowController.java
+++ b/src/main/java/com/checkmarx/flow/controller/FlowController.java
@@ -13,7 +13,10 @@ import com.checkmarx.flow.sastscanning.ScanRequestConverter;
 import com.checkmarx.flow.service.*;
 import com.checkmarx.flow.utils.HTMLHelper;
 import com.checkmarx.flow.utils.ScanUtils;
+import com.checkmarx.sdk.ShardManager.ShardSession;
+import com.checkmarx.sdk.ShardManager.ShardSessionTracker;
 import com.checkmarx.sdk.config.Constants;
+import com.checkmarx.sdk.config.CxProperties;
 import com.checkmarx.sdk.dto.sast.Filter;
 import com.checkmarx.sdk.dto.ScanResults;
 import com.checkmarx.sdk.dto.filtering.FilterConfiguration;
@@ -58,6 +61,8 @@ public class FlowController {
     private final SastScanner sastScanner;
     private final ResultsService resultsService;
     private final CxClient cxService;
+    private final CxProperties cxProperties;
+    private final ShardSessionTracker sessionTracker;
 
     private final CxGoScanner cxgoScanner;
     
@@ -81,6 +86,19 @@ public class FlowController {
         MDC.put(FlowConstants.MAIN_MDC_ENTRY, uid);
         // Validate shared API token from header
         validateToken(token);
+
+        // This primes the shard when Shard Manager is turned on
+        if(cxProperties.getEnableShardManager()) {
+            ShardSession shard = sessionTracker.getShardSession();
+            // sometimes the team comes in missing the leading "/"
+            // like this: CxServer/my-proj. The following check
+            // ensures this gets fixed like this: /CxServer/CHECKMARX
+            if(team.charAt(0) != '/') {
+                team = ("/" + team);
+            }
+            shard.setTeam(team);
+            shard.setProject(project);
+        }
 
         // Create bug tracker
         BugTracker bugTracker = getBugTracker(assignee, bug);

--- a/src/main/java/com/checkmarx/flow/service/GitHubService.java
+++ b/src/main/java/com/checkmarx/flow/service/GitHubService.java
@@ -233,14 +233,10 @@ public class GitHubService extends RepoService {
     public void startBlockMerge(ScanRequest request, String url){
         if(properties.isBlockMerge()) {
             final String PULL_REQUEST_STATUS = "pending";
-            // When Shard Manager is enabled overide the PULL url.
+            // When Shard Manager is enabled overide the PULL url to link to the correct shard.
             if(cxProperties.getEnableShardManager()) {
                 ShardSession shard = sessionTracker.getShardSession();
-                try {
-                    //
-                    /// This code is very specific to CapOne, it required the introduction
-                    /// of new properties to the GitHubService like: ShardManager and CxService.
-                    //
+                try {                    
                     String teamId = cxService.getTeamId(request.getTeam());
                     List<CxProject> projects = cxService.getProjects(teamId);
                     String projectID = "0";

--- a/src/test/java/com/checkmarx/flow/cucumber/component/analytics/pullrequest/AnalyticsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/analytics/pullrequest/AnalyticsSteps.java
@@ -17,6 +17,7 @@ import com.checkmarx.flow.service.GitHubService;
 import com.checkmarx.flow.service.ThresholdValidator;
 import com.checkmarx.flow.service.ResultsService;
 import com.checkmarx.flow.utils.AesEncryptionUtils;
+import com.checkmarx.sdk.ShardManager.ShardSessionTracker;
 import com.checkmarx.sdk.config.Constants;
 import com.checkmarx.sdk.config.CxProperties;
 import com.checkmarx.sdk.dto.sast.Filter;
@@ -74,6 +75,8 @@ public class AnalyticsSteps {
     private final CxProperties cxProperties;
     private final RestTemplate restTemplateMock;
     private final GitHubAppAuthService gitHubAppAuthService;
+    private final ShardSessionTracker sessionTracker;
+    private final CxClient cxService;
 
     private static class State {
         ScanResults scanResultsToInject;
@@ -239,7 +242,10 @@ public class AnalyticsSteps {
                 flowProperties,
                 thresholdValidator,
                 scmConfigOverrider,
-                gitHubAppAuthService);
+                gitHubAppAuthService,
+                cxProperties,
+                sessionTracker,
+                cxService);
                 
         
         CxScannerService cxScannerService = new CxScannerService(cxProperties,null, null, cxClientMock, null );

--- a/src/test/java/com/checkmarx/flow/cucumber/component/commentscript/CommentScriptSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/commentscript/CommentScriptSteps.java
@@ -11,6 +11,7 @@ import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.sastscanning.ScanRequestConverter;
 import com.checkmarx.flow.service.*;
 import com.checkmarx.flow.utils.ScanUtils;
+import com.checkmarx.sdk.ShardManager.ShardSessionTracker;
 import com.checkmarx.sdk.config.CxProperties;
 
 import com.checkmarx.sdk.dto.ScanResults;
@@ -58,7 +59,7 @@ public class CommentScriptSteps {
                               JiraProperties jiraProperties, FilterFactory filterFactory, ConfigurationOverrider configOverrider,
                               ResultsService resultService, ProjectNameGenerator projectNameGenerator, BugTrackerEventTrigger btet){
 
-        
+
         cxClientMock = mock(CxService.class);
         
         scanRequestConverterMock = mock(ScanRequestConverter.class, Mockito.withSettings().useConstructor(
@@ -78,7 +79,7 @@ public class CommentScriptSteps {
         FlowService flowService = new FlowService(Collections.singletonList(sastScanner), projectNameGenerator, resultService);
 
         CxScannerService scannerService = new CxScannerService(cxProperties, null, flowProperties, cxClientMock, null);
-        this.flowController = new FlowController(flowProperties, scannerService, flowService, helperService, jiraProperties, filterFactory, configOverrider, sastScanner, null, null, null);
+        this.flowController = new FlowController(flowProperties, scannerService, flowService, helperService, jiraProperties, filterFactory, configOverrider, sastScanner, null, null, null,null, null);
     }
 
 

--- a/src/test/java/com/checkmarx/flow/cucumber/component/thresholds/sastPR/ThresholdsSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/thresholds/sastPR/ThresholdsSteps.java
@@ -9,6 +9,7 @@ import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.exception.ExitThrowable;
 import com.checkmarx.flow.exception.MachinaException;
 import com.checkmarx.flow.service.*;
+import com.checkmarx.sdk.ShardManager.ShardSessionTracker;
 import com.checkmarx.sdk.config.Constants;
 import com.checkmarx.sdk.config.CxProperties;
 import com.checkmarx.sdk.config.ScaProperties;
@@ -78,6 +79,8 @@ public class ThresholdsSteps {
     private final GitHubAppAuthService gitHubAppAuthService;
     private final ScmConfigOverrider scmConfigOverrider;
     private final ScaProperties scaProperties;
+    private final ShardSessionTracker sessionTracker;
+    private final CxClient cxService;
 
     private ScanResults scanResultsToInject;
     private ResultsService resultsService;
@@ -87,7 +90,7 @@ public class ThresholdsSteps {
 
     public ThresholdsSteps(IntegrationTestContext testContext, CxService cxClientMock, RestTemplate restTemplateMock, FlowProperties flowProperties, ADOProperties adoProperties,
                            CxProperties cxProperties, GitHubProperties gitHubProperties, ThresholdValidator thresholdValidator,
-                           EmailService emailService, GitHubAppAuthService gitHubAppAuthService, ScmConfigOverrider scmConfigOverrider, ScaProperties scaProperties) {
+                           EmailService emailService, GitHubAppAuthService gitHubAppAuthService, ScmConfigOverrider scmConfigOverrider, ScaProperties scaProperties, ShardSessionTracker sessionTracker, CxClient cxService) {
 
         this.cxClientMock = cxClientMock;
         this.restTemplateMock = restTemplateMock;
@@ -97,6 +100,8 @@ public class ThresholdsSteps {
         this.cxProperties = cxProperties;
         this.gitHubAppAuthService = gitHubAppAuthService;
         this.scaProperties = scaProperties;
+        this.sessionTracker = sessionTracker;
+        this.cxService = cxService;
         flowProperties.setThresholds(new HashMap<>());
         gitHubProperties.setCxSummary(false);
         this.gitHubProperties = gitHubProperties;
@@ -341,7 +346,10 @@ public class ThresholdsSteps {
                 flowProperties,
                 thresholdValidator,
                 scmConfigOverrider,
-                gitHubAppAuthService);
+                gitHubAppAuthService,
+                cxProperties,
+                sessionTracker,
+                cxService);
 
         CxScannerService cxScannerService = new CxScannerService(cxProperties,null, null, cxClientMock, null );
 

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/ConfigAsCodeBranchSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/ConfigAsCodeBranchSteps.java
@@ -7,7 +7,9 @@ import com.checkmarx.flow.config.ScmConfigOverrider;
 import com.checkmarx.flow.controller.GitHubController;
 import com.checkmarx.flow.dto.github.PullEvent;
 import com.checkmarx.flow.service.*;
+import com.checkmarx.sdk.ShardManager.ShardSessionTracker;
 import com.checkmarx.sdk.config.CxProperties;
+import com.checkmarx.sdk.service.scanner.CxClient;
 import io.cucumber.java.en.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,7 +39,8 @@ public class ConfigAsCodeBranchSteps {
     private final GitAuthUrlGenerator gitAuthUrlGenerator;
     private String defaultBranch;
     private String actualBranch;
-
+    private final ShardSessionTracker sessionTracker;
+    private final CxClient cxService;
 
     @Given("use-config-as-code-from-default-branch property in application.yml is set to {string}")
     public void useConfigAsCodeFromDefaultBranch(String useDefaultBranch) {
@@ -68,7 +71,7 @@ public class ConfigAsCodeBranchSteps {
         // Don't start automation.
         FlowService flowServiceMock = mock(FlowService.class);
 
-        GitHubService gitHubService = new GitHubService(restTemplateMock, gitHubProperties, flowProperties, null, scmConfigOverrider, gitHubAppAuthService);
+        GitHubService gitHubService = new GitHubService(restTemplateMock, gitHubProperties, flowProperties, null, scmConfigOverrider, gitHubAppAuthService,cxProperties,sessionTracker,cxService);
         GitHubAppAuthService gitHubAppAuthService = new GitHubAppAuthService(restTemplateMock, gitHubProperties);
 
         GitHubController gitHubControllerSpy = Mockito.spy(new GitHubController(gitHubProperties,

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cxconfig/CxConfigSteps.java
@@ -9,6 +9,7 @@ import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.dto.github.*;
 import com.checkmarx.flow.exception.MachinaException;
 import com.checkmarx.flow.service.*;
+import com.checkmarx.sdk.ShardManager.ShardSessionTracker;
 import com.checkmarx.sdk.config.Constants;
 import com.checkmarx.sdk.config.CxProperties;
 import com.checkmarx.sdk.dto.sast.Filter;
@@ -70,6 +71,8 @@ public class CxConfigSteps {
     private final ConfigurationOverrider configOverrider;
     private final ScmConfigOverrider scmConfigOverrider;
     private final GitAuthUrlGenerator gitAuthUrlGenerator;
+    private final ShardSessionTracker sessionTracker;
+    private final CxClient cxService;
 
     private ScanResults scanResultsToInject;
 
@@ -86,7 +89,7 @@ public class CxConfigSteps {
                          CxProperties cxProperties, GitHubProperties gitHubProperties, ConfigurationOverrider configOverrider, JiraProperties jiraProperties,
                          ThresholdValidator thresholdValidator, FilterFactory filterFactory, FlowService flowService, EmailService emailService,
                          ScmConfigOverrider scmConfigOverrider, GitHubAppAuthService gitHubAppAuthService,
-                         GitAuthUrlGenerator gitAuthUrlGenerator) {
+                         GitAuthUrlGenerator gitAuthUrlGenerator, ShardSessionTracker sessionTracker, CxClient cxService) {
 
         this.cxClientMock = mock(CxService.class);
 
@@ -106,6 +109,9 @@ public class CxConfigSteps {
         this.scmConfigOverrider = scmConfigOverrider;
         this.gitHubAppAuthService = gitHubAppAuthService;
         this.gitAuthUrlGenerator = gitAuthUrlGenerator;
+        this.sessionTracker = sessionTracker;
+        this.cxService = cxService;
+
         initGitHubProperties();
     }
 
@@ -561,7 +567,10 @@ public class CxConfigSteps {
                 flowProperties,
                 thresholdValidator,
                 scmConfigOverrider,
-                gitHubAppAuthService);
+                gitHubAppAuthService,
+                cxProperties,
+                sessionTracker,
+                cxService);
 
         CxScannerService cxScannerService = new CxScannerService(cxProperties,null, null, cxClientMock, null );
 

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/jira/analytics/JiraAnalyticsCommandLineCommonSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/jira/analytics/JiraAnalyticsCommandLineCommonSteps.java
@@ -24,7 +24,7 @@ import java.util.List;
 class JiraAnalyticsCommandLineCommonSteps {
 
     static final String PROJECT_KEY = "AT1";
-    static final String JIRA_URL = "https://cxflow2.atlassian.net/";
+    static final String JIRA_URL = "https://cxflowuser.atlassian.net/";
 
     @Autowired
     protected CxProperties cxProperties;


### PR DESCRIPTION
Added shard support to /scanresults endpoint.

Updated GitHubService.startBlockMerge() to correctly set link back to shard processing when shards are enabled.