### PR TITLE
Disregarding Lows and Infos for the e-mail summary.

### DIFF
--- a/docs/Bug-Trackers-and-Feedback-Channels.md
+++ b/docs/Bug-Trackers-and-Feedback-Channels.md
@@ -669,7 +669,7 @@ cx-flow:
       api-token: your-sendgrid-token-here
 ```
 
-When `cx-flow.mail.enabled-notifications.scan-summary-with-empty-results` is set to `false`, CxFlow checks for the total number of SAST results. If they are zero, the e-mail is not sent. 
+When `cx-flow.mail.enabled-notifications.scan-summary-with-empty-results` is set to `false`, CxFlow checks for the total number of SAST **high and medium** results. If they are zero, the e-mail is not sent. 
 
 If using SMTP, the following fields are required:
 

--- a/src/main/java/com/checkmarx/flow/service/EmailService.java
+++ b/src/main/java/com/checkmarx/flow/service/EmailService.java
@@ -19,10 +19,8 @@ import org.thymeleaf.context.Context;
 
 import javax.validation.constraints.NotNull;
 import java.beans.ConstructorProperties;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -160,8 +158,12 @@ public class EmailService {
                 .map(FlowProperties.EnabledNotifications::getScanSummaryWithEmptyResults)
                 .orElse(true);
 
-        if (!scanSummaryWithEmptyResultsEventEnabled && results.getXIssues().size() == 0) {
-            log.info("cx-flow.mail.enabled-notifications.scan-summary-with-empty-results set to false, and no results were reported in scan. " +
+        List<ScanResults.XIssue> highsAndMediums = results.getXIssues().stream()
+                .filter(i -> Arrays.asList("high", "medium").contains(i.getSeverity().toLowerCase()))
+                .collect(Collectors.toList());
+
+        if (!scanSummaryWithEmptyResultsEventEnabled && highsAndMediums.size() == 0) {
+            log.info("cx-flow.mail.enabled-notifications.scan-summary-with-empty-results set to false, and no high and medium results were reported in scan. " +
                     "Skipping Scan Completed e-mail...");
             return;
         }


### PR DESCRIPTION
### Description

Client asked to remove lows and mediums from summary e-mail. 

### References

N/A

### Testing

Set the following variables either using environment variables, command-line arguments or `application.yml`:

```yaml
cx-flow:
  mail:
    notification: true # if this is set to false, all the settings below are disregarded.
    enabled-notifications:
      scan-submitted: true # the default is `true`
      scan-summary: true # the default is `true`
      scan-summary-with-empty-results: false # the default is `true`
```

Make sure to scan a project that have no highs and mediums, and then another project that has highs and mediums.

### Checklist

- [X] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
- [X] Verified that SCA and SAST scan results are as expected
