### PR TITLE
Pr parse mode implementation for sca

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.5.12"
+        CxSBSDK = "0.5.13"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.6.1'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.5.12"
+        CxSBSDK = "0.5.13"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.6.1'

--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -400,11 +400,23 @@ public class CxFlowRunner implements ApplicationRunner {
                     }
                     cxOsaParse(request, f, libs);
                 } else { //SAST
+                    List<String> enabledScanners = flowProperties.getEnabledVulnerabilityScanners();
                     if (args.containsOption("offline")) {
                         cxProperties.setOffline(true);
                     }
                     log.info("Processing Checkmarx result file {}", file);
 
+                    if((bugType.equals(BugTracker.Type.CUSTOM))){
+                        if(request.getBugTracker().getCustomBean().equalsIgnoreCase("CxXml")){
+                            log.error("The CxXml bugtracker is not support for parse mode{}");
+                            exit(ExitCode.BUILD_INTERRUPTED);
+                        }
+                    }
+
+                    if(enabledScanners.contains("sast")&&enabledScanners.contains("sca")){
+                        log.error("At a time only single scanner type is supported for parse mode implementation{}");
+                        exit(ExitCode.BUILD_INTERRUPTED);
+                    }
                     cxParse(request, f);
                 }
             } else if (args.containsOption(BATCH_OPTION)) {

--- a/src/main/java/com/checkmarx/flow/service/ASTScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/ASTScanner.java
@@ -2,6 +2,7 @@ package com.checkmarx.flow.service;
 
 import com.checkmarx.flow.config.FlowProperties;
 import com.checkmarx.flow.dto.ScanRequest;
+import com.checkmarx.flow.exception.ExitThrowable;
 import com.checkmarx.sdk.config.AstProperties;
 import com.checkmarx.sdk.dto.AstScaResults;
 import com.checkmarx.sdk.dto.ScanResults;
@@ -10,6 +11,8 @@ import com.checkmarx.sdk.dto.ast.ScanParams;
 import com.checkmarx.sdk.service.scanner.AstScanner;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.io.File;
 import java.util.Optional;
 
 
@@ -18,8 +21,8 @@ import java.util.Optional;
 @Slf4j
 public class ASTScanner extends AbstractASTScanner {
 
-    public ASTScanner(AstScanner astClient, FlowProperties flowProperties, BugTrackerEventTrigger bugTrackerEventTrigger) {
-        super(astClient, flowProperties, AstProperties.CONFIG_PREFIX, bugTrackerEventTrigger);
+    public ASTScanner(AstScanner astClient, FlowProperties flowProperties, BugTrackerEventTrigger bugTrackerEventTrigger,ResultsService resultsService) {
+        super(astClient, flowProperties, AstProperties.CONFIG_PREFIX, bugTrackerEventTrigger,resultsService);
     }
 
     @Override
@@ -27,6 +30,11 @@ public class ASTScanner extends AbstractASTScanner {
         return ScanResults.builder()
                 .astResults(internalResults.getAstResults())
                 .build();
+    }
+
+    @Override
+    protected void cxParseResults(ScanRequest request, File file) throws ExitThrowable {
+
     }
 
     @Override

--- a/src/main/java/com/checkmarx/flow/service/AbstractASTScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/AbstractASTScanner.java
@@ -1,10 +1,7 @@
 package com.checkmarx.flow.service;
 
 import com.checkmarx.flow.config.FlowProperties;
-import com.checkmarx.flow.dto.BugTracker;
-import com.checkmarx.flow.dto.OperationResult;
-import com.checkmarx.flow.dto.OperationStatus;
-import com.checkmarx.flow.dto.ScanRequest;
+import com.checkmarx.flow.dto.*;
 import com.checkmarx.flow.dto.report.AnalyticsReport;
 import com.checkmarx.flow.dto.report.ScanReport;
 import com.checkmarx.flow.exception.ExitThrowable;
@@ -27,9 +24,14 @@ import java.util.List;
 @RequiredArgsConstructor
 public abstract class AbstractASTScanner implements VulnerabilityScanner {
     private final AbstractScanner client;
-    private final FlowProperties flowProperties;
+    protected final FlowProperties flowProperties;
     private final String scanType;
     private final BugTrackerEventTrigger bugTrackerEventTrigger;
+
+    protected final ResultsService resultsService;
+    protected ScanDetails scanDetails = null;
+    protected static final String ERROR_BREAK_MSG = "Exiting with Error code 10 due to issues present";
+
 
     @Override
     public ScanResults scan(ScanRequest scanRequest) {
@@ -48,7 +50,7 @@ public abstract class AbstractASTScanner implements VulnerabilityScanner {
         
         return result;
     }
-
+    protected abstract void cxParseResults(ScanRequest request, File file) throws ExitThrowable;
     @Override
     public ScanResults scanCli(ScanRequest request, String scanType, File... files) {
         ScanResults scanResults = null;
@@ -61,6 +63,8 @@ public abstract class AbstractASTScanner implements VulnerabilityScanner {
                     scanResults = scan(request, files[0].getPath());
                     break;
                 case "cxParse":
+                    cxParseResults(request, files[0]);
+                    break;
                 case "cxBatch":
                 default:
                     log.warn("ScaScanner does not support scanType of {}, ignoring.", scanType);

--- a/src/main/java/com/checkmarx/flow/service/SCAScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/SCAScanner.java
@@ -1,10 +1,14 @@
 package com.checkmarx.flow.service;
 
 import com.checkmarx.flow.config.FlowProperties;
+import com.checkmarx.flow.dto.ExitCode;
 import com.checkmarx.flow.dto.ScanRequest;
+import com.checkmarx.flow.exception.ExitThrowable;
+import com.checkmarx.flow.exception.MachinaException;
 import com.checkmarx.flow.exception.MachinaRuntimeException;
 
 import com.checkmarx.flow.utils.ScanUtils;
+import com.checkmarx.sdk.config.RestClientConfig;
 import com.checkmarx.sdk.config.ScaProperties;
 import com.checkmarx.sdk.dto.ScanResults;
 import com.checkmarx.sdk.dto.AstScaResults;
@@ -14,13 +18,19 @@ import com.checkmarx.sdk.exception.CheckmarxException;
 
 import com.checkmarx.sdk.service.scanner.ScaScanner;
 import com.checkmarx.sdk.utils.CxRepoFileHelper;
+import com.checkmarx.sdk.utils.scanner.client.IScanClientHelper;
+import com.checkmarx.sdk.utils.scanner.client.ScaClientHelper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+
+import static com.checkmarx.flow.exception.ExitThrowable.exit;
 
 
 @Service
@@ -29,10 +39,12 @@ public class SCAScanner extends AbstractASTScanner {
 
     private final ScaProperties scaProperties;
     private final CxRepoFileHelper cxRepoFileHelper;
+    @Autowired
+    ScaScanner scaScannerClient;
 
     public SCAScanner(ScaScanner scaClient, FlowProperties flowProperties, BugTrackerEventTrigger bugTrackerEventTrigger,
-                      ScaProperties scaProperties) {
-        super(scaClient, flowProperties, ScaProperties.CONFIG_PREFIX, bugTrackerEventTrigger);
+                      ScaProperties scaProperties,ResultsService resultsService) {
+        super(scaClient, flowProperties, ScaProperties.CONFIG_PREFIX, bugTrackerEventTrigger,resultsService);
         this.scaProperties = scaProperties;
         this.cxRepoFileHelper = new CxRepoFileHelper();
     }
@@ -47,6 +59,33 @@ public class SCAScanner extends AbstractASTScanner {
     @Override
     protected String getScanId(AstScaResults internalResults) {
         return Optional.ofNullable(internalResults.getScaResults().getScanId()).orElse("");
+    }
+
+    @Override
+    protected void cxParseResults(ScanRequest scanRequest, File file) throws ExitThrowable {
+        RestClientConfig restClientConfig;
+        IScanClientHelper iScanClientHelper;
+
+        try {
+            ScanParams sdkScanParams = ScanParams.builder()
+                    .projectName(scanRequest.getProject())
+                    .scaConfig(scanRequest.getScaConfig())
+                    .filterConfiguration(scanRequest.getFilter())
+                    .build();
+
+            restClientConfig=scaScannerClient.getScanConfig(sdkScanParams);
+
+            iScanClientHelper=new ScaClientHelper(restClientConfig,log,scaProperties);
+            ScanResults results =iScanClientHelper.getReportContent(file, scanRequest.getFilter());
+            resultsService.processResults(scanRequest, results, scanDetails);
+            if (flowProperties.isBreakBuild() && results != null && results.getXIssues() != null && !results.getXIssues().isEmpty()) {
+                log.error(ERROR_BREAK_MSG);
+                exit(ExitCode.BUILD_INTERRUPTED);
+            }
+        } catch (MachinaException | CheckmarxException e) {
+            log.error("Error occurred while processing results file", e);
+            exit(3);
+        }
     }
 
     @Override


### PR DESCRIPTION
Description:
Parse mode suport for SCA product in CX-Flow.Now we can use --parse mode in cx-flow and create the issue on different bug tracker(like Jira,Json,Sarif etc).

References:
https://github.com/checkmarx-ltd/checkmarx-spring-boot-java-sdk/pull/205

Testing:

Below are the test case:

A]
  Generate report from ScaResolver tool and use this report in parse mode command execution.
  
B]
Step 1: run scan mode

 run the scan command  through CLI(i.e from cmd) and generate scan report on sca portal.

Use below  scan command:-

java -jar cx-flow-1.6.31.jar --spring.config.location="<location of your application.yml>" --scan --f="<location of your  cx-flow>" --cx-team= "CxServer" --cx-project="<project name>" --app="<app name>"

 Step2:

 From sca portal export the scan report in xml format. 

 Step 3:parse mode

 Use above exported xml file and run parse mode command through CLI(i.e from cmd).And parse report is generated on configured bug tracker in application.yml file.

Use below parse command for sca parse:-

java -jar cx-flow-1.6.31.jar --spring.config.location="<location of application.yml>l" --parse --f="<location of exported xml file report from sca portal>" --cx-team= "CxServer" --cx-project="<project name>" --app="<app name>"

Step 3:After succesfully executing above parse command then exporeted xml file report will create on configured bugtracker(like Jira,Json,Sarif etc.)
