### PR TITLE
Fix blank results posting during PostBack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ cx-flow.log*
 
 ### VSCode ###
 .vscode
+.DS_Store

--- a/src/main/java/com/checkmarx/flow/service/FlowService.java
+++ b/src/main/java/com/checkmarx/flow/service/FlowService.java
@@ -3,11 +3,14 @@ package com.checkmarx.flow.service;
 import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.exception.MachinaRuntimeException;
 import com.checkmarx.sdk.dto.ScanResults;
+import com.checkmarx.sdk.config.CxProperties;
+import com.checkmarx.sdk.config.CxPropertiesBase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +27,7 @@ public class FlowService {
     private final List<VulnerabilityScanner> scanners;
     private final ProjectNameGenerator projectNameGenerator;
     private final ResultsService resultsService;
+    private final CxProperties cxProperties = new CxProperties();
 
     /**
      * Main entry point for the automation process initiated by webhooks.
@@ -65,7 +69,9 @@ public class FlowService {
                 log.warn("Scan failed. Continuing with other scanners.");
             }
         });
-        resultsService.publishCombinedResults(scanRequest, combinedResults);
+        if(!cxProperties.getEnablePostActionMonitor()) {
+            resultsService.publishCombinedResults(scanRequest, combinedResults);
+        }
     }
 
     private List<VulnerabilityScanner> getEnabledScanners(ScanRequest scanRequest) {

--- a/src/main/java/com/checkmarx/flow/service/FlowService.java
+++ b/src/main/java/com/checkmarx/flow/service/FlowService.java
@@ -4,7 +4,6 @@ import com.checkmarx.flow.dto.ScanRequest;
 import com.checkmarx.flow.exception.MachinaRuntimeException;
 import com.checkmarx.sdk.dto.ScanResults;
 import com.checkmarx.sdk.config.CxProperties;
-import com.checkmarx.sdk.config.CxPropertiesBase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
@@ -27,7 +26,7 @@ public class FlowService {
     private final List<VulnerabilityScanner> scanners;
     private final ProjectNameGenerator projectNameGenerator;
     private final ResultsService resultsService;
-    private final CxProperties cxProperties = new CxProperties();
+    private final CxProperties cxProperties;
 
     /**
      * Main entry point for the automation process initiated by webhooks.


### PR DESCRIPTION
implement check for postback action status prior to publishing results on scan request

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This is to fix the issue where Cxflow is closing issues based on blank reports when a scan is initiated with PostBack mode enabled.

### References

#1008 

### Testing

This is currently being used in our environment.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used
- [ ] Verified that SCA and SAST scan results are as expected
