### PR TITLE
make result overview collapsible

### DIFF
--- a/src/main/java/com/checkmarx/flow/utils/HTMLHelper.java
+++ b/src/main/java/com/checkmarx/flow/utils/HTMLHelper.java
@@ -186,6 +186,7 @@ public class HTMLHelper {
     }
 
     private static void scaVulnerabilitiesTableBuilder(StringBuilder body, SCAResults r) {
+        appendAll(body, "<details><summary>Click to see details</summary>", CRLF, CRLF);
         MarkDownHelper.appendMDtableHeaders(body, "Vulnerability ID", "Package", SEVERITY,
                 // "CWE / Category",
                 "CVSS score", "Publish date", "Current version", "Recommended version", "Link in CxSCA",
@@ -205,6 +206,8 @@ public class HTMLHelper {
                                 : appendAll(new StringBuilder(), '[', f.getCveName(),
                                 "](https://nvd.nist.gov/vuln/detail/", f.getCveName(), ")")
                                 .toString()));
+        appendAll(body, "</details>", CRLF);
+
     }
 
     private static String extractPackageNameFromFindings(SCAResults r, Finding f) {

--- a/src/main/java/com/checkmarx/flow/utils/HTMLHelper.java
+++ b/src/main/java/com/checkmarx/flow/utils/HTMLHelper.java
@@ -746,6 +746,7 @@ public class HTMLHelper {
 
             if (xMap.size() > 0) {
                 setScannerDetailsHeader(results, body);
+                appendAll(body, "<details><summary>Click to see details</summary>", CRLF, CRLF);
                 MarkDownHelper.appendMDtableHeaders(body,"Lines",SEVERITY,"Category","File","Link");
                 log.info("Creating Merge/Pull Request Markdown comment");
 
@@ -756,6 +757,7 @@ public class HTMLHelper {
                 addSastAstDetailsBody(request, body, xMap, issueComparator);
 
                 addOsaDetailesBody(results, body, xMap, issueComparator);
+                appendAll(body, "</details>", CRLF, CRLF);
             }
         }
     }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Often the time, it's found that the result summary table in the Gitlab Comment could be very long and make other comments hard to read. Because of that, It would be better to make the result summary collapsible.

### References

None

### Testing

The code and feature is pretty straightforward. I have generated a new build and all work as expected.

### Checklist

- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
- [x] Verified that SCA and SAST scan results are as expected
