### PR TITLE
fixed pipeline kubernetes issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ jobs:
           cluster-name: << parameters.cluster-name >>
           install-kubectl: false          
       - kubernetes/install:
-          kubectl-version: v1.23.6
+          kubectl-version: v1.23.0
       - run:
           name: Change appVersion
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ jobs:
         type: boolean
     steps:
       - checkout
-      - kubernetes/install
+      - kubernetes/install:
           kubectl-version: v1.21.0
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
@@ -261,7 +261,7 @@ jobs:
         type: string
     steps:
       - checkout      
-      - kubernetes/install
+      - kubernetes/install:
           kubectl-version: v1.21.0
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
@@ -515,8 +515,8 @@ jobs:
       version:
         type: string
     steps:
-      - kubernetes/install
-          kubectl-version: v1.21.0    
+      - kubernetes/install:
+          kubectl-version: v1.21.0
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
           install-kubectl: false
@@ -576,7 +576,7 @@ jobs:
   clean-eks:
     executor: aws-eks/python3
     steps:
-      - kubernetes/install
+      - kubernetes/install:
           kubectl-version: v1.21.0
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: eks-cxflow-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -635,6 +635,7 @@ workflows:
           requires:
             - build
       - aws-cli-setup:
+          requires:
             - component-test
       - deploy-cxflow:
           cluster-name: eks-cxflow-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,10 +195,6 @@ jobs:
         type: boolean
     steps:
       - checkout
-      - run:
-          name: delete kube config
-          command: |
-            aws eks update-kubeconfig --name ${CLUSTER_NAME}
       - kubernetes/install:
           kubectl-version: v1.23.6
       - aws-eks/update-kubeconfig-with-authenticator:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,6 +185,10 @@ jobs:
         type: boolean
     steps:
       - checkout
+      - run:
+          name: delete kube config
+          command: |
+              aws eks update-kubeconfig --name ${CLUSTER_NAME}
       - kubernetes/install:
           kubectl-version: v1.23.6
       - aws-eks/update-kubeconfig-with-authenticator:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -636,7 +636,7 @@ workflows:
             - build
       - aws-cli-setup:
           requires:
-            - component-test
+            - component-tests
       - deploy-cxflow:
           cluster-name: eks-cxflow-ci
           chart: ./helm/cxflow

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ jobs:
       - run:
           name: delete kube config
           command: |
-              aws eks update-kubeconfig --name ${CLUSTER_NAME}
+              /usr/local/bin/aws eks update-kubeconfig --name ${CLUSTER_NAME}
       - kubernetes/install:
           kubectl-version: v1.23.6
       - aws-eks/update-kubeconfig-with-authenticator:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ jobs:
       - run:
           name: Installing own kubernetes
           command: |
-            curl -LO /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl
+            cd /usr/local/bin/kubectl && curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl
       - checkout
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
       - run:
           name: delete kube config
           command: |
-              /usr/local/bin/aws eks update-kubeconfig --name ${CLUSTER_NAME}
+            aws eks update-kubeconfig --name ${CLUSTER_NAME}
       - kubernetes/install:
           kubectl-version: v1.23.6
       - aws-eks/update-kubeconfig-with-authenticator:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,6 +160,10 @@ jobs:
       - checkout
       - aws-cli/setup:
           profile-name: example
+      - run:
+         name: delete kube config
+         command: |
+            aws eks update-kubeconfig --name ${CLUSTER_NAME}
   deploy-cxflow:
     executor: aws-eks/python3
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ jobs:
       - run:
           name: Installing own kubernetes
           command: |
-            cd /usr/local/bin/kubectl && curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl
+            cd /usr/local/bin && curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl
       - checkout
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ jobs:
       - run:
           name: Installing own kubernetes
           command: |
-            curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl | mv ./kubectl /usr/local/bin/kubectl
+            curl -LO /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl
       - checkout
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
       - run:
          name: delete kube config
          command: |
-            aws eks update-kubeconfig --name ${CLUSTER_NAME}
+            aws eks update-kubeconfig --name eks-cxflow-ci
   deploy-cxflow:
     executor: aws-eks/python3
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,10 +184,14 @@ jobs:
         description: Should we only consider jobs running on the same branch?
         type: boolean
     steps:
+      - run:
+          name: Installing own kubernetes
+          command: |
+            curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl mv ./kubectl /usr/local/bin/kubectl
       - checkout
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
-          install-kubectl: true
+          install-kubectl: false
       - run:
           name: Change appVersion
           command: |
@@ -261,7 +265,7 @@ jobs:
       - checkout
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
-          install-kubectl: true
+          install-kubectl: false
       - run:
           name: Run E2E Tests
           command: |
@@ -513,7 +517,7 @@ jobs:
     steps:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
-          install-kubectl: true
+          install-kubectl: false
       - helm/install-helm-client:
           version: << parameters.version >>
       - run:
@@ -572,7 +576,7 @@ jobs:
     steps:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: eks-cxflow-ci
-          install-kubectl: true
+          install-kubectl: false
       - run:
           name: Delete namespace
           command: |
@@ -588,7 +592,7 @@ jobs:
 
 orbs:
   aws-eks: circleci/aws-eks@1.0.0
-  kubernetes: circleci/kubernetes@1.23.6
+  kubernetes: circleci/kubernetes@0.4.0
   helm: circleci/helm@0.2.3
   checkmarx: checkmarx/circleci-kpi-shipper@0.10.0
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,12 @@ jobs:
             - ./image.tar
             - ./latest.tar
 
+  aws-cli-setup:
+    executor: aws-cli/default
+    steps:
+      - checkout
+      - aws-cli/setup:
+          profile-name: example
   deploy-cxflow:
     executor: aws-eks/python3
     parameters:
@@ -599,6 +605,7 @@ jobs:
             fi
 
 orbs:
+  aws-cli: circleci/aws-cli@3.1.1
   aws-eks: circleci/aws-eks@1.0.0
   kubernetes: circleci/kubernetes@0.4.0
   helm: circleci/helm@0.2.3
@@ -627,6 +634,8 @@ workflows:
       - component-tests:
           requires:
             - build
+      - aws-cli-setup:
+            - component-test
       - deploy-cxflow:
           cluster-name: eks-cxflow-ci
           chart: ./helm/cxflow
@@ -643,6 +652,7 @@ workflows:
           requires:
             - docker-build
             - component-tests
+            - aws-cli-setup
       - e2e-tests:
           cluster-name: eks-cxflow-ci
           namespace: cxflow-${CIRCLE_SHA1::7}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,11 +195,11 @@ jobs:
         type: boolean
     steps:
       - checkout
-      - kubernetes/install:
-          kubectl-version: v1.23.6
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
           install-kubectl: false          
+      - kubernetes/install:
+          kubectl-version: v1.23.6
       - run:
           name: Change appVersion
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,7 +186,7 @@ jobs:
     steps:
       - checkout
       - kubernetes/install:
-          kubectl-version: v1.21.0
+          kubectl-version: v1.23.6
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
           install-kubectl: false          
@@ -262,7 +262,7 @@ jobs:
     steps:
       - checkout      
       - kubernetes/install:
-          kubectl-version: v1.21.0
+          kubectl-version: v1.23.6
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
           install-kubectl: false          
@@ -516,7 +516,7 @@ jobs:
         type: string
     steps:
       - kubernetes/install:
-          kubectl-version: v1.21.0
+          kubectl-version: v1.23.6
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
           install-kubectl: false
@@ -577,7 +577,7 @@ jobs:
     executor: aws-eks/python3
     steps:
       - kubernetes/install:
-          kubectl-version: v1.21.0
+          kubectl-version: v1.23.6
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: eks-cxflow-ci
           install-kubectl: false      

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,10 +185,11 @@ jobs:
         type: boolean
     steps:
       - checkout
+      - kubernetes/install
+          kubectl-version: v1.21.0
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
-          install-kubectl: true
-          kubectl-version: v1.21.0
+          install-kubectl: false          
       - run:
           name: Change appVersion
           command: |
@@ -259,11 +260,12 @@ jobs:
       version:
         type: string
     steps:
-      - checkout
+      - checkout      
+      - kubernetes/install
+          kubectl-version: v1.21.0
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
-          install-kubectl: true
-          kubectl-version: v1.21.0
+          install-kubectl: false          
       - run:
           name: Run E2E Tests
           command: |
@@ -513,10 +515,11 @@ jobs:
       version:
         type: string
     steps:
+      - kubernetes/install
+          kubectl-version: v1.21.0    
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
-          install-kubectl: true
-          kubectl-version: v1.21.0
+          install-kubectl: false
       - helm/install-helm-client:
           version: << parameters.version >>
       - run:
@@ -573,10 +576,11 @@ jobs:
   clean-eks:
     executor: aws-eks/python3
     steps:
+      - kubernetes/install
+          kubectl-version: v1.21.0
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: eks-cxflow-ci
-          install-kubectl: true
-          kubectl-version: v1.21.0
+          install-kubectl: false      
       - run:
           name: Delete namespace
           command: |
@@ -591,7 +595,7 @@ jobs:
             fi
 
 orbs:
-  aws-eks: circleci/aws-eks@2.2.0
+  aws-eks: circleci/aws-eks@1.0.0
   kubernetes: circleci/kubernetes@0.4.0
   helm: circleci/helm@0.2.3
   checkmarx: checkmarx/circleci-kpi-shipper@0.10.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -588,7 +588,7 @@ jobs:
 
 orbs:
   aws-eks: circleci/aws-eks@1.0.0
-  kubernetes: circleci/kubernetes@0.4.0
+  kubernetes: circleci/kubernetes@1.21.0
   helm: circleci/helm@0.2.3
   checkmarx: checkmarx/circleci-kpi-shipper@0.10.0
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ jobs:
       - run:
           name: Installing own kubernetes
           command: |
-            curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl mv ./kubectl /usr/local/bin/kubectl
+            curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl | mv ./kubectl /usr/local/bin/kubectl
       - checkout
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -588,7 +588,7 @@ jobs:
 
 orbs:
   aws-eks: circleci/aws-eks@1.0.0
-  kubernetes: circleci/kubernetes@1.21.0
+  kubernetes: circleci/kubernetes@1.23.6
   helm: circleci/helm@0.2.3
   checkmarx: checkmarx/circleci-kpi-shipper@0.10.0
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -591,7 +591,7 @@ jobs:
             fi
 
 orbs:
-  aws-eks: circleci/aws-eks@1.0.0
+  aws-eks: circleci/aws-eks@2.2.0
   kubernetes: circleci/kubernetes@0.4.0
   helm: circleci/helm@0.2.3
   checkmarx: checkmarx/circleci-kpi-shipper@0.10.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,14 +184,10 @@ jobs:
         description: Should we only consider jobs running on the same branch?
         type: boolean
     steps:
-      - run:
-          name: Installing own kubernetes
-          command: |
-            cd /usr/local/bin && curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl
       - checkout
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
-          install-kubectl: false
+          install-kubectl: true
       - run:
           name: Change appVersion
           command: |
@@ -265,7 +261,7 @@ jobs:
       - checkout
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
-          install-kubectl: false
+          install-kubectl: true
       - run:
           name: Run E2E Tests
           command: |
@@ -517,7 +513,7 @@ jobs:
     steps:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
-          install-kubectl: false
+          install-kubectl: true
       - helm/install-helm-client:
           version: << parameters.version >>
       - run:
@@ -576,7 +572,7 @@ jobs:
     steps:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: eks-cxflow-ci
-          install-kubectl: false
+          install-kubectl: true
       - run:
           name: Delete namespace
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -636,7 +636,7 @@ workflows:
             - build
       - aws-cli-setup:
           requires:
-            - component-tests
+            - docker-build
       - deploy-cxflow:
           cluster-name: eks-cxflow-ci
           chart: ./helm/cxflow

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,7 @@ jobs:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
           install-kubectl: true
+          kubectl-version: v1.21.0
       - run:
           name: Change appVersion
           command: |
@@ -262,6 +263,7 @@ jobs:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
           install-kubectl: true
+          kubectl-version: v1.21.0
       - run:
           name: Run E2E Tests
           command: |
@@ -514,6 +516,7 @@ jobs:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
           install-kubectl: true
+          kubectl-version: v1.21.0
       - helm/install-helm-client:
           version: << parameters.version >>
       - run:
@@ -573,6 +576,7 @@ jobs:
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: eks-cxflow-ci
           install-kubectl: true
+          kubectl-version: v1.21.0
       - run:
           name: Delete namespace
           command: |


### PR DESCRIPTION
### Description

Pipeline is failing to create eks cluster . This issue is said to be known issue with default kubectl version, which got upgraded to 1.24.0 and it has issues. 

To fix, disabled auto kubectl installation as part of the aws-eks/update-kubeconfig-with-authenticator and added explcit kubectl-install step.  ORB version used does not support simply specifying kubectl-version on update-kubeconfig-with-authenticator.

Additionally, it is suggested to delete default kubectl config. To do this, aws cli installation and aws eks delete command is added.

### References

N/A

### Testing
Verified that when version is changed to 1.23.0 for the deploy-cxflow step, the pipeline worked.

### Checklist

N/A
