### PR TITLE
Fixed Summary Issue with multiple vulnerabilities of the same type in the same file

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.5.19"
+        CxSBSDK = "0.5.20"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.7.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.5.19"
+        CxSBSDK = "0.5.20"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.7.0'

--- a/src/main/java/com/checkmarx/flow/utils/HTMLHelper.java
+++ b/src/main/java/com/checkmarx/flow/utils/HTMLHelper.java
@@ -399,7 +399,7 @@ public class HTMLHelper {
         body.append(String.format(ISSUE_BODY, issue.getVulnerability(), issue.getFilename(), branch)).append(CRLF)
                 .append(CRLF);
         if (!ScanUtils.empty(issue.getDescription())) {
-            body.append("*").append(issue.getDescription().trim()).append("*").append(CRLF).append(CRLF);
+            body.append("*").append(issue.getDescription()).append("*").append(CRLF).append(CRLF);
         }
         if (!ScanUtils.empty(issue.getSeverity())) {
             body.append(SEVERITY).append(": ").append(issue.getSeverity()).append(CRLF).append(CRLF);


### PR DESCRIPTION
### Problem

Issue present with multiple vulnerabilities of the same type in same file was not getting generated.

When marked one of them as Not Exploitable and it was still "choosen" for the summary instead of any other vulnerability of the same type in the same file.

### Solution
Currently if multiple vulnerabilities of the same type in same file is present it generates all vulnerablities summary.

When marked one of them as Not Exploitable that summary is not updated 

### References

https://github.com/checkmarx-ltd/cx-flow/issues/914

### Testing

Have tested this issue with 9.4 and 9.5 SAST version on bugTracker as JIRA, GitLab, GitHub.


