### PR TITLE
 CXFLW-966 CxFlow: using System.Tags as an --alt-fields option throws an error

### DIFF
--- a/docs/Bug-Trackers-and-Feedback-Channels.md
+++ b/docs/Bug-Trackers-and-Feedback-Channels.md
@@ -420,6 +420,27 @@ Valid options for `bug-tracker-impl` are currently the following ones:
 Azure DevOps work items only supports an issue body/description.  Custom/template field values are not available at present.  The available issue-type values are built/tested around issue and impediment (Scrum)
 [[/Images/bug1.png|Screenshot of Azure Devops work item]]
 
+* If user wants to change System.Title,System.Description and System.Tags they need to enable boolean variable and provide details in command or in application.yml file
+```
+java -jar cx-flow-1.6.44.jar --project --cx-team="CxServer" --app="abc"  --cx-project="bcd" --alt-fields="System.Title:abc" --namespace="abc" --branch="abc" --repo-name="abc"  --alt-project="abc" --azure.system-title=true
+```
+```
+java -jar cx-flow-1.6.44.jar --project --cx-team="CxServer" --app="abc"  --cx-project="bcd" --alt-fields="System.Description:bcd" --namespace="abc" --branch="abc" --repo-name="abc"  --alt-project="abc" --azure.system-description=true
+```
+```
+java -jar cx-flow-1.6.44.jar --project --cx-team="CxServer" --app="abc"  --cx-project="bcd" --alt-fields="System.Tags:SCA" --namespace="abc" --branch="abc" --repo-name="abc"  --alt-project="abc" --azure.system-tag-blocks=true
+```
+```
+java -jar cx-flow-1.6.44.jar --alt-fields="System.Tags:SCA,System.Title:SC2,System.Description:SCA1"  --namespace="satyamchaurasia0219" --branch="shivam" --repo-name="satyamproject"  --alt-project="satyamproject"
+```
+
+* In YML File pass variables like this
+```
+azure:
+  system-title: true
+  system-description: true
+  system-tag-blocks: true~~~~~~~~~~~~~~~~~~~~~~~~
+```
 ## <a name="gitlab">GitLab Issues</a>
 GitLab Issues leverages the same configuration as specified for WebHook listeners → API token (**token**) and valid urls are required
 

--- a/src/main/java/com/checkmarx/flow/config/ADOProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/ADOProperties.java
@@ -27,6 +27,16 @@ public class ADOProperties extends RepoProperties{
 
     @Getter
     @Setter
+    private boolean systemTitle = false;
+    @Getter
+    @Setter
+    private boolean systemDescription = false;
+    @Getter
+    @Setter
+    private boolean systemTagBlocks = false;
+
+    @Getter
+    @Setter
     private int commentStatus=1;
 
     @Getter

--- a/src/main/java/com/checkmarx/flow/custom/ADOIssueTracker.java
+++ b/src/main/java/com/checkmarx/flow/custom/ADOIssueTracker.java
@@ -259,12 +259,17 @@ public class ADOIssueTracker implements IssueTracker {
         description.setOp("add");
         description.setPath(Constants.ADO_FIELD.concat(FIELD_PREFIX.concat(issueBody)));
         description.setValue(HTMLHelper.getHTMLBody(resultIssue, request, flowProperties));
+
         CreateWorkItemAttr tagsBlock = new CreateWorkItemAttr();
         tagsBlock.setOp("add");
         tagsBlock.setPath(Constants.ADO_FIELD.concat(TAGS_FIELD));
         tagsBlock.setValue(tags.toString());
 
-        List<CreateWorkItemAttr> body = new ArrayList<>(Arrays.asList(title, description, tagsBlock));
+        List<CreateWorkItemAttr> body = new ArrayList<>();
+
+        if(!properties.isSystemTitle()) body.add(title);
+        if(!properties.isSystemDescription()) body.add(description);
+        if(!properties.isSystemTagBlocks()) body.add(tagsBlock);
 
         for (Map.Entry<String, String> map : request.getAltFields().entrySet()) {
             log.debug("Custom field: {},  value: {}", map.getKey(), map.getValue());


### PR DESCRIPTION
Description
When using --alt-fields as part of a command line call for CxFlow in project mode, if a customer uses System.Tags for additional meta data, the following error is returned.

--alt-fields="System.Tags:SCA"
[11:37 AM] customer
org.springframework.web.client.HttpClientErrorException$BadRequest: 400 Bad Request: "{"$id":"1","innerException":null,"message":"VS403691: Update to work item -1 had two or more updates for field with reference name 'System.Tags'. A field cannot be updated more than once in the same update.","typeName":"System.InvalidOperationException, mscorlib","typeKey":"InvalidOperationException","errorCode":0,"eventId":0}"

Per the documentation, these tags fields should be allowed for customer project tags in ADO but seem like They are already in use via Cxflow