### PR TITLE
CXFLOW-1328: Set security-severity in the SARIF SCA report to match the markdown and tags fields

### DIFF
--- a/src/test/java/com/checkmarx/flow/custom/SarifSCAIssueTrackerTest.java
+++ b/src/test/java/com/checkmarx/flow/custom/SarifSCAIssueTrackerTest.java
@@ -1,0 +1,106 @@
+package com.checkmarx.flow.custom;
+
+import com.checkmarx.flow.config.SarifProperties;
+import com.checkmarx.flow.dto.ScanRequest;
+import com.checkmarx.flow.exception.MachinaException;
+import com.checkmarx.flow.service.FilenameFormatter;
+import com.checkmarx.flow.service.SanitizingFilenameFormatter;
+import com.checkmarx.sdk.dto.ScanResults;
+import com.checkmarx.sdk.dto.sca.SCAResults;
+import com.checkmarx.sdk.dto.sca.report.Finding;
+import com.checkmarx.sdk.dto.sca.report.Package;
+import com.checkmarx.sdk.dto.scansummary.Severity;
+import com.google.common.collect.Lists;
+import org.junit.Test;
+import java.util.List;
+
+
+public class SarifSCAIssueTrackerTest {
+    
+    @Test
+    public void initWithNullPropertiesNullParameters() {
+        SarifProperties properties = new SarifProperties();
+        properties.setFilePath("./cx.sarif");
+        FilenameFormatter filenameFormatter = new SanitizingFilenameFormatter() ;
+        SarifIssueTracker sarifIssueTracker = new SarifIssueTracker(properties, filenameFormatter);
+        try {
+            sarifIssueTracker.init(null, null);
+            assert false;
+        } catch (MachinaException e) {
+            assert true;
+        }
+    }
+
+    @Test
+    public void completeWithParameters() {
+        SarifIssueTracker issueTracker = getInstance();
+        try {
+            ScanRequest request = getRequest();
+            ScanResults results = getResults();
+            request.setFilename("./sarif-sca-result.json");
+            issueTracker.complete(request, results);
+            assert true;
+        } catch (MachinaException e) {
+            assert false;
+        }
+    }
+
+    private ScanResults getResults() {
+        Finding f1 = new Finding();
+        f1.setId("Npm-brace-expansion-1.1.6");
+        f1.setCveName("CVE-2020-28500");
+        f1.setScore(5.6);
+        f1.setSeverity(Severity.HIGH);
+        f1.setDescription("Npm-brace-expansion-1.1.6");
+        f1.setPackageId("Npm-brace-expansion-1.1.6");
+
+        Finding f2 = new Finding();
+        f2.setId("Npm-brace-expansion-1.1.6");
+        f2.setCveName("CVE-2017-18077");
+        f2.setScore(6.5);
+        f2.setSeverity(Severity.HIGH);
+        f2.setDescription("Npm-brace-expansion-1.1.6");
+        f2.setPackageId("Npm-brace-expansion-1.1.6");
+
+        List<Finding> findings = Lists.newArrayList();
+        findings.add(f1);
+        findings.add(f2);
+
+        Package p1 = new Package();
+        p1.setId("Npm-brace-expansion-1.1.6");
+        p1.setName("Npm-brace-expansion-1.1.6");
+        p1.setVersion("1.1.6");
+        
+        List<Package> packages = Lists.newArrayList();
+        packages.add(p1);
+
+        SCAResults s1 = 
+            SCAResults.builder()
+                    .scanId("scanId1")
+                    .webReportLink("http://foo.bar")
+                    .findings(findings)
+                    .packages(packages)
+                    .build();
+        
+        ScanResults results = new ScanResults();
+
+        results.setScaResults(s1);
+        return results;
+    }
+
+    private ScanRequest getRequest() {
+        return ScanRequest.builder()
+                .application("test_app")
+                .repoName("test_repo")
+                .namespace("checkmarx")
+                .product(ScanRequest.Product.CX)
+                .branch("develop")
+                .team("\\CxServer\\SP\\Checkmarx").build();
+    }
+
+    private SarifIssueTracker getInstance() {
+        SarifProperties sarifProperties = new SarifProperties();
+        FilenameFormatter filenameFormatter = new SanitizingFilenameFormatter();
+        return new SarifIssueTracker(sarifProperties, filenameFormatter);
+    }
+}


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

In a SARIF report, the `security-severity` field is set to `9.0` for all SCA findings, which is inconsistent with the markdown, text, and tag CVSS scores.

![Screenshot 2024-03-05 at 2 32 54 PM](https://github.com/checkmarx-ltd/cx-flow/assets/94542318/ba2401b7-c9ba-41da-955c-621aed3e53ba)

`map.get(key).getSeverity()` doesn't appear to be resolvable. This results in `security-severity` being set to the `DEFAULT_SEVERITY` (9.0).

The updated logic sets `security-severity` in the SARIF output as the max CVSS score such that the markdown, tags, and `security-severity` have a consistent value. 

### Testing

Added a [src/test/java/com/checkmarx/flow/custom/SarifSCAIssueTrackerTest.java](https://github.com/checkmarx-ltd/cx-flow/compare/develop...williamwissemann:security-severity-fix?expand=1#diff-4f77473c5af5c8392356cf80680540311e86e7200bac522b75c22ec12222d920) to test the new logic. 

The results from the test yield the correct value.

![Screenshot 2024-03-05 at 2 40 00 PM](https://github.com/checkmarx-ltd/cx-flow/assets/94542318/95df840a-b1e3-4ef2-9fa6-dfbdfff20771)

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
- [x] Verified that SCA and SAST scan results are as expected
