### PR TITLE
[JIRA:CXFLW-425]Fixed issues closing before scan is finished issue in postback mode

### DIFF
--- a/src/main/java/com/checkmarx/flow/service/ResultsService.java
+++ b/src/main/java/com/checkmarx/flow/service/ResultsService.java
@@ -129,49 +129,51 @@ public class ResultsService {
             getCxFields(request, results);
         }
 
-        switch (request.getBugTracker().getType()) {
-            case NONE:
-            case wait:
-            case WAIT:
-                log.info("Issue tracking is turned off");
-                break;
-            case JIRA:
-                handleJiraCase(request, results, scanDetails);
-                log.info("Results Service case JIRA : request =:  {}  results = {}  scanDetails= {}", request.toString(), results.toString(), scanDetails.toString());
-                break;
-            case GITHUBPULL:
-                gitService.processPull(request, results);
-                gitService.endBlockMerge(request, results, scanDetails);
-                break;
-            case GITLABCOMMIT:
-                gitLabService.processCommit(request, results);
-                break;
-            case GITLABMERGE:
-                gitLabService.processMerge(request, results);
-                gitLabService.endBlockMerge(request);
-                break;
-            case BITBUCKETCOMMIT:
-                bbService.processCommit(request, results);
-                break;
-            case BITBUCKETPULL:
-                bbService.processMerge(request, results);
-                break;
-            case BITBUCKETSERVERPULL:
-                bbService.processServerMerge(request, results, scanDetails);
-                bbService.setBuildEndStatus(request, results, scanDetails);
-                break;
-            case ADOPULL:
-                adoService.processPull(request, results);
-                adoService.endBlockMerge(request, results, scanDetails);
-                break;
-            case EMAIL:
-                emailService.handleEmailBugTracker(request, results);
-                break;
-            case CUSTOM:
-                handleCustomIssueTracker(request, results);
-                break;
-            default:
-                log.warn("No valid bug type was provided");
+        if(results.getScaResults() != null || results.getXIssues() != null) {
+            switch (request.getBugTracker().getType()) {
+                case NONE:
+                case wait:
+                case WAIT:
+                    log.info("Issue tracking is turned off");
+                    break;
+                case JIRA:
+                    handleJiraCase(request, results, scanDetails);
+                    log.info("Results Service case JIRA : request =:  {}  results = {}  scanDetails= {}", request.toString(), results.toString(), scanDetails.toString());
+                    break;
+                case GITHUBPULL:
+                    gitService.processPull(request, results);
+                    gitService.endBlockMerge(request, results, scanDetails);
+                    break;
+                case GITLABCOMMIT:
+                    gitLabService.processCommit(request, results);
+                    break;
+                case GITLABMERGE:
+                    gitLabService.processMerge(request, results);
+                    gitLabService.endBlockMerge(request);
+                    break;
+                case BITBUCKETCOMMIT:
+                    bbService.processCommit(request, results);
+                    break;
+                case BITBUCKETPULL:
+                    bbService.processMerge(request, results);
+                    break;
+                case BITBUCKETSERVERPULL:
+                    bbService.processServerMerge(request, results, scanDetails);
+                    bbService.setBuildEndStatus(request, results, scanDetails);
+                    break;
+                case ADOPULL:
+                    adoService.processPull(request, results);
+                    adoService.endBlockMerge(request, results, scanDetails);
+                    break;
+                case EMAIL:
+                    emailService.handleEmailBugTracker(request, results);
+                    break;
+                case CUSTOM:
+                    handleCustomIssueTracker(request, results);
+                    break;
+                default:
+                    log.warn("No valid bug type was provided");
+            }
         }
         if (results != null && results.getScanSummary() != null) {
             log.info("####Checkmarx Scan Results Summary####");


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> This PR fixes the issue of issues in github closing even before the scan for the project is complete.

### References

> #1008 

### Testing

<html>
<body>
<!--StartFragment-->

Scanners Enabled | Postback-action-enabled | Result
-- | -- | --
SAST,SCA | No | scan was finished from both scanners and issues were created in GitHub
SCA | No | Scan was finished and issues were updated in GitHub for sca , closing earlier SAST issues.
SAST | No | Scan was finished andissues were updated in GitHub for sast, closing earlier SCA issues.
SAST | Yes | scan was finished and issues were created in GitHub
SCA | Yes | scan was finished and SAST issues were closed and new issues for sca created.
SAST,SCA | Yes | scan finished and sca issues were updated and sast issues were reopened.

<!--EndFragment-->
</body>
</html>

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
- [x] Verified that SCA and SAST scan results are as expected
