### PR TITLE
Fixed closing and reopening of issues for all bug trackers

### DIFF
--- a/src/main/java/com/checkmarx/flow/service/IssueService.java
+++ b/src/main/java/com/checkmarx/flow/service/IssueService.java
@@ -175,10 +175,23 @@ public class IssueService implements ApplicationContextAware {
                 Issue issue = issueMap.getValue();
                 try {
                     if (!xMap.containsKey(key) && tracker.isIssueOpened(issue, request)) {
-                        /*Close the issue*/
-                        tracker.closeIssue(issue, request);
-                        closedIssues.add(issue.getId());
-                        log.info("Closing issue #{} with key {}", issue.getId(), key);
+                        // According to current issue title creation the SCA issues begins with CX:Title
+                        // and SAST issue title begins with CX Title hence this check works for closing only scanner
+                        // specific issues in bug tracker. If custom label prefix is introduced for any bug tracker then
+                        // this code will have to be updated.
+                        if(results.getScaResults()!= null && key.contains("CX:") ){
+                            /*Close the issue*/
+                            tracker.closeIssue(issue, request);
+                            closedIssues.add(issue.getId());
+                            log.info("Closing issue #{} with key {}", issue.getId(), key);
+                        }
+                        else if(results.getScaResults() == null && key.contains("CX ")) {
+                            /*Close the issue*/
+                            tracker.closeIssue(issue, request);
+                            closedIssues.add(issue.getId());
+                            log.info("Closing issue #{} with key {}", issue.getId(), key);
+                        }
+
                     }
                 } catch (HttpClientErrorException e) {
                     log.error("Error occurred while processing issue with key {}", key, e);

--- a/src/test/resources/cucumber/features/integrationTests/cli/scaCliScan.feature
+++ b/src/test/resources/cucumber/features/integrationTests/cli/scaCliScan.feature
@@ -30,8 +30,8 @@ Feature: SCA support in CxFlow command-line
 
         Examples:
             | filter     | number of issue |
-            | none       | 18              |
-            | High       | 5               |
+            | none       | 19              |
+            | High       | 6               |
             | Medium,Low | 13              |
             | Low        | 2               |
 

--- a/src/test/resources/cucumber/features/integrationTests/sca/scanResultsProcessing.feature
+++ b/src/test/resources/cucumber/features/integrationTests/sca/scanResultsProcessing.feature
@@ -45,14 +45,14 @@ Feature: Cx-Flow SCA Integration permutation tests
 
     Examples:
       | severities    | score | expected_vulnerabilities |
-      | HIGH          | 7.5   | 5                        |
-      | High, medium  | 6.3   | 8                        |
-      | high, invalid | 8.7   | 1                        |
-      |               | 6.4   | 7                        |
+      | HIGH          | 7.5   | 6                        |
+      | High, medium  | 6.3   | 9                        |
+      | high, invalid | 8.7   | 2                        |
+      |               | 6.4   | 8                        |
       | medium        | 0.0   | 11                       |
-      |               | 0.0   | 18                       |
+      |               | 0.0   | 19                       |
       | low           | 0.0   | 2                        |
-      |               | -0.3  | 18                       |
+      |               | -0.3  | 19                       |
 
 
   @SCA_Issues_Creation 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> This PR fixes the issue of bug trackers closing and then reopening issues. When initially both scanners were enabled and issues were created and then consecutive scan was done with only one scanner then the issues of other scanner were closed this is fixed. 

### Testing

> Manually tested all the bug trackers like ADO, GitLab, and GitHub and the issues of one scanner were not closing when a scan with other scanner was initiated. 
 
### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
- [x] Verified that SCA and SAST scan results are as expected
