### PR TITLE
Issues in Jira should not be closed on re-run of other/alternate scan for same project.

### DIFF
--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -415,11 +415,11 @@ public class CxFlowRunner implements ApplicationRunner {
                     log.error("cx-project must be provided when --project option is used");
                     exit(ExitCode.ARGUMENT_NOT_PROVIDED);
                 }
-                request.setCliMode("project");
+                request.setCliMode(CliMode.PROJECT);
                 publishLatestScanResults(request);
             } else if (args.containsOption("scan") || args.containsOption(IAST_OPTION)) {
                 log.info("Executing scan process");
-                request.setCliMode("scan");
+                request.setCliMode(CliMode.SCAN);
                 //GitHub Scan with Git Clone
                 if (args.containsOption("github")) {
                     repoUrl = getNonEmptyRepoUrl(namespace, repoName, repoUrl, gitHubProperties.getGitUri(namespace, repoName));

--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -415,9 +415,11 @@ public class CxFlowRunner implements ApplicationRunner {
                     log.error("cx-project must be provided when --project option is used");
                     exit(ExitCode.ARGUMENT_NOT_PROVIDED);
                 }
+                request.setCliMode("project");
                 publishLatestScanResults(request);
             } else if (args.containsOption("scan") || args.containsOption(IAST_OPTION)) {
                 log.info("Executing scan process");
+                request.setCliMode("scan");
                 //GitHub Scan with Git Clone
                 if (args.containsOption("github")) {
                     repoUrl = getNonEmptyRepoUrl(namespace, repoName, repoUrl, gitHubProperties.getGitUri(namespace, repoName));

--- a/src/main/java/com/checkmarx/flow/config/CliMode.java
+++ b/src/main/java/com/checkmarx/flow/config/CliMode.java
@@ -1,0 +1,6 @@
+package com.checkmarx.flow.config;
+
+public enum CliMode{
+        SCAN,
+        PROJECT
+}

--- a/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
@@ -112,6 +112,10 @@ public class ScanRequest {
     @Getter @Setter
     private String sshKeyIdentifier;
 
+    //SSH Key per repo
+    @Getter @Setter
+    private String cliMode;
+
     public ScanRequest(ScanRequest other) {
         this.namespace = other.namespace;
         this.application = other.application;
@@ -155,6 +159,7 @@ public class ScanRequest {
         this.gitUrl = other.gitUrl;
         this.disableCertificateValidation = other.disableCertificateValidation;
         this.sshKeyIdentifier = other.sshKeyIdentifier;
+        this.cliMode = other.cliMode;
     }
 
     public Map<String,String> getAltFields() {

--- a/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
@@ -1,5 +1,6 @@
 package com.checkmarx.flow.dto;
 
+import com.checkmarx.flow.config.CliMode;
 import com.checkmarx.flow.config.FindingSeverity;
 import com.checkmarx.flow.config.external.ASTConfig;
 import com.checkmarx.flow.service.VulnerabilityScanner;
@@ -112,9 +113,9 @@ public class ScanRequest {
     @Getter @Setter
     private String sshKeyIdentifier;
 
-    //SSH Key per repo
+    //command line mode
     @Getter @Setter
-    private String cliMode;
+    private CliMode cliMode;
 
     public ScanRequest(ScanRequest other) {
         this.namespace = other.namespace;

--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -7,6 +7,7 @@ import com.atlassian.jira.rest.client.api.domain.input.FieldInput;
 import com.atlassian.jira.rest.client.api.domain.input.IssueInputBuilder;
 import com.atlassian.jira.rest.client.api.domain.input.TransitionInput;
 import com.atlassian.jira.rest.client.internal.async.CustomAsynchronousJiraRestClientFactory;
+import com.checkmarx.flow.config.CliMode;
 import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.config.JiraProperties;
 import com.checkmarx.flow.constants.FlowConstants;
@@ -223,7 +224,7 @@ public class JiraService {
             log.error("Namespace/Repo/Branch or App must be provided in order to properly track ");
             throw new MachinaRuntimeException();
         }
-        if(!scannerFilter.isEmpty()){
+        if(!StringUtils.isEmpty(scannerFilter)){
             jql = jql.concat(String.format(" and \"%s\" in (%s)",
                                     jiraProperties.getLabelTracker(),
                                     scannerFilter
@@ -1235,7 +1236,7 @@ public class JiraService {
         List<String> closedIssues = new ArrayList<>();
         String filterScanner = "";
 
-        if("scan".equals(request.getCliMode())){
+        if(CliMode.SCAN.equals(request.getCliMode())){
             if (null != results.getScaResults()) {
                 filterScanner=JIRA_ISSUE_LABEL_SCA;
             }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

- For bug tracker as Jira, Create the issue in Jira with Label as SAST scanner and SCA scanner after the scan.

- Filter the issue on bases of type of scan (SCA or SAST) and Update/Open/Close the issue for which scan is initiated for the project.

- If scan is initiated for both SCA and SAST then issues for both type of scan will be update for that project.

### References

> [Include supporting link to GitHub Issue/PR number](https://github.com/checkmarx-ltd/cx-flow/issues/906)

### Testing

1. Run the SAST and SCA scan the CLI mode.
```
 $ java -jar .\cx-flow-1.6.29.jar --spring.config.location="application.yml" --scan --f=.\TestProj  --cx-flow.enabled-vulnerability-scanners="sca,sast" --cx-team=CxServer --cx-project=TestProj--app=TestProj --cx-flow.bug-tracker=JIRA --logging.level.com.checkmarx.flow.custom=debug --logging.level.com.checkmarx.flow.service=debug --logging.level.com.checkmarx.flow.utils=debug --logging.level.com.checkmarx.sdk.service=debug
``` 
2. Run the SCA or SAST scan from CLI mode.
```
 $ java -jar .\cx-flow-1.6.29.jar --spring.config.location="application.yml" --scan --f=.\TestProj  --cx-flow.enabled-vulnerability-scanners="sca" --cx-team=CxServer --cx-project=TestProj--app=TestProj --cx-flow.bug-tracker=JIRA --logging.level.com.checkmarx.flow.custom=debug --logging.level.com.checkmarx.flow.service=debug --logging.level.com.checkmarx.flow.utils=debug --logging.level.com.checkmarx.sdk.service=debug
``` 
```
 $ java -jar .\cx-flow-1.6.29.jar --spring.config.location="application.yml" --scan --f=.\TestProj  --cx-flow.enabled-vulnerability-scanners="sast" --cx-team=CxServer --cx-project=TestProj--app=TestProj --cx-flow.bug-tracker=JIRA --logging.level.com.checkmarx.flow.custom=debug --logging.level.com.checkmarx.flow.service=debug --logging.level.com.checkmarx.flow.utils=debug --logging.level.com.checkmarx.sdk.service=debug
``` 

Before this fix, Issue created in Step 1,  for other/alternate scanner, was closed on Sept 2.
After this fix, Issue created in Step 1 will not be closed in Sept 2, because issue identified in scan will be compared with issue already in Jira for that Project based on type of Scan (SAST, SCA or both). 


### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used
