### PR TITLE
[JIRA:CXFLW-119] Gitlab command line should support merge title parameter

### DIFF
--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -114,6 +114,7 @@ public class CxFlowRunner implements ApplicationRunner {
         String repoUrl;
         String branch;
         String mergeId;
+        String mergeTitle;
         String mergeNoteUri = null;
         int mergeProjectId = 0;
         String projectId;
@@ -184,6 +185,7 @@ public class CxFlowRunner implements ApplicationRunner {
         application = getOptionValues(args, "app");
         assignee = getOptionValues(args, "assignee");
         mergeId = getOptionValues(args, "merge-id");
+        mergeTitle = getOptionValues(args,"merge-title");
         preset = getOptionValues(args, "preset");
         scanTag = getOptionValues(args, "scan-tag");
         osa = args.getOptionValues("osa") != null;
@@ -298,7 +300,7 @@ public class CxFlowRunner implements ApplicationRunner {
                 break;
             case GITLABMERGE:
             case gitlabmerge:
-                log.info("Handling GitLab merge request for project: {}, merge id: {}", projectId, mergeId);
+                log.info("Handling GitLab merge request for project: {}, merge id: {}, merge title: {}", projectId, mergeId, mergeTitle);
                 bugType = BugTracker.Type.GITLABMERGE;
                 bt = BugTracker.builder()
                         .type(bugType)
@@ -383,6 +385,7 @@ public class CxFlowRunner implements ApplicationRunner {
         } else if (bugType.equals(BugTracker.Type.GITLABMERGE)) {
             request.setRepoProjectId(mergeProjectId);
             request.putAdditionalMetadata(FlowConstants.MERGE_ID, mergeId);
+            request.putAdditionalMetadata(FlowConstants.MERGE_TITLE, mergeTitle);
         }
 
         try {


### PR DESCRIPTION
…eter like merge-id or  assume some default value

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Customer is using cxflow in command line mode from their gitlab pipeline.  Cxflow fails during block/unblock merge code with explicit validation for missing merge-id or merge-title. 

As can be seen from below command, merge-id is 84 but there is no merge-title parameter supported by Cxflow.

CxFlow to either derive default value for title or support new command line parameter.

### References

> Include supporting link to GitHub Issue/PR number

### Testing

Testing CLI Mode using bellow command:
````
java --spring.config.location="C:\Checkmarx\Configuration\application_Queue.yml" --scan  --f="C:\hello-world-java" --app="HelloWorld"  --cx-project="HelloWorld" --project-id="32830354" --merge-id="14" --merge-title="Update README.md"
````

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used
- [ ] Verified that SCA and SAST scan results are as expected
