### PR TITLE
Fixed NullPointerException for SCA methods

### DIFF
--- a/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
+++ b/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
@@ -630,10 +630,22 @@ public class ScanUtils {
         return summary;
     }
     public static String removePackageCurrentVersionFromPath(String packageName, String currentPackageVersion) {
-        return packageName.replace("-" + currentPackageVersion, "");
+        if(packageName!=null)
+        {
+            return packageName.replace("-" + currentPackageVersion, "");
+        }
+        else {
+            return "";
+        }
     }
 
     public static String getCurrentPackageVersion(String packageName) {
-        return StringUtils.substringAfterLast(packageName, "-");
+        if(packageName!=null)
+        {
+            return StringUtils.substringAfterLast(packageName, "-");
+        }
+        else {
+            return "";
+        }
     }
 }


### PR DESCRIPTION
Fixed NullPointerException for SCA methods

Methods name
- removePackageCurrentVersionFromPath
- getCurrentPackageVersion