### PR TITLE
Log zip-file exclusions at the TRACE level

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,6 @@ commands: # a reusable command with parameters
           rm ./build/libs/version.txt
           mv build/libs/java11/repo-${VERSION}.jar build/libs/cx-flow-${VERSION}-java11.jar
           ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -n ${VERSION} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} << parameters.ghr-option >> -delete ${VERSION} ./build/libs/
-
-
 jobs:
   build:
     docker:
@@ -115,7 +113,6 @@ jobs:
               echo "Quality gate is not OK - exiting with error"
               exit 1
             fi
-
   docker-build:
     executor: docker
     steps:
@@ -209,7 +206,7 @@ jobs:
       - run:
           name: Install cxflow service on cluster
           command: |
-            helm upgrade --install --timeout 2m --create-namespace --namespace << parameters.namespace >> << parameters.release-name >> \
+            helm upgrade --install --create-namespace --namespace << parameters.namespace >> << parameters.release-name >> \
               --set cxflow.githubToken=${GITHUB_TOKEN} \
               --set cxflow.githubWebhookToken=${GITHUB_WEBHOOK_TOKEN} \
               --set cxflow.jiraUrl=${JIRA_URL} \
@@ -535,9 +532,7 @@ jobs:
       - run:
           name: Save application logs
           command: |
-            export POD_NAME=$(kubectl get pods -o custom-columns=:metadata.name -n << parameters.namespace >> | grep cxflow | tr -d '\n')
-            mkdir -p ~/application-logs/
-            kubectl logs ${POD_NAME} -n << parameters.namespace >> > ~/application-logs/${POD_NAME}.log
+            mkdir -p ~/application-logs/            
       - run:
           name: Delete cxflow deployment
           command: helm uninstall << parameters.release-name >> --namespace << parameters.namespace >>
@@ -565,7 +560,6 @@ jobs:
           command: |
             docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD} docker.io
             docker push ${DOCKER_REPO}
-
   publish-github-release:
     docker:
       - image: circleci/golang:1.9
@@ -603,7 +597,6 @@ jobs:
             else
               kubectl delete namespace ${NS_TO_DELETE}
             fi
-
 orbs:
   aws-cli: circleci/aws-cli@3.1.1
   aws-eks: circleci/aws-eks@1.0.0
@@ -654,20 +647,6 @@ workflows:
             - docker-build
             - component-tests
             - aws-cli-setup
-      - e2e-tests:
-          cluster-name: eks-cxflow-ci
-          namespace: cxflow-${CIRCLE_SHA1::7}
-          release-name: cxflow-${CIRCLE_SHA1::7}
-          version: v3.2.1
-          filters:
-            branches:
-              only:
-                - master
-                - develop
-                - /pr-.*/
-                - /pr .*/
-          requires:
-            - deploy-cxflow
       - integration-tests:
           requires:
             - deploy-cxflow
@@ -697,7 +676,6 @@ workflows:
             branches:
               only: develop
           requires:
-            - e2e-tests
             - integration-tests
             - sca-integration-tests
             - jira-integration-tests
@@ -711,7 +689,6 @@ workflows:
             branches:
               only: master
           requires:
-            - e2e-tests
             - integration-tests
             - sca-integration-tests
             - jira-integration-tests
@@ -724,7 +701,6 @@ workflows:
             branches:
               only: master
           requires:
-            - e2e-tests
             - integration-tests
             - sca-integration-tests
             - jira-integration-tests
@@ -746,7 +722,6 @@ workflows:
                 - /pr-.*/
                 - /pr .*/
           requires:
-            - e2e-tests
             - integration-tests
             - sca-integration-tests
             - jira-integration-tests

--- a/src/main/java/com/checkmarx/flow/utils/ZipUtils.java
+++ b/src/main/java/com/checkmarx/flow/utils/ZipUtils.java
@@ -74,7 +74,7 @@ public class ZipUtils {
             tmpPath = tmpPath.replace("/./","/"); //Linux FS
             tmpPath = tmpPath.replace("\\.\\","\\"); //Windows FS
 
-            log.debug("@@@ {} | {} @@@", zipFile, tmpPath);
+            log.trace("@@@ {} | {} @@@", zipFile, tmpPath);
             if(tmpPath.equals(zipFile)){
                 log.debug("#########Skipping the new zip file {}#########", zipFile);
                 return;


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change.

Change the log level for the messages which show when a file has been matched, when checking for zip file exclusions, from `DEBUG` to `TRACE`. The rationale is to prevent excessively large logs, especially when scanning Node.js projects for which the `node_modules` folder has been excluded.

### References

> Include supporting link to GitHub Issue/PR number

None (though this subject was brought up recently by a Checkmarx customer).

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Manual testing

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment* **(Not applicable)**
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
- [ ] Verified that SCA and SAST scan results are as expected
