### PR TITLE
Fix postback Scan Reports

### DIFF
--- a/src/main/java/com/checkmarx/flow/controller/FlowController.java
+++ b/src/main/java/com/checkmarx/flow/controller/FlowController.java
@@ -233,18 +233,23 @@ public class FlowController {
                     prd.branch = scanDetailToken;
                     break;
                 case 4:
+                    prd.project = scanDetailToken;
+                case 5:
+                    prd.team = scanDetailToken;
+                case 6:
                     prd.mergeNoteUri = scanDetailToken;
                     break;
-                case 5:
+                case 7:
                     prd.pullRequestURL = scanDetailToken;
                     break;
-                case 6:
+                case 8:
                     if(scanDetailToken.equals("PULL")) {
                         prd.bugType = BugTracker.Type.GITHUBPULL;
                     } else {
                         prd.bugType = BugTracker.Type.CUSTOM;
                     }
                     break;
+
                 default:
                     // Nothing to do.
                     break;

--- a/src/main/java/com/checkmarx/flow/controller/FlowController.java
+++ b/src/main/java/com/checkmarx/flow/controller/FlowController.java
@@ -192,7 +192,6 @@ public class FlowController {
                     .repoType(ScanRequest.Repository.GITHUB)
                     .product(p)
                     .branch(prd.branch)
-                    .additionalMetadata(prd.additionalMetadata)
                     .build();
             // There won't be a scan ID on the post-back, so we need to fake it in the
             // event shard support is turned on (very likely if using post-back support).
@@ -203,6 +202,7 @@ public class FlowController {
             // Now go ahead and process the scan as normal.
             ScanResults scanResults = cxService.getReportContentByScanId(Integer.parseInt(scanID), scanRequest.getFilter());
             scanRequest.putAdditionalMetadata("statuses_url", prd.pullRequestURL);
+            scanRequest.putAdditionalMetadata("github-installation-id", prd.installationId);
             scanRequest.setMergeNoteUri(prd.mergeNoteUri);
             BugTracker bt = ScanUtils.getBugTracker(null, prd.bugType, jiraProperties, bugTracker);
             scanRequest.setBugTracker(bt);
@@ -235,8 +235,10 @@ public class FlowController {
                     break;
                 case 4:
                     prd.project = scanDetailToken;
+                    break;
                 case 5:
                     prd.team = scanDetailToken;
+                    break;
                 case 6:
                     prd.mergeNoteUri = scanDetailToken;
                     break;
@@ -244,7 +246,8 @@ public class FlowController {
                     prd.pullRequestURL = scanDetailToken;
                     break;
                 case 8:
-                    prd.additionalMetadata.put("github-installation-id", scanDetailToken);
+                    prd.installationId = scanDetailToken;
+                    break;
                 case 9:
                     if(scanDetailToken.equals("PULL")) {
                         prd.bugType = BugTracker.Type.GITHUBPULL;
@@ -657,6 +660,6 @@ class PostRequestData {
     String namespace = "";
     String team = "";
     String project = "";
-    Map<String, String> additionalMetadata;
+    String installationId = "";
     BugTracker.Type bugType;
 }

--- a/src/main/java/com/checkmarx/flow/controller/FlowController.java
+++ b/src/main/java/com/checkmarx/flow/controller/FlowController.java
@@ -154,7 +154,7 @@ public class FlowController {
             @RequestBody String postBackData,
             @PathVariable(value = "scanID") String scanID
     ) {
-        log.debug("Handling post-back from SAST");
+        log.info("Handling post-back from SAST");
         int maxNumberOfTokens = 100;
         PostRequestData prd = new PostRequestData();
         String token = " ";

--- a/src/main/java/com/checkmarx/flow/controller/FlowController.java
+++ b/src/main/java/com/checkmarx/flow/controller/FlowController.java
@@ -192,6 +192,7 @@ public class FlowController {
                     .repoType(ScanRequest.Repository.GITHUB)
                     .product(p)
                     .branch(prd.branch)
+                    .additionalMetadata(prd.additionalMetadata)
                     .build();
             // There won't be a scan ID on the post-back, so we need to fake it in the
             // event shard support is turned on (very likely if using post-back support).
@@ -243,6 +244,8 @@ public class FlowController {
                     prd.pullRequestURL = scanDetailToken;
                     break;
                 case 8:
+                    prd.additionalMetadata.put("github-installation-id", scanDetailToken);
+                case 9:
                     if(scanDetailToken.equals("PULL")) {
                         prd.bugType = BugTracker.Type.GITHUBPULL;
                     } else {
@@ -654,5 +657,6 @@ class PostRequestData {
     String namespace = "";
     String team = "";
     String project = "";
+    Map<String, String> additionalMetadata;
     BugTracker.Type bugType;
 }

--- a/src/main/java/com/checkmarx/flow/service/AbstractVulnerabilityScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/AbstractVulnerabilityScanner.java
@@ -128,6 +128,7 @@ public abstract class AbstractVulnerabilityScanner implements VulnerabilityScann
             scanComment += (scanRequest.getTeam() + ";");
             scanComment += (scanRequest.getMergeNoteUri() + ";");
             scanComment += (scanRequest.getAdditionalMetadata("statuses_url") + ";");
+            scanComment += (scanRequest.getAdditionalMetadata("github-installation-id") + ";");
             BugTracker bt = scanRequest.getBugTracker();
             if(bt.getType().getType().equals("GITHUBPULL")) {
                 scanComment += "PULL";


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Extra fields existed in the Scan Comments for a "PostBack" scan.  Those fields were not recognized by the Postback Parser on the `/postbackAction` endpoint.  The missing fields were added and tested.

Also, the Postback mode report generation does not use the GitHub App.  Fields were added to the scan comments to pass the installation id so that CxFlow can post as the GitHub app.

### References

Fix postback - Re: Issue #939 

### Testing

Testing was completed by deploying into our development environment with multiple shards.

Manual Testing:
Enable Sharding and PostBack mode in Cxflow.
Trigger scan from GitHub
Results should post back to the Comment once complete.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
