### PR TITLE
Pr case insensitive jira statuses

### DIFF
--- a/docs/Bug-Trackers-and-Feedback-Channels.md
+++ b/docs/Bug-Trackers-and-Feedback-Channels.md
@@ -189,6 +189,8 @@ closed-status:
 * open-status → this is a list of the available status an issue can be in that indicate the issue is still in **open** state according to Jira
 * closed-status → this is a list of the available status an issue can be in that indicate the issue is still in **closed** state according to Jira
 
+Note that CxFlow ignores case when comparing statuses.
+
 ### <a name="fields"> Fields</a>
 * **type**
   * **static**: Used for static values (specifically requires a jira-default-value to be provided)

--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -1483,7 +1483,7 @@ public class JiraService {
             try {
                 boolean isJiraIssueAVulnerability = map.containsKey(jiraIssue.getKey());
                 log.trace("Trying to close JIRA issue {} with key {}.", jiraIssue.getValue().getKey(), jiraIssue.getKey());
-                if (!isJiraIssueAVulnerability && (request.getBugTracker().getOpenStatus().contains(jiraIssue.getValue().getStatus().getName()))) {
+                if (!isJiraIssueAVulnerability && (request.getBugTracker().getOpenStatus().stream().anyMatch(jiraIssue.getValue().getStatus().getName()::equalsIgnoreCase))) {
                     /*Close the issue*/
                     log.info("Closing issue {} with key {}.", jiraIssue.getValue().getKey(), jiraIssue.getKey());
                     this.transitionCloseIssue(jiraIssue.getValue().getKey(),

--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -429,7 +429,7 @@ public class JiraService {
         BugTracker bugTracker = request.getBugTracker();
         String severity = issue.getSeverity();
         Issue jiraIssue = this.getIssue(bugId);
-        if (bugTracker.getClosedStatus().contains(jiraIssue.getStatus().getName())) {
+        if (bugTracker.getClosedStatus().stream().anyMatch(jiraIssue.getStatus().getName()::equalsIgnoreCase)) {
             this.transitionIssue(bugId, bugTracker.getOpenTransition());
         }
         IssueInputBuilder issueBuilder = new IssueInputBuilder();
@@ -1524,7 +1524,7 @@ public class JiraService {
     }
 
     private void closeIssueInCaseOfIssueIsInOpenState(ScanRequest request, List<String> closedIssues, Issue fpIssue) throws JiraClientException {
-        if (request.getBugTracker().getOpenStatus().contains(fpIssue.getStatus().getName())) { //If the status is of open state, close it
+        if (request.getBugTracker().getOpenStatus().stream().anyMatch(fpIssue.getStatus().getName()::equalsIgnoreCase)) { //If the status is of open state, close it
             /*Close the issue*/
             log.info("Closing issue with key {}", fpIssue.getKey());
             this.transitionCloseIssue(fpIssue.getKey(), request.getBugTracker().getCloseTransition(), request.getBugTracker(), true);

--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -969,7 +969,7 @@ public class JiraService {
      */
     private Transition getTransitionByName(Iterable<Transition> transitions, String transitionName) {
         for (Transition transition : transitions) {
-            if (transition.getName().equals(transitionName)) {
+            if (transition.getName().equalsIgnoreCase(transitionName)) {
                 return transition;
             }
         }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Jira statuses are not case-sensitive: you cannot have two distinct statuses whose names differ only by case. Furthermore, in its UI, Jira displays the statuses in uppercase but the Jira API does not. E.g., the "In progress" status will be displayed in the UI as "IN PROGRESS" but the API will return "In Progress". This makes it easy for a customer to misconfigure CxFlow as the natural approach is to use the value from the UI.

With this change, CxFlow ignores case when comparing Jira statuses.

### References

N/A

### Testing

Manual testing: create an `application.yml` file that specifies Jira as the bug-tracker and gives the Jira statuses in a case different to that returned by the Jira API.

### Checklist

A number of tests are failing but I do not think that they are related to the changes in this PR.

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
- [ ] Verified that SCA and SAST scan results are as expected
