### PR TITLE
Vulnerability URL fix for SCA 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ FROM alpine:3.18.2 AS java11
 WORKDIR app
 RUN apk update && \
     apk upgrade 
-RUN apk add openjdk11=11.0.19_p7-r1 --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
+RUN apk add openjdk11=11.0.20_p8-r2 --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk
 RUN apk --no-cache add curl
 RUN apk add sudo

--- a/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
+++ b/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
@@ -606,7 +606,7 @@ public class ScanUtils {
         String urlCompatiblePackageId = finding.getPackageId().replace(":", urlColonEncode);
 
         vulnerabilityUrl.append(finding.getId())
-                .append(urlColonEncode).append(urlCompatiblePackageId).append("/vulnerabilityDetails");
+                .append(urlColonEncode).append(urlCompatiblePackageId).append("/vulnerabilityDetailsGql");
 
         return vulnerabilityUrl.toString();
     }


### PR DESCRIPTION
### Description

Issue seems to be with URL. JIRA taking incorrect URL.

 

JIRA Actual URL:

(https://eu.sca.checkmarx.net/#/projects/6f54c9aa-94fd-4eed-ab85-0e7a56a8a8f0/reports/f80e5846-200f-47b7-bd10-f0a986b3bcaf/vulnerabilities/CVE-2014-0107%3AMaven-xalan%3Aserializer-2.7.1/vulnerabilityDetails) 

 

Expected URL:

(https://eu.sca.checkmarx.net/#/projects/6f54c9aa-94fd-4eed-ab85-0e7a56a8a8f0/reports/f80e5846-200f-47b7-bd10-f0a986b3bcaf/vulnerabilities/CVE-2014-0107%3AMaven-xalan%3Aserializer-2.7.1/vulnerabilityDetailsGql)

