### PR TITLE
Add support for after/before/failed scan email notifications

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.5.17"
+        CxSBSDK = "0.5.18"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.6.6'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.5.17"
+        CxSBSDK = "0.5.18"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.6.6'

--- a/docs/Config-As-Code.md
+++ b/docs/Config-As-Code.md
@@ -86,6 +86,20 @@ Example Config As Code:
   "scanCustomFields": {
     "field3": "value3",
     "field4": "value4"
+  },
+  "emailNotifications": {
+    "afterScan": [
+      "user1@example.com",
+      "user2@example.com"
+    ],
+    "beforeScan": [
+      "user3@example.com",
+      "user4@example.com"
+    ],
+    "failedScan": [
+      "user5@example.com",
+      "user6@example.com"
+    ]
   }
 }
 ```

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -127,6 +127,13 @@ checkmarx:
   cx-branch: false
   scan-queuing: true
   scan-queuing-timeout: 720 # Webhook and --scan command line only, number of minutes
+  email-notifications:
+    after-scan:
+      - user1@example.com
+    before-scan:
+      - user2@example.com
+    failed-scan:
+      - user3@example.com
 
 github:
   webhook-token: XXXXX
@@ -505,6 +512,7 @@ The configuration can be set or overridden at execution time using the command l
 | `scan-queuing`            | false                 | No | Yes | Yes | A flag to enable queuing of scan events. |
 | `scan-queuing-timeout`    | 720                   | No | Yes | Yes | The amount of time (in minutes) for which cx-flow will keep a scan event data in its queue before sending to CxSAST, when all the available concurrent scans in CxSAST are in use. | 
 | `disable-clubbing`        | false                 | No | Yes | Yes              | If set to true, results are not grouped at all.By default, results are grouped only by vulnerability and filename.|
+| `email-notifications`     |                       | No |     | Yes (Scan only) | A map containing any or all of the following keys: `after-scan`, `before-scan`, `failed-scan`. The vaue of each key is a list of email addresses to which a notification should be sent in the case of the relevant event.|
 
 No* = Default is applied
 
@@ -572,6 +580,25 @@ checkmarx:
   scan-queuing: true
   scan-queuing-timeout: 720 #Amount of time in minutes
 ```
+
+### <a name="emailNotifications"> Email Notifications</a>
+If present, this property specifies the email notifications to be sent when a SAST scan is run. Notifications can be sent before a scan starts, after a scan finishes, and when a scan fails. The content of the `email-notifications` property is a map from the following keys to lists of email receipients: `after-scan`, `before-scan`, `failed-scan`.
+```yaml
+checkmarx:
+  ...
+  email-notifications:
+    after-scan:
+      - user1@example.com
+      - user2@example.com
+    before-scan:
+      - user3@example.com
+      - user4@example.com
+    failed-scan:
+      - user5@example.com
+      - user6@example.com
+```
+
+Email notifications can also be configured via conf-as-code.
 
 ## <a name="webhook">WebHook Configuration</a>
 Each repository type requires its own specific configuration block as defined below.  Each of these have available overrides that can be provided in the form of URL parameters or as a JSON configuration blob that is base64 encoded and provided as an url parameter (override=<XXXXXX>).

--- a/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
@@ -6,6 +6,7 @@ import com.checkmarx.flow.config.external.ASTConfig;
 import com.checkmarx.flow.service.VulnerabilityScanner;
 import com.checkmarx.sdk.config.ScaConfig;
 import com.checkmarx.sdk.dto.filtering.FilterConfiguration;
+import com.checkmarx.sdk.dto.cx.CxEmailNotifications;
 import lombok.*;
 
 import java.util.*;
@@ -117,6 +118,9 @@ public class ScanRequest {
     @Getter @Setter
     private CliMode cliMode;
 
+    @Getter @Setter
+    private CxEmailNotifications emailNotifications;
+
     public ScanRequest(ScanRequest other) {
         this.namespace = other.namespace;
         this.application = other.application;
@@ -161,6 +165,7 @@ public class ScanRequest {
         this.disableCertificateValidation = other.disableCertificateValidation;
         this.sshKeyIdentifier = other.sshKeyIdentifier;
         this.cliMode = other.cliMode;
+        this.emailNotifications = other.emailNotifications;
     }
 
     public Map<String,String> getAltFields() {

--- a/src/main/java/com/checkmarx/flow/sastscanning/ScanRequestConverter.java
+++ b/src/main/java/com/checkmarx/flow/sastscanning/ScanRequestConverter.java
@@ -226,7 +226,8 @@ public class ScanRequestConverter {
                 .withSshKeyIdentifier(request.getSshKeyIdentifier())
                 .withClientSecret(request.getScannerApiSec())
                 .withCustomFields(request.getCxFields())
-                .withScanCustomFields(request.getScanFields());
+                .withScanCustomFields(request.getScanFields())
+                .withEmailNotifications(request.getEmailNotifications());
 
         if (StringUtils.isNotEmpty(request.getBranch())) {
             params.withBranch(Constants.CX_BRANCH_PREFIX.concat(request.getBranch()));

--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -262,6 +262,7 @@ public class ConfigurationOverrider {
         });
         override.map(CxConfig::getCustomFields).ifPresent(s -> request.setCxFields(s));
         override.map(CxConfig::getScanCustomFields).ifPresent(s -> request.setScanFields(s));
+        override.map(CxConfig::getEmailNotifications).ifPresent(s -> request.setEmailNotifications(s));
         overrideUsingConfigProvider(override, overrideReport, request);
     }
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change.

This PR allows CxFlow to configure the recipients of after/before/failed scan emails for SAST scans. The notifications can be configured via the `application.yml` file (and, by extension, the command line and via environment variables) or via config-as-code. If both are present, the config-as-code configuration takes precedence.

Although this feature builds with the latest (at the time of writing) version of the Checkmarx Spring Boot Java SDK (version 0.5.17), it depends on [PR #227](https://github.com/checkmarx-ltd/checkmarx-spring-boot-java-sdk/pull/227). In other words, the merging of this PR should wait until a version of the SDK is available which includes the aforementioned change.
### References

> Include supporting link to GitHub Issue/PR number

This feature has been requested by a client but is not specific to that client.



### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Two manual tests were performed:

Firstly, a scan was run with the following in the `application.yml` file:

```
checkmarx:
  ...
  email-notifications:
    after-scan:
      - a@ex.com
      - b@ex.com
    before-scan:
      - c@ex.com
      - d@ex.com
    failed-scan:
      - e@ex.com
      - f@ex.com
```

Secondly, the following `cx.config` file was added to the project:

```
{
  "version": 1.0,
  "emailNotifications": {
    "afterScan": ["after.scan@local.domain"],
    "beforeScan": ["before.scan@local.domain"],
    "failedScan": ["failed.scan@local.domain"]
  }
}
```

In both cases, the new project was created with the expected email notifications configured.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
- [ ] Verified that SCA and SAST scan results are as expected
