### PR TITLE
CXFLW-540 Fixed Jira team issue for sca

### DIFF
--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -1137,7 +1137,14 @@ public class JiraService {
         displayedParametersMap.put("*Repository Url:* ", request.getRepoUrl());
         displayedParametersMap.put("*Application:* ", request.getApplication());
         displayedParametersMap.put("*Cx-Project:* ", request.getProject());
-        displayedParametersMap.put("*Cx-Team:* ", request.getTeam());
+        if(issue.getScaDetails()!=null)
+        {
+            displayedParametersMap.put("*Cx-Team:* ", request.getScaConfig().getTeam());
+        }
+        else
+        {
+            displayedParametersMap.put("*Cx-Team:* ", request.getTeam());
+        }
         displayedParametersMap.put("*Severity:* ", issue.getSeverity());
         displayedParametersMap.put("*CWE:* ", issue.getCwe());
         displayedParametersMap.put("*Status:* ", issue.getVulnerabilityStatus());


### PR DESCRIPTION

### Description

When running CxFlow with
enabled-vulnerability-scanners:
- SCA
- SAST

and teams are different between SCA and SAST

sca:
team: "/CxServer/sast"

checkmarx:
team: /CxServer/sca

SCA tickets in Jira contains
Cx-Team: /CxServer/sast"

Instead, if only running SCA, SCA Jira tickets do not contain any Cx-Team data (i.e. Cx-Team does not appear)

### References

https://github.com/checkmarx-ltd/cx-flow/issues/1033


