### PR TITLE
When cx-flow.mail.cc is not set, NullPointerException

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -89,6 +89,8 @@ cx-flow:
      username: xxx
      password: xxx
      enabled: true
+     notification: true # default is false
+     cc: myemail@mycompany.com # comma-separated list of e-mails
   zip-exclude: \.git/.*, .*\.png
 
 checkmarx:
@@ -314,6 +316,8 @@ cx-flow:
      username: xxx
      password: xxx
      enabled: true
+     notification: true # default is false
+     cc: myemail@mycompany.com # comma-separated list of e-mails
   zip-exclude: \.git/.*, .*\.png
 ```
 
@@ -347,6 +351,20 @@ cx-flow:
 | `preserve-project-name`   | false                 | No       | Yes     | Yes          | When **False**: The project name will be the repository name after normalization (i.e. Front-End-dev). Legal characters are: `a-z`, `A-Z`, `0-9`, `-`, `_`, `.`. All other characters will be replaced in the normalization process with "-". <br/> When **True**: The project name will be the exact project name inputted without normalization (i.e. Front End-dev). <br/> **For attention:** <br/> 1. Not all scanners allow project names with invalid characters.<br/> 2. The preserve-project-name parameter is also effective for project name coming from config-as-code. |
 
 No* = Default is applied
+
+#### <a name="filtering">E-Mail notifications</a>
+
+```yaml
+cx-flow:
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: xxx
+    password: xxx
+    enabled: true
+    notification: true # default is false
+    cc: myemail@mycompany.com # comma-separated list of e-mails
+```
 
 #### <a name="filtering">Filtering</a>
 Filtering, as specified above, is available on the following criteria:

--- a/src/main/java/com/checkmarx/flow/service/EmailService.java
+++ b/src/main/java/com/checkmarx/flow/service/EmailService.java
@@ -60,7 +60,18 @@ public class EmailService {
                 messageHelper.setFrom(contact);
             }
 
-            String[] ccList = (flowProperties.getMail().getCc()).toArray(new String[0]);
+            FlowProperties.Mail mailProperties = flowProperties.getMail();
+            String[] ccList = new String[0];
+            if (mailProperties != null) {
+                List<String> cc = mailProperties.getCc();
+
+                if (cc != null) {
+                    ccList = cc.toArray(new String[0]);
+                } else {
+                    log.warn("Property cx-flow.mail.cc is not defined.");
+                }
+            }
+
             if (CollectionUtils.isNotEmpty(recipients)) {
                 messageHelper.setTo(recipients.toArray(new String[0]));
                 messageHelper.setCc(ccList);


### PR DESCRIPTION
### Description

When `cx-flow.mail.notification` is `true` and `cx-flow.mail.cc` is not defined or empty, we have a NullPointerException. 

### References

https://github.com/checkmarx-ltd/cx-flow/issues/753

### Testing

Use this configuration:

```yaml
cx-flow:
  token: xxxx
  bug-tracker: Json
  bug-tracker-impl:
    - CxXml
    - Json
    - JIRA
    - GitLab
    - GitHub
    - Csv
    - Azure
    - Rally
    - ServiceNow
    - Sarif
  branches:
    - develop
    - master
    - security
  filter-severity:
    - High
  filter-category:
  filter-cwe:
  filter-status:
  mitre-url: https://cwe.mitre.org/data/definitions/%s.html
  jira-project-field: jira-project
  jira-issuetype-field: jira-issuetype
  jira-custom-field: jira-fields
  jira-assignee-field: jira-assignee
  mail:
    host: your-smtp.com
    port: 2525
    username: your-user
    password: your-password
    enabled: true
    notification: true
    # cc: your.email@checkmarx.com
```

### Checklist

- [X] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
