### PR TITLE
CXFLW-573 GitLab merge requests create an endless loop of scans #1079

### DIFF
--- a/src/main/java/com/checkmarx/flow/controller/GitLabController.java
+++ b/src/main/java/com/checkmarx/flow/controller/GitLabController.java
@@ -85,6 +85,15 @@ public class GitLabController extends WebhookController {
                         .success(true)
                         .build());
             }
+            else if(body.getChanges().getTitle() != null && body.getChanges().getTitle().getCurrent() != null &&
+                    (body.getChanges().getTitle().getCurrent().startsWith("WIP:CX|")))  {
+                log.info("Merge requested not processed.  Title is WIP:CX|");
+
+                return ResponseEntity.status(HttpStatus.OK).body(EventResponse.builder()
+                        .message("No processing occurred for updates to Merge Request")
+                        .success(true)
+                        .build());
+            }
             String app = body.getRepository().getName();
             if(StringUtils.isNotEmpty(controllerRequest.getApplication())){
                 app = controllerRequest.getApplication();
@@ -144,6 +153,7 @@ public class GitLabController extends WebhookController {
                     .filter(filter)
                     .organizationId(getOrganizationId(proj))
                     .gitUrl(gitUrl)
+                    .scanResubmit(String.valueOf(flowProperties.getScanResubmit()))
                     .hash(objectAttributes.getLastCommit().getId())
                     .build();
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Fixed endless loops of scan during gitlab merge request.

### References

#1079

### Testing

Manual Testing using Gitlab Merge Request using sast and sca.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
- [x] Verified that SCA and SAST scan results are as expected
