### PR TITLE
Tweak the log masking configuration

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -53,7 +53,7 @@
                 <maskPattern>[^&amp;]password=(.+?)\s</maskPattern>
                 <!-- For logging the token request (if logging HTTP requests) -->
                 <maskPattern>&amp;password=(.+?)&amp;</maskPattern>
-                <maskPattern>token=(.+?)\s</maskPattern>
+                <maskPattern>token=(.+?)[&amp;\s]</maskPattern>
                 <maskPattern>"access_token":"([^"]+)"</maskPattern>
                 <maskPattern>Authorization: Bearer (.+)</maskPattern>
                 <pattern>${CONSOLE_LOG_PATTERN}</pattern>


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change.

The log masking pattern for tokens now stops at either whitespace or an ampersand (previously, it stopped only at whitespace). This means that text like:

    token=abcdefg&foo=bar

Is masked as:

    token=*******&foo=bar

Instead of:

    token=***************

### References

> Include supporting link to GitHub Issue/PR number
N/A

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment* (note that this is not applicable to this change)
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
- [ ] Verified that SCA and SAST scan results are as expected
