### PR TITLE
Support suppression of code snippets for Jira tickets

### DIFF
--- a/docs/Bug-Trackers-and-Feedback-Channels.md
+++ b/docs/Bug-Trackers-and-Feedback-Channels.md
@@ -83,6 +83,10 @@ jira:
       - Done
    sast-issue-summary-format: "[VULNERABILITY] in [PROJECT] with severity [SEVERITY] @ [FILENAME]"
    sast-issue-summary-branch-format: "[VULNERABILITY] in [PROJECT] with severity [SEVERITY] @ [FILENAME][[BRANCH]]"
+   suppress-code-snippets:
+      - Hardcoded_Password_in_Connection_String
+      - Password_In_Comment
+      - Use_Of_Hardcoded_Password
    fields:
 #    - type: cx #[ cx | static | result ]
 #      name: Platform # cx custom field name | cwe, category, severity, application, *project*, repo-name, branch, repo-url, namespace, recommendations, loc, site, issueLink, filename, language
@@ -248,6 +252,17 @@ The sast-issue-summary-format and sast-issue-summary-branch-format properties ca
 **[VULNERABILTY]** → The vulnerability
 
 The default Jira issue summary format (for CxSAST issues) is `[PREFIX][VULNERABILITY] @ [FILENAME][POSTFIX]` (`[PREFIX][VULNERABILITY] @ [FILENAME] [[BRANCH]][POSTFIX]` if the `--branch` command line option has been used).
+
+### <a name="suppressCodeSnippets">Suppressing Code Snippets</a>
+
+When creating a Jira ticket, CxFlow will add a code snippet to the ticket. Sometimes, it is preferable to suppress the creation of code snippets as they may contain sensitive information (e.g., hard-coded passwords). The suppress-code-snippets property can be used to specify a list of vulnerabilities for which code snippets will not be created. For example:
+
+```
+   suppress-code-snippets:
+      - Hardcoded_Password_in_Connection_String
+      - Password_In_Comment
+      - Use_Of_Hardcoded_Password
+```
 
 ### <a name="issueSummaryFormat">Jira Issue Handling for Scan Mode</a>
 * Jira Issue will be created with Label as SAST scanner and SCA scanner after the scan.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -191,6 +191,10 @@ jira:
      - In Review
   closed-status:
      - Done
+  suppress-code-snippets:
+      - Hardcoded_Password_in_Connection_String
+      - Password_In_Comment
+      - Use_Of_Hardcoded_Password
   fields:
      - type: result
        name: application

--- a/src/main/java/com/checkmarx/flow/config/JiraProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/JiraProperties.java
@@ -54,7 +54,7 @@ public class JiraProperties {
     private String labelPrefix;
     private String sastIssueSummaryFormat = "[PREFIX][VULNERABILITY] @ [FILENAME][POSTFIX]";
     private String sastIssueSummaryBranchFormat = "[PREFIX][VULNERABILITY] @ [FILENAME] [[BRANCH]][POSTFIX]";
-
+    private List<String> suppressCodeSnippets;
 
     public String getUrl() {
         return this.url;
@@ -358,4 +358,9 @@ public class JiraProperties {
         this.sastIssueSummaryBranchFormat = sastIssueSummaryBranchFormat;
     }
 
+    public List<String> getSuppressCodeSnippets() { return this.suppressCodeSnippets; }
+
+    public void setSuppressCodeSnippets(List<String> suppressCodeSnippets) {
+        this.suppressCodeSnippets = suppressCodeSnippets;
+    }
 }

--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -1202,21 +1202,21 @@ public class JiraService {
                     .sorted(Map.Entry.comparingByKey())
                     .forEach(entry -> {
                         if (!ScanUtils.empty(entry.getValue().getCodeSnippet())) {
-                            body.append("----").append(HTMLHelper.CRLF);
-                            if (!ScanUtils.empty(fileUrl)) {
-                                String line = "[Line #";
-                                if (request.getRepoType().equals(ScanRequest.Repository.BITBUCKETSERVER)) {
-                                    body.append(line).append(entry.getKey()).append(":|").append(fileUrl).append("#").append(entry.getKey()).append("]").append(HTMLHelper.CRLF);
-                                } else if (request.getRepoType().equals(ScanRequest.Repository.BITBUCKET)) { //BB Cloud
-                                    body.append(line).append(entry.getKey()).append(":|").append(fileUrl).append(lines).append(entry.getKey()).append("]").append(HTMLHelper.CRLF);
-                                } else {
-                                    body.append(line).append(entry.getKey()).append(":|").append(fileUrl).append("#L").append(entry.getKey()).append("]").append(HTMLHelper.CRLF);
-                                }
-                            } else {
-                                body.append("Line #").append(entry.getKey()).append(HTMLHelper.CRLF);
-                            }
                             if (jiraProperties.getSuppressCodeSnippets() == null ||
                                     !jiraProperties.getSuppressCodeSnippets().contains(issue.getVulnerability())) {
+                                body.append("----").append(HTMLHelper.CRLF);
+                                if (!ScanUtils.empty(fileUrl)) {
+                                    String line = "[Line #";
+                                    if (request.getRepoType().equals(ScanRequest.Repository.BITBUCKETSERVER)) {
+                                        body.append(line).append(entry.getKey()).append(":|").append(fileUrl).append("#").append(entry.getKey()).append("]").append(HTMLHelper.CRLF);
+                                    } else if (request.getRepoType().equals(ScanRequest.Repository.BITBUCKET)) { //BB Cloud
+                                        body.append(line).append(entry.getKey()).append(":|").append(fileUrl).append(lines).append(entry.getKey()).append("]").append(HTMLHelper.CRLF);
+                                    } else {
+                                        body.append(line).append(entry.getKey()).append(":|").append(fileUrl).append("#L").append(entry.getKey()).append("]").append(HTMLHelper.CRLF);
+                                    }
+                                } else {
+                                    body.append("Line #").append(entry.getKey()).append(HTMLHelper.CRLF);
+                                }
                                 body.append("{code}").append(HTMLHelper.CRLF);
                                 body.append(entry.getValue().getCodeSnippet()).append(HTMLHelper.CRLF);
                                 body.append("{code}").append(HTMLHelper.CRLF);

--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -1215,9 +1215,12 @@ public class JiraService {
                             } else {
                                 body.append("Line #").append(entry.getKey()).append(HTMLHelper.CRLF);
                             }
-                            body.append("{code}").append(HTMLHelper.CRLF);
-                            body.append(entry.getValue().getCodeSnippet()).append(HTMLHelper.CRLF);
-                            body.append("{code}").append(HTMLHelper.CRLF);
+                            if (jiraProperties.getSuppressCodeSnippets() == null ||
+                                    !jiraProperties.getSuppressCodeSnippets().contains(issue.getVulnerability())) {
+                                body.append("{code}").append(HTMLHelper.CRLF);
+                                body.append(entry.getValue().getCodeSnippet()).append(HTMLHelper.CRLF);
+                                body.append("{code}").append(HTMLHelper.CRLF);
+                            }
                         }
                     });
             body.append("----").append(HTMLHelper.CRLF);


### PR DESCRIPTION

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change.

A new property has been added to the `JiraProperties` class: `suppressCodeSnippets`. This property is a list of vulnerability names for which code snippets should not be generated when creating a Jira ticket.

The rationale behind this is that some code snippets can contain sensitive information (e.g., hard-coded passwords).

### References

> Include supporting link to GitHub Issue/PR number

Address issue https://github.com/checkmarx-ltd/cx-flow/issues/964

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Manual testing. I created a test project for which the following vulnerabilities are detected:

- Improper_Restriction_of_XXE_Ref
- OS_Access_Violation
- Password_In_Comment
- Path_Traversal

I ran CxFlow without specifying the `suppress-code-snippets` property causing code snippets to be generated for all the vulnerabilities.

I ran CxFlow with the following configuration:

```
jira:
  ...
  suppress-code-snippets:
    - Password_In_Comment
``` 

For this run, code snippets were generated for all vulnerabilities except the Password_In_Comment vulnerability.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
- [X ] Verified that SCA and SAST scan results are as expected . SAST: 1Medium is false positive SCA: All  file-common packages are part of test data.

Regarding the active GitHub checks, CircleCI failed during the cleanup phase:

```
#!/bin/bash -eo pipefail
export POD_NAME=$(kubectl get pods -o custom-columns=:metadata.name -n cxflow-${CIRCLE_SHA1::7} | grep cxflow | tr -d '\n')
mkdir -p ~/application-logs/
kubectl logs ${POD_NAME} -n cxflow-${CIRCLE_SHA1::7} > ~/application-logs/${POD_NAME}.log

error: expected 'logs [-f] [-p] (POD | TYPE/NAME) [-c CONTAINER]'.
POD or TYPE/NAME is a required argument for the logs command
See 'kubectl logs -h' for help and examples

Exited with code exit status 1
CircleCI received exit code 1
```

Regarding the last item in the checklist, how can this be verified before creating the pull request?