### PR TITLE
Feature for CxXML as bug-tracker for CxSCA

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.5.11"
+        CxSBSDK = "0.5.12"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.6.1'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.5.11"
+        CxSBSDK = "0.5.12"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.6.1'

--- a/docs/Bug-Trackers-and-Feedback-Channels.md
+++ b/docs/Bug-Trackers-and-Feedback-Channels.md
@@ -361,14 +361,23 @@ cx-flow:
 ```
 
 ## <a name="cxxml">CxXML</a>
-The XML bug-tracker (defined as CxXml) is useful, if you want to retrieve the latest scan results per project (batch mode) from Checkmarx per project, Team, or the entire instance.  This is the original XML report provided by Checkmarx.  
+The XML bug-tracker (defined as CxXml) is useful, if you want to retrieve the latest scan results per project (batch mode) from Checkmarx per project, Team, or the entire instance. This is the original XML report provided by Checkmarx. When using CxXML with both CxSAST and CxSCA scanners enabled, two seprate reports will be generated, one for CxSAST report and one for CxSCA report.
 
-**Note**: The Checkmarx config block must specify `preserve-xml` as `true` for this feedback type.  *Only available for SAST 8.x|9.x*
+CxSCA currently does not support `--batch` mode, but retrieving latest scan for a particular project (project mode) is still possible.
+
+When both the scanners are enabled it is a known issue that duplicate CxSAST reports are generated.
+
+**Note**: The Checkmarx,Sca config blocks must specify `preserve-xml` as `true` for this feedback type.  
 ```
 checkmarx:
    ...
    ...
      preserve-xml: true
+     
+sca:
+  ....
+  ....
+  preserve-xml:true     
 cx-xml:
    file-name-format: "[NAMESPACE]-[REPO]-[BRANCH]-[TIME].xml"
    data-folder: "C:\\tmp"

--- a/docs/CxSCA-Integration.md
+++ b/docs/CxSCA-Integration.md
@@ -36,6 +36,7 @@ sca:
   exclude-files: "**/*.xml"
   manifests-include-pattern: "!**/*.xml, **/*.yml"
   fingerprints-include-pattern: "**/*.yml"
+  preserve-xml: true
 ```
 
 To use an European tenant:
@@ -55,6 +56,7 @@ sca:
   exclude-files: "**/*.xml"
   manifests-include-pattern: "!**/*.xml, **/*.yml"
   fingerprints-include-pattern: "**/*.yml"
+  preserve-xml: true
 ```
 
 ## <a name="bug">Bug-Trackers</a>
@@ -63,6 +65,7 @@ SCA integration supports tickets management with the following bug trackers:
 * GitLab
 * Azure
 * GitHub
+* CxXML
 
 <br/>The tickets format is the same for each of the bug trackers.
 

--- a/src/main/java/com/checkmarx/flow/service/AbstractASTScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/AbstractASTScanner.java
@@ -83,6 +83,7 @@ public abstract class AbstractASTScanner implements VulnerabilityScanner {
                 .scaConfig(request.getScaConfig())
                 .filterConfiguration(request.getFilter())
                 .build();
+        setScannerSpecificProperties(request,sdkScanParams);
         AstScaResults internalResults = client.getLatestScanResults(sdkScanParams);
         return toScanResults(internalResults);
     }

--- a/src/main/java/com/checkmarx/flow/service/SCAScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/SCAScanner.java
@@ -4,6 +4,7 @@ import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.exception.MachinaRuntimeException;
 
+import com.checkmarx.flow.utils.ScanUtils;
 import com.checkmarx.sdk.config.ScaProperties;
 import com.checkmarx.sdk.dto.ScanResults;
 import com.checkmarx.sdk.dto.AstScaResults;
@@ -51,6 +52,9 @@ public class SCAScanner extends AbstractASTScanner {
     @Override
     protected void setScannerSpecificProperties(ScanRequest scanRequest, ScanParams scanParams) {
         try {
+            if(!ScanUtils.empty(scanRequest.getBugTracker().getCustomBean()) && scanRequest.getBugTracker().getCustomBean().equalsIgnoreCase("CxXml")){
+                scaProperties.setPreserveXml(true);
+            }
             if (scaProperties.isEnabledZipScan()) {
                 log.info("CxAST-SCA zip scan is enabled");
                 String scaClonedFolderPath = cxRepoFileHelper.getScaClonedRepoFolderPath(scanRequest.getRepoUrlWithAuth(), scanRequest.getExcludeFiles(), scanRequest.getBranch());

--- a/src/main/java/com/checkmarx/flow/service/SCAScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/SCAScanner.java
@@ -52,6 +52,9 @@ public class SCAScanner extends AbstractASTScanner {
     @Override
     protected void setScannerSpecificProperties(ScanRequest scanRequest, ScanParams scanParams) {
         try {
+//            If bugtracker is not empty and type is CxXML then set
+//            preserveXml to true, as it is needed to retrieve sca
+//            report in xml format
             if(!ScanUtils.empty(scanRequest.getBugTracker().getCustomBean()) && scanRequest.getBugTracker().getCustomBean().equalsIgnoreCase("CxXml")){
                 scaProperties.setPreserveXml(true);
             }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> This PR adds support for retrieving CxSCA risk report in XML format when bug tracker is set as CxXML. 

### Testing

- SCA --project mode (should create 1 file with sca risk report)
- SAST --project mode (should create 1 file with sast report)
- SCA --scan mode (should create 1 file with sca risk report)
- SAST --scan mode (should create 1 file with sast report)
- SCA --web mode (should create 1 file with sca risk report)
- SAST --web mode (should create 1 file with sast report)
- SCA,SAST --project mode (should create 3 files  with sca and sast reports)
- SCA,SAST --scan mode (should create 2 files  with sca and sast reports)
- SCA,SAST --web mode (should create 2 files  with sca and sast reports)
- When preserveXml is set to false and bug tracker is CxXML then it should download XML report
- When preserveXml is set to false should not download XML report
- When preserveXml is set to true should download XML report
- sast -- batch mode

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
- [x] Verified that SCA and SAST scan results are as expected
