### PR TITLE
Scan failing due to value of size variable of Azure Repository is large

### DIFF
--- a/src/main/java/com/checkmarx/flow/dto/azure/Repository.java
+++ b/src/main/java/com/checkmarx/flow/dto/azure/Repository.java
@@ -28,7 +28,7 @@ public class Repository {
     @JsonProperty("project")
     private Project project;
     @JsonProperty("size")
-    private Integer size;
+    private Long size;
     @JsonProperty("defaultBranch")
     private String defaultBranch;
     @JsonProperty("remoteUrl")
@@ -88,12 +88,12 @@ public class Repository {
     }
     
     @JsonProperty("size")
-    public Integer getSize() {
+    public Long getSize() {
         return size;
     }
 
     @JsonProperty("size")
-    public void setSize(Integer size) {
+    public void setSize(Long size) {
         this.size = size;
     }
 


### PR DESCRIPTION
Scan failing due to value of size variable of Azure Repository is large

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

If Repository is very large then request webhook size variable value does not fit in Integer data type.
Changing the data type to Long in "com.checkmarx.flow.dto.azure.Repository" to accommodate larger value. 

### References

> Include supporting link to GitHub Issue/PR number

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used
- [ ] Verified that SCA and SAST scan results are as expected
