### PR TITLE
CXFLW-625 SCA scan failures with Threshold and DevDependencies Ticket No | 00144935

### DIFF
--- a/build-11.gradle
+++ b/build-11.gradle
@@ -3,7 +3,7 @@ import org.gradle.api.tasks.testing.Test
 buildscript {
 	ext {
 
-        CxSBSDK = "0.5.37"
+        CxSBSDK = "0.5.40"
 
         ConfigProviderVersion = "1.0.9"
         //cxVersion = "8.90.5"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
 
-        CxSBSDK = "0.5.37"
+        CxSBSDK = "0.5.40"
 
         ConfigProviderVersion = "1.0.10"
         //cxVersion = "8.90.5"

--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -664,7 +664,7 @@ public class CxFlowRunner implements ApplicationRunner {
 
         if(flowProperties.getEnabledVulnerabilityScanners()!=null){
             if((flowProperties.getEnabledVulnerabilityScanners().contains("sca") ||
-                    flowProperties.getEnabledVulnerabilityScanners().contains("SCA")) && thresholdValidator.thresholdsExceededDirectDependency(request, results)){
+                    flowProperties.getEnabledVulnerabilityScanners().contains("SCA")) && thresholdValidator.thresholdsExceededDirectNDEVDependency(request, results)){
                 log.info("Build failed because some direct dependency issues were found.");
                 breakBuildResult = true;
             }

--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -585,8 +585,8 @@ public class JiraService {
                                 value = location.substring(0,location.length()-1);
                                 break;
                             case "dev-dependency":
-                                log.debug("dev-dependency: {}", issue.getScaDetails().get(0).getVulnerabilityPackage().isIsDevelopment());
-                                value = String.valueOf(issue.getScaDetails().get(0).getVulnerabilityPackage().isIsDevelopment()).toUpperCase();
+                                log.debug("dev-dependency: {}", issue.getScaDetails().get(0).getVulnerabilityPackage().isIsDevelopmentDependency());
+                                value = String.valueOf(issue.getScaDetails().get(0).getVulnerabilityPackage().isIsDevelopmentDependency()).toUpperCase();
                                 break;
                             case "direct-dependency":
                                 log.debug("direct-dependency: {}", issue.getScaDetails().get(0).getVulnerabilityPackage().isIsDirectDependency());

--- a/src/main/java/com/checkmarx/flow/service/ThresholdValidator.java
+++ b/src/main/java/com/checkmarx/flow/service/ThresholdValidator.java
@@ -9,6 +9,6 @@ public interface ThresholdValidator {
     boolean isMergeAllowed(ScanResults results, RepoProperties repoProperties, PullRequestReport pullRequestReport);
     boolean thresholdsExceeded(ScanRequest request, ScanResults results);
 
-    boolean thresholdsExceededDirectDependency(ScanRequest request, ScanResults results);
+    boolean thresholdsExceededDirectNDEVDependency(ScanRequest request, ScanResults results);
     boolean isThresholdsConfigurationExist(ScanRequest scanRequest);
 }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

hen customer marks a vulnerability as "Not Exploitable" for SCA, it still causes the Threshold to trigger in CxFlow which breaks their build. 

This is creating an issue for the customer as they do not want these vulnerabilities to trigger the Threshold which is why they're marking them as Not Exploitable.

Steps to Reproduce

For direct dependency marks a vulnerability as "Not Exploitable" for SCA, it still causes the Threshold to trigger in CxFlow which breaks their build.
Actual Result

For direct dependency marks a vulnerability as "Not Exploitable" for SCA, it should breaks build.
Expected Result

For direct dependency marks a vulnerability as "Not Exploitable" for SCA, it should not breaks build.
Possible solution
