### PR TITLE
Pr bitbucket delete event support

### DIFF
--- a/docs/Delete-Branch.md
+++ b/docs/Delete-Branch.md
@@ -32,7 +32,7 @@ This will make CxFlow to always read configuration-as-code from repository defau
 * [GitHub](#github)
 * [Azure Devops](#ado)
 * [GitLab](#gitlab)
-* [BitBucket] (#bitbucket)
+* [BitBucket](#bitbucket)
 
 #### <a name="github">GitHub</a>
 
@@ -71,7 +71,14 @@ GitLab does not support webhook delete events therefore CxFlow does not support 
 
 #### <a name="bitbucket">Bitbucket Server</a>
 
-Bitbucket Server will delete a SAST project **only when using the Post Webhooks plugin**.  The current implementation is limited in that:
+* Uses the webhook PUSH event
+* When an unprotected branch is deleted BitBucket server sends a PUSH event of type DELETE.
+
+Bitbucket Server will delete a SAST project either using the PUSH webhook event or using the Post Webhooks plugin.  The current implementation is limited in that:
 
 * Project delete not work if using Config-As-Code given the settings for team and/or project name have been deleted from the branch.
 * Project delete will work if the project name is calculated or scripted and the team assigned to the project matches the default team in the CxFlow YAML configuration.
+
+**Bitbucket Cloud**
+
+Bitbucket cloud currently does not support deleting project in CxSAST when unprotected branch is deleted.


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> This PR adds feature to delete project in CxSAST when an unprotected branch is deleted in BitBucket server

### Testing

> Configured CxFlow with Bitbucket server(on-prem) and created a PR which created project with name JavaVulnerabilityLabE-branch-name.
> In CxSAST the count of total used projects incremented by 1.
> When branch was deleted from Bitbucket server PUSH event with type DELETE was fired and DELETE event was handled.
> After processing the DELETE event project was deleted from CxSAST server and the total used projects count decremented by 1.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
