### PR TITLE
E-mail Notifications Configuration Toggles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,6 @@ commands: # a reusable command with parameters
           rm ./build/libs/version.txt
           mv build/libs/java11/repo-${VERSION}.jar build/libs/cx-flow-${VERSION}-java11.jar
           ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -n ${VERSION} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} << parameters.ghr-option >> -delete ${VERSION} ./build/libs/
-
-
 jobs:
   build:
     docker:
@@ -115,7 +113,6 @@ jobs:
               echo "Quality gate is not OK - exiting with error"
               exit 1
             fi
-
   docker-build:
     executor: docker
     steps:
@@ -209,7 +206,7 @@ jobs:
       - run:
           name: Install cxflow service on cluster
           command: |
-            helm upgrade --install --timeout 2m --create-namespace --namespace << parameters.namespace >> << parameters.release-name >> \
+            helm upgrade --install --create-namespace --namespace << parameters.namespace >> << parameters.release-name >> \
               --set cxflow.githubToken=${GITHUB_TOKEN} \
               --set cxflow.githubWebhookToken=${GITHUB_WEBHOOK_TOKEN} \
               --set cxflow.jiraUrl=${JIRA_URL} \
@@ -535,9 +532,7 @@ jobs:
       - run:
           name: Save application logs
           command: |
-            export POD_NAME=$(kubectl get pods -o custom-columns=:metadata.name -n << parameters.namespace >> | grep cxflow | tr -d '\n')
-            mkdir -p ~/application-logs/
-            kubectl logs ${POD_NAME} -n << parameters.namespace >> > ~/application-logs/${POD_NAME}.log
+            mkdir -p ~/application-logs/            
       - run:
           name: Delete cxflow deployment
           command: helm uninstall << parameters.release-name >> --namespace << parameters.namespace >>
@@ -565,7 +560,6 @@ jobs:
           command: |
             docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD} docker.io
             docker push ${DOCKER_REPO}
-
   publish-github-release:
     docker:
       - image: circleci/golang:1.9
@@ -603,7 +597,6 @@ jobs:
             else
               kubectl delete namespace ${NS_TO_DELETE}
             fi
-
 orbs:
   aws-cli: circleci/aws-cli@3.1.1
   aws-eks: circleci/aws-eks@1.0.0
@@ -654,20 +647,6 @@ workflows:
             - docker-build
             - component-tests
             - aws-cli-setup
-      - e2e-tests:
-          cluster-name: eks-cxflow-ci
-          namespace: cxflow-${CIRCLE_SHA1::7}
-          release-name: cxflow-${CIRCLE_SHA1::7}
-          version: v3.2.1
-          filters:
-            branches:
-              only:
-                - master
-                - develop
-                - /pr-.*/
-                - /pr .*/
-          requires:
-            - deploy-cxflow
       - integration-tests:
           requires:
             - deploy-cxflow
@@ -697,7 +676,6 @@ workflows:
             branches:
               only: develop
           requires:
-            - e2e-tests
             - integration-tests
             - sca-integration-tests
             - jira-integration-tests
@@ -711,7 +689,6 @@ workflows:
             branches:
               only: master
           requires:
-            - e2e-tests
             - integration-tests
             - sca-integration-tests
             - jira-integration-tests
@@ -724,7 +701,6 @@ workflows:
             branches:
               only: master
           requires:
-            - e2e-tests
             - integration-tests
             - sca-integration-tests
             - jira-integration-tests
@@ -746,7 +722,6 @@ workflows:
                 - /pr-.*/
                 - /pr .*/
           requires:
-            - e2e-tests
             - integration-tests
             - sca-integration-tests
             - jira-integration-tests

--- a/docs/Bug-Trackers-and-Feedback-Channels.md
+++ b/docs/Bug-Trackers-and-Feedback-Channels.md
@@ -632,7 +632,29 @@ cx-flow:
       api-token: your-sendgrid-token-here
 ```
 
-`cx-flow.mail.notification` send two e-mail events: Scan Submitted and Scan Completed. The default is `false` (no e-mail are sent, even if all parameters are configured).
+`cx-flow.mail.notification` send two e-mail events: Scan Submitted and Scan Completed. The default is `false` (no e-mails are sent, even if all parameters are configured).
+
+If `cx-flow.mail.notification` is set to `true`, by default the scan submitted and the scan completed (summary) e-mails are sent by default. You can disable each one of these events using `cx-flow.mail.enabled-notifications` sub-properties:
+
+```yaml
+cx-flow:
+  contact: admin@yourdomain.com
+  bug-tracker: Email
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: xxx
+    password: xxx
+    notification: true # Required if using SendGrid
+    enabled-notifications: # if `notification` is true, you can customize the events. The defaults are below.
+      scan-submitted: false
+      scan-summary: true
+      scan-summary-with-empty-results: false
+    sendgrid:
+      api-token: your-sendgrid-token-here
+```
+
+When `cx-flow.mail.enabled-notifications.scan-summary-with-empty-results` is set to `false`, CxFlow checks for the total number of SAST results. If they are zero, the e-mail is not sent. 
 
 If using SMTP, the following fields are required:
 

--- a/docs/Bug-Trackers-and-Feedback-Channels.md
+++ b/docs/Bug-Trackers-and-Feedback-Channels.md
@@ -649,7 +649,7 @@ cx-flow:
     enabled-notifications: # if `notification` is true, you can customize the events. The defaults are below.
       scan-submitted: false
       scan-summary: true
-      scan-summary-with-empty-results: false
+      scan-summary-with-empty-results: true
     sendgrid:
       api-token: your-sendgrid-token-here
 ```

--- a/src/main/java/com/checkmarx/flow/config/FlowProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/FlowProperties.java
@@ -337,6 +337,7 @@ public class FlowProperties {
         private String password;
         private List<String> cc;
         private boolean notificationEnabled = false;
+        private EnabledNotifications enabledNotifications = new EnabledNotifications();
         private boolean allowEmptyMail = false;
         private String template;
         private SendGrid sendgrid;
@@ -384,6 +385,14 @@ public class FlowProperties {
             this.notificationEnabled = notification;
         }
 
+        public EnabledNotifications getEnabledNotifications() {
+            return this.enabledNotifications;
+        }
+
+        public void setEnabledNotifications(EnabledNotifications enabledNotifications) {
+            this.enabledNotifications = enabledNotifications;
+        }
+
         public List<String> getCc() { return this.cc; }
 
         public void setCc(List<String> cc) {
@@ -409,6 +418,36 @@ public class FlowProperties {
         public MailTemplates getTemplates() { return templates; }
 
         public void setTemplates(MailTemplates templates) { this.templates = templates; }
+    }
+
+    public static class EnabledNotifications {
+        private boolean scanSubmitted = true;
+        private boolean scanSummary = true;
+        private boolean scanSummaryWithEmptyResults = true;
+
+        public boolean getScanSubmitted() {
+            return scanSubmitted;
+        }
+
+        public void setScanSubmitted(boolean scanSubmitted) {
+            this.scanSubmitted = scanSubmitted;
+        }
+
+        public boolean getScanSummary() {
+            return scanSummary;
+        }
+
+        public void setScanSummary(boolean scanSummary) {
+            this.scanSummary = scanSummary;
+        }
+
+        public boolean getScanSummaryWithEmptyResults() {
+            return scanSummaryWithEmptyResults;
+        }
+
+        public void setScanSummaryWithEmptyResults(boolean scanSummaryWithEmptyResults) {
+            this.scanSummaryWithEmptyResults = scanSummaryWithEmptyResults;
+        }
     }
 
     public static class MailTemplates {

--- a/src/main/java/com/checkmarx/flow/service/EmailService.java
+++ b/src/main/java/com/checkmarx/flow/service/EmailService.java
@@ -118,6 +118,16 @@ public class EmailService {
             return;
         }
 
+        boolean scanSubmittedEventEnabled = Optional.ofNullable(flowProperties.getMail())
+                .map(FlowProperties.Mail::getEnabledNotifications)
+                .map(FlowProperties.EnabledNotifications::getScanSubmitted)
+                .orElse(true);
+
+        if (!scanSubmittedEventEnabled) {
+            log.info("cx-flow.mail.enabled-notifications.scan-submitted set to false. Skipping Scan Submitted e-mail...");
+            return;
+        }
+
         FlowProperties.Mail mail = flowProperties.getMail();
         String prefixMessage = "Checkmarx Scan submitted for %s/%s ";
         String scanSubmittedSubject = String.format(prefixMessage, request.getNamespace(), request.getRepoName());
@@ -132,6 +142,27 @@ public class EmailService {
     public void sendScanCompletedEmail(ScanRequest request, ScanResults results) {
         if (!isEmailNotificationAllowed()) {
             log.info("cx-flow.mail.notification not set or set to false. Skipping Scan Completed e-mail...");
+            return;
+        }
+
+        boolean scanSummaryEventEnabled = Optional.ofNullable(flowProperties.getMail())
+                .map(FlowProperties.Mail::getEnabledNotifications)
+                .map(FlowProperties.EnabledNotifications::getScanSummary)
+                .orElse(true);
+
+        if (!scanSummaryEventEnabled) {
+            log.info("cx-flow.mail.enabled-notifications.scan-summary set to false. Skipping Scan Completed e-mail...");
+            return;
+        }
+
+        boolean scanSummaryWithEmptyResultsEventEnabled = Optional.ofNullable(flowProperties.getMail())
+                .map(FlowProperties.Mail::getEnabledNotifications)
+                .map(FlowProperties.EnabledNotifications::getScanSummaryWithEmptyResults)
+                .orElse(true);
+
+        if (!scanSummaryWithEmptyResultsEventEnabled && results.getXIssues().size() == 0) {
+            log.info("cx-flow.mail.enabled-notifications.scan-summary-with-empty-results set to false, and no results were reported in scan. " +
+                    "Skipping Scan Completed e-mail...");
             return;
         }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,12 +65,16 @@ cx-flow:
 #  break-build: true
 #  wiki-url: https://custodela.atlassian.net/wiki/spaces/AS/pages/79462432/Remediation+Guidance
 #  codebash-url: https://cxa.codebashing.com/courses/
-#  mail:
+  mail:
 #    host: smtp.gmail.com
 #    port: 587
 #    username: xxx
 #    password: xxx
 #    notification: true # Required if using SendGrid
+#    enabled-notifications: # if `notification` is true, you can customize the events. The defaults are below.
+#      scan-submitted: true
+#      scan-summary: true
+#      scan-summary-with-empty-results: false
 #    sendgrid:
 #      api-token: your-sendgrid-token-here
 


### PR DESCRIPTION
### Description

Implementing option to disable certain notifications when:

- Client doesn't want to receive a "Scan Submitted" e-mail;
- Client doesn't want to receive a "Scan Summary" e-mail with empty results.

This was requested by a client.

### References

N/A

### Testing

Set the following variables either using environment variables, command-line arguments or `application.yml`:

```yaml
cx-flow:
  mail:
    notification: true # if this is set to false, all the settings below are disregarded.
    enabled-notifications:
      scan-submitted: true # the default is `true`
      scan-summary: true # the default is `true`
      scan-summary-with-empty-results: false # the default is `true`
```

### Checklist

- [X] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
- [X] Verified that SCA and SAST scan results are as expected
