### PR TITLE
Downgrading OGNL due to https://github.com/thymeleaf/thymeleaf-spring…

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -115,7 +115,7 @@ dependencies {
     compile("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}")
 
     compile("org.thymeleaf:thymeleaf-spring5:3.0.15.RELEASE")
-    implementation 'ognl:ognl:3.3.2'
+    implementation 'ognl:ognl:3.1.29'
 
     compile ("org.apache.httpcomponents:httpclient:4.5.13")
     compile ("org.codehaus.groovy:groovy-all:3.0.9") {

--- a/build.gradle
+++ b/build.gradle
@@ -90,9 +90,6 @@ dependencies {
         exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
         exclude group: 'ch.qos.logback', module: 'logback-core'
     }
-
-    // compile 'org.springframework:spring-context-support:5.2.8.RELEASE'
-    // compile 'org.springframework.boot:spring-boot-starter-mail:2.5.6'
     
     compile('org.springframework.boot:spring-boot-starter-aop'){
         exclude group: 'ch.qos.logback', module: 'logback-core'

--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,9 @@ dependencies {
         exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
         exclude group: 'ch.qos.logback', module: 'logback-core'
     }
+
+    // compile 'org.springframework:spring-context-support:5.2.8.RELEASE'
+    // compile 'org.springframework.boot:spring-boot-starter-mail:2.5.6'
     
     compile('org.springframework.boot:spring-boot-starter-aop'){
         exclude group: 'ch.qos.logback', module: 'logback-core'
@@ -134,7 +137,7 @@ dependencies {
     compile("org.apache.httpcomponents:httpclient:4.5.13")
 
     compile("org.thymeleaf:thymeleaf-spring5:3.0.15.RELEASE")
-    implementation 'ognl:ognl:3.3.2'
+    implementation 'ognl:ognl:3.1.29'
 
     compile("org.codehaus.groovy:groovy-all:3.0.9") {
         exclude group: 'org.apache.ant', module: 'ant'


### PR DESCRIPTION
…/issues/203.

### Description

- Resolves https://github.com/checkmarx-ltd/cx-flow/issues/1025: `java.lang.NoClassDefFoundError: ognl/DefaultMemberAccess`

### References

https://github.com/checkmarx-ltd/cx-flow/issues/1025 and https://github.com/thymeleaf/thymeleaf-spring/issues/203

### Testing

Just run CxFlow 1.6.34 with Java 8, in server mode, with an application.yml having cx-flow-mail defined with either SMTP parameters, or a Sendgrid API key.

### Checklist

- [X] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
- [X] Verified that SCA and SAST scan results are as expected
