### PR TITLE
Pr cxflw 175 secondary rate limit

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -712,7 +712,7 @@ github:
 | `block-merge`            | false     | When triggering scans based on PullRequest, this will create a new status of pending, which will block the merge ability until the scan is complete in Checkmarx.                                                 |
 | `scan-submitted-comment` | true      | Comment on PullRequest with "Scan submitted (or not submitted) to Checkmarx ...".                                                                                                                                 | 
 | `max-description-length` | 50000     | Manages number of characters to view in issue description.(value should be greater than 4 and less than 50000)                                                                                                    |
-| `max-delay`              |           | When Secondary rate limit is hit, it will delay each api call for issue creation(Mininum value should be 3)                                                                                                       |
+| `max-delay`              |           | When Secondary rate limit is hit, it will delay each API call for issue creation(Mininum value should be 3)                                                                                                       |
 **Note**: A service account is required with access to the repositories that will be scanned, pull requests that will be commented on, and GitHub issues that will be created/updated.
 
 ### <a name="gitlab">GitLab</a>

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -698,19 +698,21 @@ github:
    block-merge: true
    detailed: false
    scan-submitted-comment: false
-   max-description-length : <should be less than 50000>
+   max-description-length : <should be greater than 4 and less than 50000>
+   max-delay : <minimum value should be 3>
 ```
 
-| Configuration            | Default        | Description                                                                                                                                                                                                      |
-|--------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `webhook-token`          |                | Token used as a shared secret when calling the CxFlow WebHook WebService.  It authenticates users for the request. GitHub signs the request with this value, and the signature is validated on the receiving end. |
-| `token`                  |                | The API token with access to the repository, with at least Read only access to the code, the ability to add comments to pull requests, and the ability to create GitHub Issues.                                  |
-| `url`                    |                | Main repo url for GitHub                                                                                                                                                                                         |
-| `api-url`                |                | The API endpoint for GitHub, which is a different context or potentially FQDN than the main repo url.                                                                                                            
-| `false-positive-label`   | false-positive | A label that can be defined within the GitHub Issue feedback that is used to ignore issues                                                                                                                       |
-| `block-merge`            | false          | When triggering scans based on PullRequest, this will create a new status of pending, which will block the merge ability until the scan is complete in Checkmarx.                                                |
-| `scan-submitted-comment` | true           | Comment on PullRequest with "Scan submitted (or not submitted) to Checkmarx ...".                                                                                                                                | 
-| `max-description-length` | 50000          | Manages number of characters to view in issue description.(value should be greater than 4 and less than 50000)                                                                                                   |
+| Configuration            | Default   | Description                                                                                                                                                                                                       |
+|--------------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `webhook-token`          |           | Token used as a shared secret when calling the CxFlow WebHook WebService.  It authenticates users for the request. GitHub signs the request with this value, and the signature is validated on the receiving end. |
+| `token`                  |           | The API token with access to the repository, with at least Read only access to the code, the ability to add comments to pull requests, and the ability to create GitHub Issues.                                   |
+| `url`                    |           | Main repo url for GitHub                                                                                                                                                                                          |
+| `api-url`                |           | The API endpoint for GitHub, which is a different context or potentially FQDN than the main repo url.                                                                                                             
+| `false-positive-label`   | false-positive | A label that can be defined within the GitHub Issue feedback that is used to ignore issues                                                                                                                        |
+| `block-merge`            | false     | When triggering scans based on PullRequest, this will create a new status of pending, which will block the merge ability until the scan is complete in Checkmarx.                                                 |
+| `scan-submitted-comment` | true      | Comment on PullRequest with "Scan submitted (or not submitted) to Checkmarx ...".                                                                                                                                 | 
+| `max-description-length` | 50000     | Manages number of characters to view in issue description.(value should be greater than 4 and less than 50000)                                                                                                    |
+| `max-delay`              |           | When Secondary rate limit is hit, it will delay each api call for issue creation(Mininum value should be 3)                                                                                                       |
 **Note**: A service account is required with access to the repositories that will be scanned, pull requests that will be commented on, and GitHub issues that will be created/updated.
 
 ### <a name="gitlab">GitLab</a>

--- a/src/main/java/com/checkmarx/flow/config/GitHubProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/GitHubProperties.java
@@ -30,6 +30,10 @@ public class GitHubProperties extends RepoProperties {
     @Setter
     private int maxDescriptionLength =50000;
 
+    @Getter
+    @Setter
+    private int maxDelay;
+
     public String getMergeNoteUri(String namespace, String repo, String mergeId){
         String format = "%s/%s/%s/issues/%s/comments";
         return String.format(format, getApiUrl(), namespace, repo, mergeId);


### PR DESCRIPTION

### Description

The default 'create issue' API in GitHub is very strict about rate limits. We consistently get a 'secondary rate limit error' after creating ~20 issues. To avoid the error, we need to make a ~3s delay between requests.

### Testing

Tested on SAST 9.4 with bug Tracker as GitHub


