### PR TITLE
Jira 9 support added

### DIFF
--- a/docs/Prerequisites-and-Requirements.md
+++ b/docs/Prerequisites-and-Requirements.md
@@ -1,14 +1,14 @@
 The following applications are required:
 
-| Software | Version | Notes                                                                                                                        |
-| -------- | ------- |------------------------------------------------------------------------------------------------------------------------------|
-| **Java Runtime** | 8, 11 | Specific builds exist for both Java 8 and 11, or higher version. CxFlow can run anywhere with Java 1.8/11+ Runtime available |
-| **CxSAST** | 8.8, 8.9, 9.x | CxFlow uses Checkmarx's REST APIs, available for version 8.8 and higher                                                      |
-| **Jira** | 6.4, 7.x, 8 | Jira Cloud and Software have been tested                                                                                     |
-| **GitHub** | Cloud and Enterprise supported versions | Both WebHook and Issue integration                                                                                           |
+| Software | Version                                            | Notes                                                                                                                        |
+| -------- |----------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| **Java Runtime** | 8, 11                                              | Specific builds exist for both Java 8 and 11, or higher version. CxFlow can run anywhere with Java 1.8/11+ Runtime available |
+| **CxSAST** | 8.8, 8.9, 9.x                                      | CxFlow uses Checkmarx's REST APIs, available for version 8.8 and higher                                                      |
+| **Jira** | 6.4, 7.x, 8.x, 9.x                                 | Jira Cloud and Software have been tested                                                                                     |
+| **GitHub** | Cloud and Enterprise supported versions            | Both WebHook and Issue integration                                                                                           |
 | **GitLab** | Cloud, Community and Enterprise supported versions | Both WebHook and Issue integration                                                                                           |
-| **BitBucket** | Cloud, Server (version 7.2 and higher) | WebHook                                                                                                                      |
-| **Azure DevOps** | Cloud, Server 2019, TFS Server 2018 | Both WebHook and WorkItem integration                                                                                        |
+| **BitBucket** | Cloud, Server (version 7.2 and higher)             | WebHook                                                                                                                      |
+| **Azure DevOps** | Cloud, Server 2019, TFS Server 2018                | Both WebHook and WorkItem integration                                                                                        |
 
 ## Additional Requirements
 * The server requirements depend on your use case. The minimum requirements are: 2 core, 4GB RAM and 20GB disk space

--- a/src/main/java/com/checkmarx/flow/config/JiraProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/JiraProperties.java
@@ -55,6 +55,7 @@ public class JiraProperties {
     private String sastIssueSummaryFormat = "[PREFIX][VULNERABILITY] @ [FILENAME][POSTFIX]";
     private String sastIssueSummaryBranchFormat = "[PREFIX][VULNERABILITY] @ [FILENAME] [[BRANCH]][POSTFIX]";
     private List<String> suppressCodeSnippets;
+    //dynamically set
     @Getter @Setter
     private String Version;
     @Getter @Setter

--- a/src/main/java/com/checkmarx/flow/config/JiraProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/JiraProperties.java
@@ -55,6 +55,10 @@ public class JiraProperties {
     private String sastIssueSummaryFormat = "[PREFIX][VULNERABILITY] @ [FILENAME][POSTFIX]";
     private String sastIssueSummaryBranchFormat = "[PREFIX][VULNERABILITY] @ [FILENAME] [[BRANCH]][POSTFIX]";
     private List<String> suppressCodeSnippets;
+    @Getter @Setter
+    private String Version;
+    @Getter @Setter
+    private String DeployType;
 
     public String getUrl() {
         return this.url;

--- a/src/main/java/com/checkmarx/flow/jira9X/FieldSchema.java
+++ b/src/main/java/com/checkmarx/flow/jira9X/FieldSchema.java
@@ -1,0 +1,110 @@
+
+package com.checkmarx.flow.jira9X;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+        "type",
+        "system",
+        "items",
+        "custom",
+        "customId"
+})
+public class FieldSchema  {
+    @JsonProperty("type")
+    private String type;
+    @JsonProperty("system")
+    private String system;
+    @JsonProperty("items")
+    private String items;
+    @JsonProperty("custom")
+    private String custom;
+    @JsonProperty("customId")
+    private Long customId;
+
+    @JsonProperty("type")
+    public String getType() {
+        return type;
+    }
+
+    @JsonProperty("type")
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @JsonProperty("system")
+    public String getSystem() {
+        return system;
+    }
+
+    @JsonProperty("system")
+    public void setSystem(String system) {
+        this.system = system;
+    }
+
+    @JsonProperty("items")
+    public String getItems() {
+        return items;
+    }
+
+    @JsonProperty("items")
+    public void setItems(String items) {
+        this.items = items;
+    }
+
+    @JsonProperty("custom")
+    public String getCustom() {
+        return custom;
+    }
+
+    @JsonProperty("custom")
+    public void setCustom(String custom) {
+        this.custom = custom;
+    }
+
+    @JsonProperty("customId")
+    public Long getCustomId() {
+        return customId;
+    }
+
+    @JsonProperty("customId")
+    public void setCustomId(Long customId) {
+        this.customId = customId;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(FieldSchema.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+        sb.append("type");
+        sb.append('=');
+        sb.append(((this.type == null)?"<null>":this.type));
+        sb.append(',');
+        sb.append("system");
+        sb.append('=');
+        sb.append(((this.system == null)?"<null>":this.system));
+        sb.append(',');
+        sb.append("items");
+        sb.append('=');
+        sb.append(((this.items == null)?"<null>":this.items));
+        sb.append(',');
+        sb.append("custom");
+        sb.append('=');
+        sb.append(((this.custom == null)?"<null>":this.custom));
+        sb.append(',');
+        sb.append("customId");
+        sb.append('=');
+        sb.append(((this.customId == null)?"<null>":this.customId));
+        sb.append(',');
+        if (sb.charAt((sb.length()- 1)) == ',') {
+            sb.setCharAt((sb.length()- 1), ']');
+        } else {
+            sb.append(']');
+        }
+        return sb.toString();
+    }
+
+}

--- a/src/main/java/com/checkmarx/flow/jira9X/IssueFields.java
+++ b/src/main/java/com/checkmarx/flow/jira9X/IssueFields.java
@@ -1,0 +1,186 @@
+
+package com.checkmarx.flow.jira9X;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+        "required",
+        "schema",
+        "name",
+        "fieldId",
+        "autoCompleteUrl",
+        "hasDefaultValue",
+        "operations",
+        "allowedValues",
+        "defaultValue"
+})
+
+public class IssueFields {
+    @JsonProperty("required")
+    private Boolean required;
+    @JsonProperty("schema")
+    private com.checkmarx.flow.jira9X.FieldSchema schema;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("fieldId")
+    private String fieldId;
+    @JsonProperty("autoCompleteUrl")
+    private URI autoCompleteUrl;
+    @JsonProperty("hasDefaultValue")
+    private Boolean hasDefaultValue;
+    @JsonProperty("operations")
+    private Set<com.checkmarx.flow.jira9X.StandardOperation> operations = null;
+    @JsonProperty("allowedValues")
+    private Iterable<Object> allowedValues = null;
+
+    @JsonProperty("defaultValue")
+    private Map<String, URI> defaultValue;
+
+    @JsonProperty("required")
+    public Boolean getRequired() {
+        return required;
+    }
+
+    @JsonProperty("required")
+    public void setRequired(Boolean required) {
+        this.required = required;
+    }
+
+    @JsonProperty("schema")
+    public com.checkmarx.flow.jira9X.FieldSchema getSchema() {
+        return schema;
+    }
+
+    @JsonProperty("schema")
+    public void setSchema(FieldSchema schema) {
+        this.schema = schema;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonProperty("fieldId")
+    public String getFieldId() {
+        return fieldId;
+    }
+
+    @JsonProperty("fieldId")
+    public void setFieldId(String fieldId) {
+        this.fieldId = fieldId;
+    }
+
+    @JsonProperty("autoCompleteUrl")
+    public URI getAutoCompleteUrl() {
+        return autoCompleteUrl;
+    }
+
+    @JsonProperty("autoCompleteUrl")
+    public void setAutoCompleteUrl(URI autoCompleteUrl) {
+        this.autoCompleteUrl = autoCompleteUrl;
+    }
+
+    @JsonProperty("hasDefaultValue")
+    public Boolean getHasDefaultValue() {
+        return hasDefaultValue;
+    }
+
+    @JsonProperty("hasDefaultValue")
+    public void setHasDefaultValue(Boolean hasDefaultValue) {
+        this.hasDefaultValue = hasDefaultValue;
+    }
+
+    @JsonProperty("operations")
+    public Set<com.checkmarx.flow.jira9X.StandardOperation> getOperations() {
+        return operations;
+    }
+
+    @JsonProperty("operations")
+    public void setOperations(Set<com.checkmarx.flow.jira9X.StandardOperation> operations) {
+        this.operations = operations;
+    }
+
+    @JsonProperty("allowedValues")
+    public Iterable<Object> getAllowedValues() {
+        return allowedValues;
+    }
+
+    @JsonProperty("allowedValues")
+    public void setAllowedValues(Iterable<Object> allowedValues) {
+        this.allowedValues = allowedValues;
+    }
+
+    @JsonProperty("defaultValue")
+    public Map<String, URI> getDefaultValue() {
+        return defaultValue;
+    }
+
+    @JsonProperty("defaultValue")
+    public void setDefaultValue(Map<String, URI> defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(IssueFields.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+        sb.append("required");
+        sb.append('=');
+        sb.append(((this.required == null)?"<null>":this.required));
+        sb.append(',');
+        sb.append("schema");
+        sb.append('=');
+        sb.append(((this.schema == null)?"<null>":this.schema));
+        sb.append(',');
+        sb.append("name");
+        sb.append('=');
+        sb.append(((this.name == null)?"<null>":this.name));
+        sb.append(',');
+        sb.append("fieldId");
+        sb.append('=');
+        sb.append(((this.fieldId == null)?"<null>":this.fieldId));
+        sb.append(',');
+        sb.append("autoCompleteUrl");
+        sb.append('=');
+        sb.append(((this.autoCompleteUrl == null)?"<null>":this.autoCompleteUrl));
+        sb.append(',');
+        sb.append("hasDefaultValue");
+        sb.append('=');
+        sb.append(((this.hasDefaultValue == null)?"<null>":this.hasDefaultValue));
+        sb.append(',');
+        sb.append("operations");
+        sb.append('=');
+        sb.append(((this.operations == null)?"<null>":this.operations));
+        sb.append(',');
+        sb.append("allowedValues");
+        sb.append('=');
+        sb.append(((this.allowedValues == null)?"<null>":this.allowedValues));
+        sb.append(',');
+        sb.append("defaultValue");
+        sb.append('=');
+        sb.append(((this.defaultValue == null)?"<null>":this.defaultValue));
+        sb.append(',');
+        if (sb.charAt((sb.length()- 1)) == ',') {
+            sb.setCharAt((sb.length()- 1), ']');
+        } else {
+            sb.append(']');
+        }
+        return sb.toString();
+    }
+
+}

--- a/src/main/java/com/checkmarx/flow/jira9X/IssueType.java
+++ b/src/main/java/com/checkmarx/flow/jira9X/IssueType.java
@@ -1,0 +1,131 @@
+
+package com.checkmarx.flow.jira9X;
+
+import java.net.URI;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+        "self",
+        "id",
+        "description",
+        "iconUrl",
+        "name",
+        "subtask"
+})
+@Generated("jsonschema2pojo")
+public class IssueType {
+
+    @JsonProperty("self")
+    private URI self;
+    @JsonProperty("id")
+    private Long id;
+    @JsonProperty("description")
+    private String description;
+    @JsonProperty("iconUrl")
+    private URI iconUrl;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("subtask")
+    private Boolean subtask;
+
+    @JsonProperty("self")
+    public URI getSelf() {
+        return self;
+    }
+
+    @JsonProperty("self")
+    public void setSelf(URI self) {
+        this.self = self;
+    }
+
+    @JsonProperty("id")
+    public Long getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @JsonProperty("description")
+    public String getDescription() {
+        return description;
+    }
+
+    @JsonProperty("description")
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @JsonProperty("iconUrl")
+    public URI getIconUrl() {
+        return iconUrl;
+    }
+
+    @JsonProperty("iconUrl")
+    public void setIconUrl(URI iconUrl) {
+        this.iconUrl = iconUrl;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonProperty("subtask")
+    public Boolean getSubtask() {
+        return subtask;
+    }
+
+    @JsonProperty("subtask")
+    public void setSubtask(Boolean subtask) {
+        this.subtask = subtask;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(IssueType.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+        sb.append("self");
+        sb.append('=');
+        sb.append(((this.self == null)?"<null>":this.self));
+        sb.append(',');
+        sb.append("id");
+        sb.append('=');
+        sb.append(((this.id == null)?"<null>":this.id));
+        sb.append(',');
+        sb.append("description");
+        sb.append('=');
+        sb.append(((this.description == null)?"<null>":this.description));
+        sb.append(',');
+        sb.append("iconUrl");
+        sb.append('=');
+        sb.append(((this.iconUrl == null)?"<null>":this.iconUrl));
+        sb.append(',');
+        sb.append("name");
+        sb.append('=');
+        sb.append(((this.name == null)?"<null>":this.name));
+        sb.append(',');
+        sb.append("subtask");
+        sb.append('=');
+        sb.append(((this.subtask == null)?"<null>":this.subtask));
+        sb.append(',');
+        if (sb.charAt((sb.length()- 1)) == ',') {
+            sb.setCharAt((sb.length()- 1), ']');
+        } else {
+            sb.append(']');
+        }
+        return sb.toString();
+    }
+
+}

--- a/src/main/java/com/checkmarx/flow/jira9X/Project.java
+++ b/src/main/java/com/checkmarx/flow/jira9X/Project.java
@@ -1,0 +1,148 @@
+package com.checkmarx.flow.jira9X;
+
+import java.net.URI;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+        "expand",
+        "self",
+        "id",
+        "key",
+        "name",
+        "avatarUrls",
+        "projectTypeKey",
+        "archived"
+})
+public class Project {
+
+    @JsonProperty("expand")
+    private String expand;
+    @JsonProperty("self")
+    private URI self;
+    @JsonProperty("id")
+    private Long id;
+    @JsonProperty("key")
+    private String key;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("avatarUrls")
+    private Map<String, URI> avatarUrls;
+    @JsonProperty("projectTypeKey")
+    private String projectTypeKey;
+    @JsonProperty("archived")
+    private Boolean archived;
+    @JsonProperty("expand")
+    public String getExpand() {
+        return expand;
+    }
+    @JsonProperty("expand")
+    public void setExpand(String expand) {
+        this.expand = expand;
+    }
+    @JsonProperty("self")
+    public URI getSelf() {
+        return self;
+    }
+    @JsonProperty("self")
+    public void setSelf(URI self) {
+        this.self = self;
+    }
+    @JsonProperty("id")
+    public Long getId() {
+        return id;
+    }
+    @JsonProperty("id")
+    public void setId(Long id) {
+        this.id = id;
+    }
+    @JsonProperty("key")
+    public String getKey() {
+        return key;
+    }
+    @JsonProperty("key")
+    public void setKey(String key) {
+        this.key = key;
+    }
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+    @JsonProperty("avatarUrls")
+    public Map<String, URI> getAvatarUrls() {
+        return avatarUrls;
+    }
+    @JsonProperty("avatarUrls")
+    public void setAvatarUrls(Map<String, URI> avatarUrls) {
+        this.avatarUrls = avatarUrls;
+    }
+    @JsonProperty("projectTypeKey")
+    public String getProjectTypeKey() {
+        return projectTypeKey;
+    }
+    @JsonProperty("projectTypeKey")
+    public void setProjectTypeKey(String projectTypeKey) {
+        this.projectTypeKey = projectTypeKey;
+    }
+    @JsonProperty("archived")
+    public Boolean getArchived() {
+        return archived;
+    }
+    @JsonProperty("archived")
+    public void setArchived(Boolean archived) {
+        this.archived = archived;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(Project.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+        sb.append("expand");
+        sb.append('=');
+        sb.append(((this.expand == null)?"<null>":this.expand));
+        sb.append(',');
+        sb.append("self");
+        sb.append('=');
+        sb.append(((this.self == null)?"<null>":this.self));
+        sb.append(',');
+        sb.append("id");
+        sb.append('=');
+        sb.append(((this.id == null)?"<null>":this.id));
+        sb.append(',');
+        sb.append("key");
+        sb.append('=');
+        sb.append(((this.key == null)?"<null>":this.key));
+        sb.append(',');
+        sb.append("name");
+        sb.append('=');
+        sb.append(((this.name == null)?"<null>":this.name));
+        sb.append(',');
+        sb.append("avatarUrls");
+        sb.append('=');
+        sb.append(((this.avatarUrls == null)?"<null>":this.avatarUrls));
+        sb.append(',');
+        sb.append("projectTypeKey");
+        sb.append('=');
+        sb.append(((this.projectTypeKey == null)?"<null>":this.projectTypeKey));
+        sb.append(',');
+        sb.append("archived");
+        sb.append('=');
+        sb.append(((this.archived == null)?"<null>":this.archived));
+        sb.append(',');
+        if (sb.charAt((sb.length()- 1)) == ',') {
+            sb.setCharAt((sb.length()- 1), ']');
+        } else {
+            sb.append(']');
+        }
+        return sb.toString();
+    }
+
+}

--- a/src/main/java/com/checkmarx/flow/jira9X/StandardOperation.java
+++ b/src/main/java/com/checkmarx/flow/jira9X/StandardOperation.java
@@ -1,0 +1,50 @@
+
+package com.checkmarx.flow.jira9X;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+
+
+public enum StandardOperation {
+
+    SET("set"),
+    ADD("add"),
+    REMOVE("remove"),
+    EDIT("edit");
+    private final String value;
+    private final static Map<String, StandardOperation> CONSTANTS = new HashMap<String, StandardOperation>();
+
+    static {
+        for (StandardOperation c: values()) {
+            CONSTANTS.put(c.value, c);
+        }
+    }
+
+    StandardOperation(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return this.value;
+    }
+
+    @JsonValue
+    public String value() {
+        return this.value;
+    }
+
+    @JsonCreator
+    public static StandardOperation fromValue(String value) {
+        StandardOperation constant = CONSTANTS.get(value);
+        if (constant == null) {
+            throw new IllegalArgumentException(value);
+        } else {
+            return constant;
+        }
+    }
+
+}

--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -1049,7 +1049,6 @@ public class JiraService {
                     .build();
             log.debug("jira properties values for version:{} and deploymentName:{} ",jiraProperties.getVersion(),jiraProperties.getDeployType());
             int parseVersion=0;
-            String ver = jiraProperties.getVersion();
             int versionLength = jiraProperties.getVersion().length();
             int secondValue;
             Iterable<CimProject> metadata =null;
@@ -1166,7 +1165,6 @@ public class JiraService {
             JSONObject obj = new JSONObject(response.getBody());
             String versionName = obj.getString("version");
             String deployType = obj.getString("deploymentType");
-            log.debug("jira version:{} deployment Type:{}",versionName,deployType);
             versionAndDeploy.add(versionName);
             versionAndDeploy.add(deployType);
         }catch (HttpClientErrorException e) {
@@ -1184,8 +1182,6 @@ public class JiraService {
             ResponseEntity<String> response = restTemplate.exchange(Str, HttpMethod.GET, httpEntity, String.class);
             ObjectMapper mapper = new ObjectMapper();
             project = mapper.readValue(response.getBody(), new TypeReference<List<com.checkmarx.flow.jira9X.Project>>() {});
-            log.debug("response for project:{}",response.getBody());
-            log.debug("project:{}", project);
         }catch (HttpClientErrorException e) {
             log.error("Error occurred http error {} ", e.getStatusCode());
         } catch (JsonMappingException e) {
@@ -1203,12 +1199,10 @@ public class JiraService {
         List<com.checkmarx.flow.jira9X.IssueType> issueType=null;
         try {
             ResponseEntity<String> response = restTemplate.exchange(Str, HttpMethod.GET, httpEntity, String.class);
-            log.debug("response for IssueType:{}",response.getBody());
             JSONObject obj = new JSONObject(response.getBody());
             String issueValues = String.valueOf(obj.getJSONArray("values"));
             ObjectMapper mapper = new ObjectMapper();
             issueType = mapper.readValue(issueValues, new TypeReference<List<com.checkmarx.flow.jira9X.IssueType>>() {});
-            log.debug("issueTypes:{}", issueType);
         }catch (HttpClientErrorException e) {
             log.error("Error occurred http error {} ", e.getStatusCode());
         } catch (JsonMappingException e) {
@@ -1226,12 +1220,10 @@ public class JiraService {
         List<com.checkmarx.flow.jira9X.IssueFields> issueFields=null;
         try {
             ResponseEntity<String> response = restTemplate.exchange(Str, HttpMethod.GET, httpEntity, String.class);
-            log.debug("response for IssueFields:{}",response.getBody());
             JSONObject obj = new JSONObject(response.getBody());
             String issueValues = String.valueOf(obj.getJSONArray("values"));
             ObjectMapper mapper = new ObjectMapper();
              issueFields = mapper.readValue(issueValues, new TypeReference<List<com.checkmarx.flow.jira9X.IssueFields>>() {});
-            log.debug("issueTypes:{}", issueFields);
         }catch (HttpClientErrorException e) {
             log.error("Error occurred http error {} ", e.getStatusCode());
         } catch (JsonMappingException e) {


### PR DESCRIPTION
### Description
/rest/api/2/issue/createmeta Endpoint for Jira Rest Client has been deprecated from 8.4 version.  New Endpoints are

 Return the list of projects 

 /rest/api/2/project  

Return a list of issuetypes given in project

 /rest/api/2/issue/createmeta/{projectIdOrKey}/issuetypes 

Return a list of fields given a project and issuetype

/rest/api/2/issue/createmeta/{projectIdOrKey}/issuetypes/{issueTypeId} 

### References

[> Include supporting link to GitHub Issue/PR number](https://github.com/checkmarx-ltd/cx-flow/issues/1082)

### Testing
Tested on Jira 9.2.0 Server
