### PR TITLE
Added Support for Jira On-premise Personal Access Token

### DIFF
--- a/docs/Bug-Trackers-and-Feedback-Channels.md
+++ b/docs/Bug-Trackers-and-Feedback-Channels.md
@@ -86,6 +86,7 @@ jira:
    url: https://xxxx.atlassian.net
    username: xxxx
    token: xxxx
+   token-type: <API,PASSWORD,PAT>
    project: SS
    issue-type: Application Security Bug
    label-prefix: < CUSTOM PREFIX NAME >
@@ -186,20 +187,37 @@ jira:
 Jira's credentials configuration differs for on-premises and cloud environments.
 
 #### Cloud Configuration
+Jira cloud supports token-type as api-token. To generate api-token for Jira, Please refer [Tutorials](https://github.com/checkmarx-ltd/cx-flow/wiki/Tutorials#cliprep) chapter.
+In case of Jira Cloud token-type parameter is optional.
 ```yaml
 jira:
    url: <Jira Cloud url>
    username: <Configured email address>
    token: <Jira api token>
+   token-type: API
 ```
-To generate api token for Jira, Please refer [Tutorials](https://github.com/checkmarx-ltd/cx-flow/wiki/Tutorials#cliprep) chapter.
+
 #### On-premise Configuration
+Jira on-premises supports token-type, Personal Access Tokens and  Passwords. Provide the token value as the password if token-type is set to PASSWORD. Provide the token value as a personal access token if the token-type is PAT. 
+
+To generate personal access token for Jira on-premise.
+* Select your profile picture at the top right of the screen, then choose Profile. 
+* Once you access your profile, select Personal Access Tokens in the left-hand menu.
+* Select Create token.
+* Give your new token a name.
+* Optionally, for security reasons, you can set your token to automatically expire after a set number of days.
+* Click Create
+
+Your personal access token is created. Copy the token and store it in a safe space.
 ```yaml
 jira:
    url: <Jira on-premise url>
    username: <Jira on-premise username>
-   token: <Jira on-premise password>
+   token: <password/personal access token>
+   token-type: <PASSWORD/PAT>
 ```
+
+**Note:** When using Jira on-premises, a password is expected as the value in the token if the token-type is not specified.
 ### <a name="labelprefix">Label Prefix</a>
 ```
 label-prefix: < CUSTOM PREFIX NAME > 

--- a/docs/Tutorials.md
+++ b/docs/Tutorials.md
@@ -870,7 +870,7 @@ Thresholds for High Issue is passed as '--cx-flow.thresholds.High=0' inside 'par
 <br/>
 
 This tutorial is designed to teach the following topics:
-* How to configure a Jira project for CxFlow
+* How to configure a Jira Cloud project for CxFlow
 * Automated ticket creation using CxFlow CLI
 * Scanning via CxFlow CLI
 
@@ -897,7 +897,7 @@ This tutorial is designed to teach the following topics:
     * Click Copy to clipboard, then paste the token to your script, or elsewhere to save: it should be pasted into the token: <\> of the application.yml
 * Create a custom field for this project and issue type screen by clicking the settings wheel in the top right  corner
     * Click Issues \> Custom Fields \> Create Custom Field
-    * Click Tutorialels and give it a name “Application”
+    * Click Tutorials and give it a name “Application”
     * Description = CxSAST Project
     * Select the checkboxes next to APPSEC: Kanban Bug Screen & APPSEC: Kanban Default Issue Screen
     * Click Update
@@ -906,7 +906,7 @@ This tutorial is designed to teach the following topics:
     * Description = CxSAST Vulnerability Type
     * Select the checkboxes next to APPSEC: Kanban Bug Screen & APPSEC: Kanban Default Issue Screen
     * Click Update
-*Note :* Jira's credentials configuration differs for on-premises and cloud environments, Please refer to [Bug Trackers and Feedback Channels](https://github.com/checkmarx-ltd/cx-flow/wiki/Bug-Trackers-and-Feedback-Channels#cred) chapter for mmore details
+*Note :* Jira's credentials configuration differs for on-premises and cloud environments, Please refer to [Bug Trackers and Feedback Channels](https://github.com/checkmarx-ltd/cx-flow/wiki/Bug-Trackers-and-Feedback-Channels#cred) chapter for more details
 ### <a name="clitriggering">Triggering Scans with CxFlow</a>
 ##### [Top of Tutorial](#clijira)
 
@@ -916,7 +916,7 @@ bug-tracker: JIRA
   #bug-tracker-impl:
 ```
 * After the .YML file is completely filled out and saved
-* The following command clones a github repo, creates a CxSAST scan for the cloned repo, and creates tickets according to the .yml file
+* The following command clones a GitHub repo, creates a CxSAST scan for the cloned repo, and creates tickets according to the .yml file
 ```
 cd C:\CxFlow
 git clone https://github.com/ethicalhack3r/DVWA.git 

--- a/src/main/java/com/atlassian/jira/rest/client/internal/async/CustomAsynchronousJiraRestClientFactory.java
+++ b/src/main/java/com/atlassian/jira/rest/client/internal/async/CustomAsynchronousJiraRestClientFactory.java
@@ -6,6 +6,7 @@ import java.net.URI;
 
 
 public class CustomAsynchronousJiraRestClientFactory extends AsynchronousJiraRestClientFactory {
+    private static final String AUTHORIZATION_HEADER = "Authorization";
 
     public JiraRestClient createCustom(final URI serverUri, final AuthenticationHandler authenticationHandler, int socketTimeoutInMs) {
         final DisposableHttpClient httpClient = new CustomAsynchronousHttpClientFactory()
@@ -15,6 +16,10 @@ public class CustomAsynchronousJiraRestClientFactory extends AsynchronousJiraRes
 
     public JiraRestClient createWithBasicHttpAuthenticationCustom(final URI serverUri, final String username, final String password, final int socketTimeoutInMs) {
         return createCustom(serverUri, new BasicHttpAuthenticationHandler(username, password),socketTimeoutInMs);
+    }
+
+    public JiraRestClient createWithPATHttpAuthenticationCustom(final URI serverUri, final String token, final int socketTimeoutInMs ){
+        return createCustom(serverUri,builder -> builder.setHeader(AUTHORIZATION_HEADER, "Bearer " + token),socketTimeoutInMs);
     }
 
 }

--- a/src/main/java/com/checkmarx/flow/config/JiraProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/JiraProperties.java
@@ -64,6 +64,8 @@ public class JiraProperties {
     private String Version;
     @Getter @Setter
     private String DeployType;
+    @Getter @Setter
+    private TokenType TokenType;
 
     public String getUrl() {
         return this.url;
@@ -371,5 +373,11 @@ public class JiraProperties {
 
     public void setSuppressCodeSnippets(List<String> suppressCodeSnippets) {
         this.suppressCodeSnippets = suppressCodeSnippets;
+    }
+
+    public enum TokenType {
+        PAT,
+        PASSWORD,
+        API;
     }
 }


### PR DESCRIPTION
### Description

Added new Jira parameter named token-type to differentiate between token as password or PAT
```
jira:
   url: <Jira on-premise url>
   username: <Jira on-premise username>
   token: <password/personal access token>
   token-type: <PASSWORD/PAT> 
```

Note: When using Jira on-premises, a password is expected as the value in the token if the token-type is not specified.
### References

https://github.com/checkmarx-ltd/cx-flow/issues/878

