### PR TITLE
CXFLW-753 Added Documentaition for scanID as output variable

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -30,6 +30,7 @@
 * [BugTrackers](#bugtrackers)
 * [Encryption](#encryption)
 * [External Scripting](#external)
+* [SAST Scan ID in Github Action Output variable](#outputscanid)
 
 CxFlow uses **Spring Boot** and for Server Mode, it requires an `application.yml` file to drive the execution. The sections below outlines available properties and when/how they can be used in different execution modes. In addition, all the Spring Boot configuration rules apply. For additional information on Spring Boot, refer to
 https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html
@@ -1028,3 +1029,33 @@ There are places where a custom **groovy** script can be used while executing Cx
 * The team to be used.
   
 For additional information, refer to the [External Scripting](https://github.com/checkmarx-ltd/cx-flow/wiki/External-Scripts) chapter.
+
+## <a name="outputscanid">SAST Scan ID in Github Action Output variable</a>
+If user want to use SAST Scan ID for further usage cx-flow stores SCAN ID in githuab output variable name : **cxflowscanid**
+
+```
+- name: Checkmarx CxFlow Action
+      id: step1
+      uses: cx-flow/checkmarx-cxflow-github-action@v1.6
+        project: ${{ github.event.repository.name }}
+        team: ${{ secrets.CHECKMARX_TEAMS }}
+        checkmarx_url: ${{ secrets.CHECKMARX_URL }}
+        checkmarx_username: ${{ secrets.CHECKMARX_USERNAME }}
+        checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
+        checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
+        scanners: sast
+        params: --github --checkmarx.incremental=false --checkmarx.settings-override=true --namespace=${{ github.repository_owner }} --repo-name=${{ github.event.repository.name }} --branch=${{ github.ref_name }} --cx-flow.filter-severity --cx-flow.filter-category --checkmarx.disable-clubbing=true --repo-url=${{ github.event.repository.url }}
+   
+```
+Steps to retrieve SCAN ID**** in output variable -
+
+* Since Scan ID we are getting only after run of cx-flow, So we will use ID of Checkmarx CxFlow Action steps in output variable to fetch SCAN ID 
+```
+outputs:
+      output1: ${{ steps.step1.outputs.cxflowscanid }}
+```
+* Now SCAN ID is stored in output1 variable which can be used in any jobs as per user convince.
+
+ 
+**NOTE**: If SAST scan is taking time to scan files and other jobs are stuck due to this so user can run cx-flow in Async mode and with the help of SCAN ID from output variable, User can fetch results.
+In This way there is no jobs will be blocked due to processing of cx-flow.


### PR DESCRIPTION
Description

I am trying to get the value of the scan ID so I can use it with the Checkmarx API later in my Github Actions workflow.

The Github Actions has the following organization:

Each Github repository can setup one or more workflows. Each workflow is triggered in response to events that occur within the repository (e.g. pull requests, releases, manual invocation, etc.)

Each workflow contains one or more jobs. The jobs run parallelly in separate compute instances unless you setup dependencies between the jobs.

Each job contains one or more steps. The steps are run in sequence.

Each step can either be a shell script or a custom action. The step can take inputs and environment variables as well as produce named output values that can be referenced by future steps.

Checkmarx provides a custom action called [checkmarx-ts/checkmarx-cxflow-github-action](https://github.com/checkmarx-ts/checkmarx-cxflow-github-action) that we are using to run cx-flow as a step in our Github actions workflow. I am asking for the checkmarx-ts/checkmarx-cxflow-github-action to be updated to set an output called “scanId” to the ID of the scan that was performed. Outputs can easily be set by appending to a special file that Github Actions provides ([documentation is here](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter), [Docker specific example can be found here](https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action#writing-the-action-code)).

Implementing this output will allow us to retrieve the scan ID in subsequent steps of our Github Actions workflow. It is important to note that the scan ID cannot be retrieved from the log output of checkmarx-ts/checkmarx-cxflow-github-action, because there is a significant time delay between when the log output happens and when it shows up in the Github API. Custom actions outputs are the most reliable way to pass data between steps of a workflow job.