### PR TITLE
CxFlow (GH 950): Map latest scan custom fields to JIRA fields

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.5.23"
+        CxSBSDK = "0.5.24"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.7.0'

--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.5.22"
+        CxSBSDK = "0.5.23"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.7.0'

--- a/build-11.gradle
+++ b/build-11.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
 	ext {
-        CxSBSDK = "0.5.24"
+        CxSBSDK = "0.5.23"
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"
         springBootVersion = '2.7.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.5.23"
+        CxSBSDK = "0.5.24"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.7.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.5.22"
+        CxSBSDK = "0.5.23"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.7.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        CxSBSDK = "0.5.24"
+        CxSBSDK = "0.5.23"
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"
         springBootVersion = '2.7.0'

--- a/docs/Bug-Trackers-and-Feedback-Channels.md
+++ b/docs/Bug-Trackers-and-Feedback-Channels.md
@@ -106,9 +106,13 @@ jira:
       - Use_Of_Hardcoded_Password
    fields:
 #    - type: cx #[ cx | static | result ]
-#      name: Platform # cx custom field name | cwe, category, severity, application, *project*, repo-name, branch, repo-url, namespace, recommendations, loc, site, issueLink, filename, language
+#      name: Platform # cx custom field name | cx-scan | cwe, category, severity, application, *project*, repo-name, branch, repo-url, namespace, recommendations, loc, site, issueLink, filename, language
 #      jira-field-name: Application
 #      jira-field-type: label #[ security | text | label | single-select | multi-select ]
+     - type: cx
+       name: cx-scan
+       jira-field-name: Application
+       jira-field-type: label
      - type: result
        name: application
        jira-field-name: Application
@@ -213,7 +217,7 @@ Note that CxFlow ignores case when comparing statuses.
   * **static**: Used for static values (specifically requires a jira-default-value to be provided)
   * **cx**: Used to map specific Checkmarx Custom Field values
   * **result**: Used to map known values from Checkmarx results or repository/scan request details.  Refer to the Result values below.
-* **name**: If cx reflects the type, it is the name of the custom field within Checkmarx
+* **name**: If cx reflects the type, it is the name of the custom field within Checkmarx.Also, **cx-scan** is the scan custom fields in type cx.
   * If **result** is provided as type, the name must be one of the following:
 
 ```

--- a/src/main/java/com/checkmarx/flow/service/IastService.java
+++ b/src/main/java/com/checkmarx/flow/service/IastService.java
@@ -181,7 +181,8 @@ public class IastService {
             boolean htmlDescription = false;
             switch (request.getBugTracker().getType()) {
                 case JIRA:
-                    String jiraIssue = postIssueToJira(scanVulnerabilities, request, scansResultQuery, vulnerability, scan);
+                    ScanResults results = null;
+                    String jiraIssue = postIssueToJira(results, scanVulnerabilities, request, scansResultQuery, vulnerability, scan);
                     if (jiraService.getJiraProperties() != null) {
                         log.info("Create jira issue: " + jiraService.getJiraProperties().getUrl() + "/browse/" + jiraIssue);
                     }
@@ -309,14 +310,14 @@ public class IastService {
         return result.toString();
     }
 
-    private String postIssueToJira(ScanVulnerabilities scanVulnerabilities,
+    private String postIssueToJira(ScanResults results, ScanVulnerabilities scanVulnerabilities,
                                    ScanRequest request,
                                    ResultInfo scansResultQuery,
                                    VulnerabilityInfo vulnerability,
                                    Scan scan) throws JiraClientException {
 
         ScanResults.XIssue xIssue = generateXIssue(scanVulnerabilities, scansResultQuery, scan, vulnerability, false);
-        return jiraService.createIssue(xIssue, request);
+        return jiraService.createIssue(results, xIssue, request);
     }
 
     private String generateIastLinkToVulnerability(ScanVulnerabilities scanVulnerabilities,

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/cli/iast/IastCliSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/cli/iast/IastCliSteps.java
@@ -20,6 +20,7 @@ import com.checkmarx.flow.exception.IastThresholdsSeverityException;
 import com.checkmarx.flow.exception.MachinaException;
 import com.checkmarx.flow.service.*;
 import com.checkmarx.jira.JiraTestUtils;
+import com.checkmarx.sdk.dto.ScanResults;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -267,7 +268,7 @@ public class IastCliSteps {
         IssueTracker issueTracker = null;
         switch (bugTracker) {
             case "jira":
-                verify(jiraService, times(createdIssues)).createIssue(any(), any());
+                verify(jiraService, times(createdIssues)).createIssue(any(), any(), any());
                 return;
             case "github":
                 issueTracker = gitHubIssueTracker;
@@ -286,7 +287,7 @@ public class IastCliSteps {
 
 
     private void mockServiceCreateIssue() throws MachinaException {
-        when(jiraService.createIssue(any(), any())).thenReturn("BCB-202");
+        when(jiraService.createIssue(any(), any(), any())).thenReturn("BCB-202");
 
         when(gitHubIssueTracker.createIssue(any(), any())).thenReturn(mock(Issue.class));
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR adds mapping of scan-level custom fields to JIRA. Scan Custom Fields can be added with type 'cx' and name 'cx-scan' in the configuration file.

### References
#950 

### Testing
Manual Testing using JIRA as bug tracker. 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
- [x] Verified that SCA and SAST scan results are as expected
