### PR TITLE
[JIRA:CXFLW-391]Fixed issue closing and reopening in JIRA

### DIFF
--- a/docs/Bug-Trackers-and-Feedback-Channels.md
+++ b/docs/Bug-Trackers-and-Feedback-Channels.md
@@ -7,6 +7,7 @@
   * [Fields](#fields)
   * [Assigning tickets to a user](#assigningTickets)
   * [Configuring the Jira Issue Summary](#issueSummaryFormat)
+  * [Jira Issue Handling](#issueHandling)
 * [Custom Bug trackers](#custom)
 * [Azure DevOps Work Items](#azure)
 * [GitLab Issues](#gitlab)
@@ -271,28 +272,10 @@ When creating a Jira ticket, CxFlow will add a code snippet to the ticket. Somet
       - Use_Of_Hardcoded_Password
 ```
 
-### <a name="issueSummaryFormat">Jira Issue Handling for Scan Mode</a>
-* Jira Issue will be created with Label as SAST scanner and SCA scanner after the scan.
-* Issue will be filtered on the bases of type of scan (SCA or SAST) and issue will be Update/Open/Close for which scan is initiated that project.
-* For scan initiated for both SCA and SAST then issues for both type of scan will be created or updated for that project.If User re-run scan for any one type 
- either SCA or SAST for same project id, then Issue will be updated for that scan type and Issues for other scan type(created before re-run) will 
- not be impacted. 
-
-**Description**
-
-1. Run the SAST and SCA scan the CLI mode.
-```
- $ java -jar .\cx-flow-1.6.29.jar --spring.config.location="application.yml" --scan --f=.\TestProj  --cx-flow.enabled-vulnerability-scanners="sca,sast" --cx-team=CxServer --cx-project=TestProj--app=TestProj --cx-flow.bug-tracker=JIRA --logging.level.com.checkmarx.flow.custom=debug --logging.level.com.checkmarx.flow.service=debug --logging.level.com.checkmarx.flow.utils=debug --logging.level.com.checkmarx.sdk.service=debug
-``` 
-2. Run the SCA or SAST scan from CLI mode.
-```
- $ java -jar .\cx-flow-1.6.29.jar --spring.config.location="application.yml" --scan --f=.\TestProj  --cx-flow.enabled-vulnerability-scanners="sca" --cx-team=CxServer --cx-project=TestProj--app=TestProj --cx-flow.bug-tracker=JIRA --logging.level.com.checkmarx.flow.custom=debug --logging.level.com.checkmarx.flow.service=debug --logging.level.com.checkmarx.flow.utils=debug --logging.level.com.checkmarx.sdk.service=debug
-``` 
-```
- $ java -jar .\cx-flow-1.6.29.jar --spring.config.location="application.yml" --scan --f=.\TestProj  --cx-flow.enabled-vulnerability-scanners="sast" --cx-team=CxServer --cx-project=TestProj--app=TestProj --cx-flow.bug-tracker=JIRA --logging.level.com.checkmarx.flow.custom=debug --logging.level.com.checkmarx.flow.service=debug --logging.level.com.checkmarx.flow.utils=debug --logging.level.com.checkmarx.sdk.service=debug
-``` 
-
-Issue created in Step 1 will not be closed in Sept 2, because issue identified in scan will be compared with issue already in Jira for that Project based on type of Scan (SAST, SCA or both).
+### <a name="issueHandling">Jira Issue Handling</a>
+* Issues in JIRA are tagged with a label of `Scanner` with its value being either `SCA` or `SAST` based on the scanner result for which issue is created.
+* There will be filtering of issues based on the type of scan (SCA or SAST) and issues will be updated/created/closed based on the type of scanner used to initiate the scan for that project. 
+* If a scan is initiated for both SCA and SAST, issues of both the scanner types will be created or updated. Re-running scans for either SCA or SAST for the same project id will update issues for that scanner only. Issues of the other type scanner(created before re-run) will not be affected. 
 
 ## <a name="custom">Custom Bug Trackers</a>
 Refer to the [development section](https://github.com/checkmarx-ltd/cx-flow/wiki/Development) for the implementation approach.

--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -1311,16 +1311,14 @@ public class JiraService {
         List<String> closedIssues = new ArrayList<>();
         String filterScanner = "";
 
-        if(CliMode.SCAN.equals(request.getCliMode())){
-            if (null != results.getScaResults()) {
-                filterScanner=JIRA_ISSUE_LABEL_SCA;
-            }
-            if(null != results.getXIssues()){
-                if(filterScanner.isEmpty()){
-                    filterScanner=JIRA_ISSUE_LABEL_SAST;
-                }else{
-                    filterScanner=filterScanner + "," + JIRA_ISSUE_LABEL_SAST;
-                }
+        if (null != results.getScaResults()) {
+            filterScanner=JIRA_ISSUE_LABEL_SCA;
+        }
+        if(null != results.getXIssues()){
+            if(filterScanner.isEmpty()){
+                filterScanner=JIRA_ISSUE_LABEL_SAST;
+            }else{
+                filterScanner=filterScanner + "," + JIRA_ISSUE_LABEL_SAST;
             }
         }
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> This PR fixes the issue of JIRA issues changing statuses when closed and reopened when ran in --project mode.

### Testing

Mode of   Scanning with JIRA BT | Enabled scanners | Initial conditions | Results
-- | -- | -- | --
SCAN | SAST,SCA | No Issues present in JIRA for        any of the scanners(i.e empty project) | 1. Scan initiated for both the   scanners and once completed results were generated.     2. Based on the results issues are created in JIRA for both the scanners.
SCAN | SAST | 1. Issues for both scanners   present in     JIRA board.     2. Manually changed the status of sca     issues to IN PROGRESS. | 1. All the sast issues were   updated.     2. Sca issues status was not changed.
SCAN | SCA | 1. Issues for both scanners   present in     JIRA board.     2. Manually changed the status of sast     issues to IN PROGRESS. | 1. All the sca issues were   updated.     2. sast issues status was not changed.
PROJECT | SAST,SCA | 1. Issues for both scanner   present in JIRA board.     2. Manually changed the status of sca issues to IN PROGRESS. | 1. SAST results were retrieved   and issues in JIRA board were updated.     2. SCA results were retrieved and issues for both the scanners in JIRA   board were updated.
PROJECT | SCA | 1. Issues for both scanners are   present in JIRA board. | Only issues of SCA scanner were   updated.
PROJECT | SAST | 1. Issues for both scanners are   present in JIRA board. | Only issues of SAST scanner were   updated.
PARSE | SCA | 1. Issues for both scanners are   present in JIRA board. | Only issues of SCA scanner were   updated.
PARSE | SAST | 1. Issues for both scanners are   present in JIRA board. | Only issues of SAST scanner were   updated.
WEB | SAST,SCA | No Issues present in JIRA for        any of the scanners(i.e empty project) | 1. Scan initiated for both the   scanners and once completed results were generated.     2. Based on the results issues are created in JIRA for both the scanners.
WEB | SCA | 1. Issues for both scanners   present in     JIRA board.     2. Manually changed the status of sast     issues to IN PROGRESS. | 1. All the sca issues were   updated.     2. sast issues status was not changed.
WEB | SAST | 1. Issues for both scanners   present in     JIRA board.     2. Manually changed the status of sca     issues to IN PROGRESS. | 1. All the sast issues were   updated.     2. Sca issues status was not changed.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
- [x] Verified that SCA and SAST scan results are as expected
