### PR TITLE
Allow zip exclude via config as code

### DIFF
--- a/docs/Config-As-Code.md
+++ b/docs/Config-As-Code.md
@@ -29,9 +29,10 @@ Example Config As Code:
       "application": "test app",
       "branches": ["develop", "main", "master"],
       "emails": ["xxxx@checkmarx.com"],
-      "bugTracker": "JIRA", // other possible values: "GitLab", "GitHub", "Azure"
-      "scanResubmit": "true", // values: "true" or "false"
-      "sshKeyIdentifier": "Key of the ssh-key-list parameter present in application.yml file."
+      "bugTracker": "JIRA", // other possible values: "GitLab", "GitHub", "Azure",
+      "scanResubmit": "true", // values: "true" or "false",
+      "sshKeyIdentifier": "Key of the ssh-key-list parameter present in application.yml file.",
+      "zipExclude": ".git/.*, src/test/.*, target/.*",
       "jira": {
         "project": "APPSEC",
         "issue_type": "Bug",

--- a/src/main/java/com/checkmarx/flow/dto/FlowOverride.java
+++ b/src/main/java/com/checkmarx/flow/dto/FlowOverride.java
@@ -36,6 +36,8 @@ public class FlowOverride {
     public List<String> vulnerabilityScanners = null;
     @JsonProperty("sshKeyIdentifier")
     public String sshKeyIdentifier;
+    @JsonProperty("zipExclude")
+    public String zipExclude;
     
     public FlowOverride() {
     }
@@ -116,8 +118,20 @@ public class FlowOverride {
         return sshKeyIdentifier;
     }
 
+    public void setZipExclude(String zipExclude) { this.zipExclude = zipExclude; }
+
+    public String getZipExclude() { return zipExclude; }
+
     public String toString() {
-        return "FlowOverride(application=" + this.getApplication() + ", branches=" + this.getBranches() + " emails=" + this.getEmails() + ", jira=" + this.getJira() + ", filters=" + this.getFilters() + "thresholds=" + this.getThresholds() + ", sshKeyIdentifier=" + this.getSshKeyIdentifier() +")";
+        return "FlowOverride(application=" + this.getApplication() +
+                ", branches=" + this.getBranches() +
+                ", emails=" + this.getEmails() +
+                ", jira=" + this.getJira() +
+                ", filters=" + this.getFilters() +
+                ", thresholds=" + this.getThresholds() +
+                ", sshKeyIdentifier=" + this.getSshKeyIdentifier() +
+                ", zipExclude=" + this.getZipExclude() +
+                ")";
     }
 
 

--- a/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/ScanRequest.java
@@ -121,6 +121,9 @@ public class ScanRequest {
     @Getter @Setter
     private CxEmailNotifications emailNotifications;
 
+    @Getter @Setter
+    private String zipExclude;
+
     public ScanRequest(ScanRequest other) {
         this.namespace = other.namespace;
         this.application = other.application;
@@ -166,6 +169,7 @@ public class ScanRequest {
         this.sshKeyIdentifier = other.sshKeyIdentifier;
         this.cliMode = other.cliMode;
         this.emailNotifications = other.emailNotifications;
+        this.zipExclude = other.zipExclude;
     }
 
     public Map<String,String> getAltFields() {

--- a/src/main/java/com/checkmarx/flow/service/AbstractVulnerabilityScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/AbstractVulnerabilityScanner.java
@@ -313,7 +313,8 @@ public abstract class AbstractVulnerabilityScanner implements VulnerabilityScann
             String effectiveProjectName = projectNameGenerator.determineProjectName(request);
             request.setProject(effectiveProjectName);
             overrideScanPreset(request);
-            File zipFile = ZipUtils.zipToTempFile(path, flowProperties.getZipExclude());
+            String zipExclude = request.getZipExclude() != null ? request.getZipExclude() : flowProperties.getZipExclude();
+            File zipFile = ZipUtils.zipToTempFile(path, zipExclude);
             ScanDetails details = executeCxScan(request, zipFile);
             results = getScanResults(request, details.getProjectId(), details.getScanId());
             log.debug("Deleting temp file {}", zipFile.getPath());

--- a/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ConfigurationOverrider.java
@@ -116,7 +116,11 @@ public class ConfigurationOverrider {
         if(!StringUtils.isEmpty(override.getSshKeyIdentifier() ) ) {
             request.setSshKeyIdentifier(override.getSshKeyIdentifier());
         }
-        
+
+        if(!StringUtils.isEmpty(override.getZipExclude() ) ) {
+            request.setZipExclude(override.getZipExclude());
+        }
+
         request.setBugTracker(bt);
         
         Optional.ofNullable(override.getApplication())


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Support the specifying of the `zip-exclude` property via config-as-code. Addresses issue #1043.

- Add a `zipExclude` property to the `FlowOverride` class.
- Add a `zipExclude` property to the `ScanRequest` class.
- Update the `AbstractVulnerabilityScanner` class to use the `request`'s `zipExclude` property, if present.
- Update the `ConfigurationOverrider` class to set the `ScanRequest`'s `zipExclude` property to the value from the `cx.config` file, if present.

The example `cx.config` file in the `Config-As-Code.md` page has been updated accordingly.

### References

See issue #1043.

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Manual testing. The project to be scanned contained the following `cx.config` file:

```
{
    "version": 1.0,
    "additionalProperties": {
        "cxFlow": {
            "zipExclude": "exclude/.*"
        }
    }
}
```

The project also included two directories, `include` and `exclude`.

After running CxFlow with the following command line, looking in the `CxSrc` folder, it was seen that the `exclude` folder had, indeed, been excluded.

```
java -jar ~/Documents/src/cx-flow/build/libs/java11/cx-flow-1.6.35.jar --scan --f=zip-exclude-test --cx-project=ZipExcludeTest --app=ZipExcludeTest
```

The CxFlow log also showed that the property was being respected:

```
2022-06-27 00:15:36.074  INFO 11556 --- [           main] c.c.f.u.ZipUtils                          [45DCxSch] : Applying exclusions: exclude/.*
2022-06-27 00:15:36.078 DEBUG 11556 --- [           main] c.c.f.u.ZipUtils                          [45DCxSch] : Zip Absolute path: C:\Users\cxadmin\Documents\Test\cx.cb0ee906-f37c-4d26-8522-37acd5c82173.zip
2022-06-27 00:15:36.081 DEBUG 11556 --- [           main] c.c.f.u.ZipUtils                          [45DCxSch] : @@@ C:\Users\cxadmin\Documents\Test\cx.cb0ee906-f37c-4d26-8522-37acd5c82173.zip $1 C:\Users\cxadmin\Documents\Test\zip-exclude-test\cx.config @@@
2022-06-27 00:15:36.105 DEBUG 11556 --- [           main] c.c.f.u.ZipUtils                          [45DCxSch] : @@@ C:\Users\cxadmin\Documents\Test\cx.cb0ee906-f37c-4d26-8522-37acd5c82173.zip $1 C:\Users\cxadmin\Documents\Test\zip-exclude-test\exclude\exclude.py @@@
2022-06-27 00:15:36.106 DEBUG 11556 --- [           main] c.c.f.u.ZipUtils                          [45DCxSch] : match: exclude/.*$1exclude/exclude.py
2022-06-27 00:15:36.107 DEBUG 11556 --- [           main] c.c.f.u.ZipUtils                          [45DCxSch] : @@@ C:\Users\cxadmin\Documents\Test\cx.cb0ee906-f37c-4d26-8522-37acd5c82173.zip $1 C:\Users\cxadmin\Documents\Test\zip-exclude-test\include\include.py @@@
2022-06-27 00:15:36.111  INFO 11556 --- [           main] c.c.f.u.ZipUtils                          [45DCxSch] : Successfully created C:\Users\cxadmin\Documents\Test\cx.cb0ee906-f37c-4d26-8522-37acd5c82173.zip
```


### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
- [ ] Verified that SCA and SAST scan results are as expected
