### PR TITLE
Gitlab Security Reports is expecting a string instead of a float

### DIFF
--- a/src/main/java/com/checkmarx/flow/custom/GitLabSecurityDashboard.java
+++ b/src/main/java/com/checkmarx/flow/custom/GitLabSecurityDashboard.java
@@ -200,7 +200,7 @@ public class GitLabSecurityDashboard extends ImmutableIssueTracker {
     public static class SecurityDashboard {
         @JsonProperty("version")
         @Builder.Default
-        public Double version = 2.0;
+        public String version = "2.0";
         @JsonProperty("vulnerabilities")
         public List<Vulnerability> vulnerabilities;
         @JsonProperty("remediations")


### PR DESCRIPTION
### Description

When you use Gitlab Security Dashboard reports it gives a warning at the moment:

> :warning: Warning parsing security reports
Check the messages generated while parsing the following security reports, as they may prevent the results from being ingested by GitLab. Ensure the security report conforms to a supported [JSON Schema](https://docs.gitlab.com/ee/development/integrations/secure.html#report).
checkmarx-scan-security-dashboard-on-mr (1)
[Schema] property '/version' is not of type: string

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used
- [ ] Verified that SCA and SAST scan results are as expected
