### PR TITLE
Nextdoor.com got to simulate a situation where request.getRepoName() …

### DIFF
--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -207,9 +207,22 @@ public class ConfigurationOverrider {
         override.map(CxConfig::getProject)
                 .filter(StringUtils::isNotBlank)
                 .ifPresent(p -> {
-                    /*Replace ${repo} and ${branch}  with the actual reponame and branch - then strip out non-alphanumeric (-_ are allowed)*/
-                    String project = p.replace("${repo}", request.getRepoName())
-                            .replace("${branch}", request.getBranch());
+                    /* Replace ${repo} and ${branch}  with the actual reponame and branch - then strip out non-alphanumeric (-_ are allowed) */
+                    String project = p;
+                    String repoName = request.getRepoName();
+                    if (repoName != null) {
+                        project = project.replace("${repo}", request.getRepoName());
+                    } else {
+                        log.warn("Overriding main properties: Repo name is not defined.");
+                    }
+
+                    String branch = request.getBranch();
+                    if (branch != null) {
+                        project = project.replace("${branch}", request.getBranch());
+                    } else {
+                        log.warn("Overriding main properties: Branch is not defined.");
+                    }
+
                     request.setProject(project);
                     overrideReport.put("project", project);
                 });


### PR DESCRIPTION
…and/or requires.getBranch() come as null as this point.

### Description

Running CxFlow in CircleCI using command line gets this error.

### References

N/A

### Testing

Run with the following configuration:

```bash
#!/bin/sh -eo pipefail
java -jar /app/cx-flow.jar \
--scan \
--cx-team="/CxServer/Nextdoor" \
--cx-project="nextdoor.com-django" \
--app="${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BRANCH}" \
--spring.profiles.active="sast" \
--f=. \
--cx-flow.bug-tracker="Json" \
--cx-flow.bug-tracker-impl="Json" \
--cx-flow.enabled-vulnerability-scanners="sast" \
--filter-severity=High \
--checkmarx.version=9.0 \
--checkmarx.scope="sast_rest_api" \
--checkmarx.url="${CX_SERVER}/cxrestapi" \
--checkmarx.portal-url="${CX_SERVER}/cxwebinterface/Portal/CxWebService.asmx" \
--checkmarx.incremental=true \
--checkmarx.scan-preset="Checkmarx Default" \
--checkmarx.configuration="Default Configuration" \
--checkmarx.scan-timeout=120 \
--sca.appUrl="" \
--sca.apiUrl="" \
--sca.accessControlUrl="" \
--ast.apiUrl="" \
--ast.preset="Checkmarx Default" \
--ast.incremental="false" \
--ast.webAppUrl="" \
--cxgo.team="/CxServer/Nextdoor" \
--cxgo.base-url="https://api.checkmarx.net" \
--cxgo.portal-url="https://cloud.checkmarx.net" \
--cxgo.multi-tenant="true" \
--cxgo.configuration="" \
--cxgo.scan-preset="" \
--json.file-name-format="checkmarx.json" \
--json.data-folder="./" \
--cx-flow.enabled-vulnerability-scanners="sast" --checkmarx.username=${CX_USER} --checkmarx.password=${CX_PASSWORD} --checkmarx.incremental-threshold=10 --cx-flow.break-build=true
```

### Checklist

- [X] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
