### PR TITLE
Scan Queuing Change from PR #857 (added scanQueuing and scanQueuingTimeout  size/M)

### DIFF
--- a/src/main/java/com/checkmarx/flow/service/AbstractVulnerabilityScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/AbstractVulnerabilityScanner.java
@@ -73,22 +73,26 @@ public abstract class AbstractVulnerabilityScanner implements VulnerabilityScann
             String scanComment = getScanComment(scanRequest);
 
             if (existingScanId != UNKNOWN_INT) {
-                Boolean scanResubmit = false;
-                if (scanRequest.getScanResubmit() != null) {
-                    scanResubmit = Boolean.parseBoolean(scanRequest.getScanResubmit());
-                } else if (flowProperties.getScanResubmit()){
-                    scanResubmit = flowProperties.getScanResubmit();
-                }
-                if (scanResubmit) {
-                    log.info("Existing ongoing scan with id {} found for Project : {}", existingScanId, projectId);
-                    log.info("Aborting the ongoing scan with id {} for Project: {}", existingScanId, projectId);
-                    getScannerClient().cancelScan(existingScanId);
-                    log.info("Resubmitting the scan for Project: {}", projectId);
+                if(!getCxPropertiesBase().getScanQueuing()) {
+                    Boolean scanResubmit = false;
+                    if (scanRequest.getScanResubmit() != null) {
+                        scanResubmit = Boolean.parseBoolean(scanRequest.getScanResubmit());
+                    } else if (flowProperties.getScanResubmit()){
+                        scanResubmit = flowProperties.getScanResubmit();
+                    }
+                    if (scanResubmit) {
+                        log.info("Existing ongoing scan with id {} found for Project : {}", existingScanId, projectId);
+                        log.info("Aborting the ongoing scan with id {} for Project: {}", existingScanId, projectId);
+                        getScannerClient().cancelScan(existingScanId);
+                        log.info("Resubmitting the scan for Project: {}", projectId);
+                        scanId = getScannerClient().createScan(cxScanParams, scanComment);
+                    } else {
+                        log.warn("Property scan-resubmit set to {} : New scan not submitted, due to existing ongoing scan for the same Project id {}", flowProperties.getScanResubmit(), projectId);
+                        bugTrackers.getBugTrackerEventTrigger().triggerScanNotSubmittedBugTrackerEvent(scanRequest, getEmptyScanResults());
+                        throw new CheckmarxException(String.format("Active Scan with Id %d already exists for Project: %d", existingScanId, projectId));
+                    }
+                }else {
                     scanId = getScannerClient().createScan(cxScanParams, scanComment);
-                } else {
-                    log.warn("Property scan-resubmit set to {} : New scan not submitted, due to existing ongoing scan for the same Project id {}", flowProperties.getScanResubmit(), projectId);
-                    bugTrackers.getBugTrackerEventTrigger().triggerScanNotSubmittedBugTrackerEvent(scanRequest, getEmptyScanResults());
-                    throw new CheckmarxException(String.format("Active Scan with Id %d already exists for Project: %d", existingScanId, projectId));
                 }
             } else {
                 scanId = getScannerClient().createScan(cxScanParams, scanComment);


### PR DESCRIPTION
PR #857 (added scanQueuing and scanQueuingTimeout  size/M) overridden by

PR #884 (Add scanResubmit property to config-as-code)

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

If checkmarx.scan-queuing is true then Submit the new scan Request. If checkmarx.scan-queuing is false (Default Value) then check for scan resubmit and Process the request accordingly.

### References

> Include supporting link to GitHub Issue/PR number

### Testing
Set checkmarx.scan-queuing to true.
Run cx-flow in web hook mode.
Submit twice code change request at same time from the git repository.
Here, both the the scan request will get processed by creating new scan.

Set checkmarx.scan-queuing to false.
Run cx-flow in web hook mode.
Submit twice code change request at same time from the git repository.
Here, first scan request will get processed and other request will get rejected if scan resubmit is false.
If if scan resubmit is true, then first scan request will cancelled and other request will get processed.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used
