### PR TITLE
CXFLW-829 Added Documentation for AWS buildspec

### DIFF
--- a/docs/Thresholds-and-policies.md
+++ b/docs/Thresholds-and-policies.md
@@ -55,6 +55,15 @@ Under Branch policies configuration, enable Checkmarx scan as ‘required’ (ht
 
 CxFlow does not support blocking pull request in GitLab. If **block-merge: true and error-merge: true** then CxFlow will post status of vulnerability as comment but it will not block PR.
 
+<u>**AWS Code build (Buildspec)**</u>:
+
+If the build is not breaking because the pipeline is not able to get the exit code, the user can add the following script to catch the exit code from the Cx-Flow logs.
+```****
+export EXIT_CODE=$(grep 'Finished with exit code:' cx-flow.log | tail -1 |sed 's/.*: //')
+
+echo $EXIT_CODE
+```
+
 ## <a name="thresholds">Thresholds vs Basic filters</a>
 
 By default, CxFlow uses the basic filter configuration to make a ‘break decision’.


### PR DESCRIPTION
Description

I am following "[AWS CodeBuild](https://checkmarx.com/resource/documents/en/34965-8206-aws-codebuild.html) " to trigger CxSAST scan from AWS CodeBuild. The CxSAST scan was triggered successfully, but there are two issues in related to thresholds: (1) I want the build to fail if high vul >=1 or medium vul >=1 or low vul >=10. The actual scan returns 0 high, 0 medium, and 3 low, but CxFlow still exit with code 10. It seems the build doesn't take my threshold into account. (2) I want the build fail when CxFlow exit with code 10. But in reality, even if CxFlow prints error in the log, the buildspec command still returns 0, thus made the build phase succeed.