### PR TITLE
Added new parameter  commentUpdate

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -801,6 +801,7 @@ github:
    scan-submitted-comment: false
    max-description-length : <should be greater than 4 and less than 50000>
    max-delay : <minimum value should be 3>
+   comment-update: false
 ```
 
 | Configuration            | Default        | Description                                                                                                                                                                                                       |
@@ -814,6 +815,7 @@ github:
 | `scan-submitted-comment` | true           | Comment on PullRequest with "Scan submitted (or not submitted) to Checkmarx ...".                                                                                                                                 | 
 | `max-description-length` | 50000          | Manages number of characters to view in issue description.(value should be greater than 4 and less than 50000)                                                                                                    |
 | `max-delay`              |                | When Secondary rate limit is hit, it will delay each API call for issue creation(Mininum value should be 3)                                                                                                       |
+| `comment-update`         | true           | if false, will create a new comment for every scan                                                                                                                                                                |
 **Note**: A service account is required with access to the repositories that will be scanned, pull requests that will be commented on, and GitHub issues that will be created/updated.
 
 ### <a name="gitlab">GitLab</a>
@@ -825,6 +827,7 @@ gitlab:
    api-url: https://gitlab.com/api/v4/
    false-positive-label: false-positive
    block-merge: true
+   comment-update: false
 ```
 
 | Configuration            | Default        | Description                                                                                                                                                                         |
@@ -835,7 +838,8 @@ gitlab:
 | `api-url`                |                | The API endpoint for GitLab, which serves a different context or potential FQDN than the main repo url.                                                                             |
 | `false-positive-label`   | false-positive | A label that can be defined within the GitLab Issue feedback to ignore issues                                                                                                       |
 | `block-merge`            | false          | When triggering scans based on Merge Request, the Merge request is marked as WIP in GitLab, which blocks the merge ability until the scan is complete in Checkmarx.                 |
-| `scan-submitted-comment` | true           | Comment on Merge Request with "Scan submitted (or not submitted) to Checkmarx ...".                                                                                                 | 
+| `scan-submitted-comment` | true           | Comment on Merge Request with "Scan submitted (or not submitted) to Checkmarx ...".                                                                                                 |
+| `comment-update`         | true           | if false, will create a new comment for every scan                                                                                                                                  |
 
 **Note**: A service account is required with access to the repositories that are going to be scanned, pull requests that are commented on, and GitLab issues that are created/updated.
 

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -8,6 +8,7 @@ After the upgrade, the customers need to use the CxFlow Java11.jar file
 <br>[Quick Start](#quickstart)
 
 
+
 ## <a name="whatisit">What is it?</a>
 CxFlow is a Spring Boot application that can run anywhere Java is installed. CxFlow glues together Checkmarx CxSAST and CxSCA scans with feedback to issue tracking systems via webhooks triggered by SCM events. 
 

--- a/src/main/java/com/checkmarx/flow/config/GitHubProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/GitHubProperties.java
@@ -39,6 +39,9 @@ public class GitHubProperties extends RepoProperties {
     @Getter
     @Setter
     private Map<FindingSeverity,String> issueslabel;
+    @Getter
+    @Setter
+    private boolean commentUpdate =true;
 
     public String getMergeNoteUri(String namespace, String repo, String mergeId){
         String format = "%s/%s/%s/issues/%s/comments";

--- a/src/main/java/com/checkmarx/flow/config/GitLabProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/GitLabProperties.java
@@ -27,6 +27,10 @@ public class GitLabProperties extends RepoProperties {
     @Setter
     private Map<FindingSeverity,String> issueslabel;
 
+    @Getter
+    @Setter
+    private boolean commentUpdate =true;
+
 
 
     public String getGitUri(String namespace, String repo){

--- a/src/main/java/com/checkmarx/flow/service/BugTrackerEventTrigger.java
+++ b/src/main/java/com/checkmarx/flow/service/BugTrackerEventTrigger.java
@@ -37,7 +37,7 @@ public class BugTrackerEventTrigger {
         switch (bugTrackerType) {
             case GITLABMERGE:
                 if (gitLabService.isScanSubmittedComment()) {
-                    gitLabService.sendMergeComment(request, SCAN_MESSAGE);
+                    gitLabService.sendMergeComment(request, SCAN_MESSAGE,gitLabService.isCommentUpdate());
                 }
                 gitLabService.startBlockMerge(request);
                 break;
@@ -50,7 +50,7 @@ public class BugTrackerEventTrigger {
 
             case GITHUBPULL:
                 if (gitService.isScanSubmittedComment()) {
-                    gitService.sendMergeComment(request, SCAN_MESSAGE);
+                    gitService.sendMergeComment(request, SCAN_MESSAGE,gitService.isCommentUpdate());
                 }
                 gitService.startBlockMerge(request, cxProperties.getUrl());
                 break;
@@ -108,7 +108,7 @@ public class BugTrackerEventTrigger {
         switch (bugTrackerType) {
             case GITLABMERGE:
                 if (gitLabService.isScanSubmittedComment()) {
-                    gitLabService.sendMergeComment(scanRequest, SCAN_FAILED_MESSAGE);
+                    gitLabService.sendMergeComment(scanRequest, SCAN_FAILED_MESSAGE,gitLabService.isCommentUpdate());
                 }
                 gitLabService.endBlockMerge(scanRequest);
                 break;
@@ -121,7 +121,7 @@ public class BugTrackerEventTrigger {
 
             case GITHUBPULL:
                 if (gitService.isScanSubmittedComment()) {
-                    gitService.sendMergeComment(scanRequest, SCAN_FAILED_MESSAGE);
+                    gitService.sendMergeComment(scanRequest, SCAN_FAILED_MESSAGE,gitService.isCommentUpdate());
                 }
                 String targetURL = cxProperties.getBaseUrl().concat(GitHubService.CX_USER_SCAN_QUEUE);
                 gitService.errorBlockMerge(scanRequest, targetURL, SCAN_FAILED_MESSAGE);
@@ -186,7 +186,7 @@ public class BugTrackerEventTrigger {
         switch (bugTrackerType) {
             case GITLABMERGE:
                 if (gitLabService.isScanSubmittedComment()) {
-                    gitLabService.sendMergeComment(scanRequest, SCAN_NOT_SUBMITTED_MESSAGE);
+                    gitLabService.sendMergeComment(scanRequest, SCAN_NOT_SUBMITTED_MESSAGE,gitLabService.isCommentUpdate());
                 }
                 gitLabService.endBlockMerge(scanRequest);
                 break;
@@ -199,7 +199,7 @@ public class BugTrackerEventTrigger {
 
             case GITHUBPULL:
                 if (gitService.isScanSubmittedComment()) {
-                    gitService.sendMergeComment(scanRequest, SCAN_NOT_SUBMITTED_MESSAGE);
+                    gitService.sendMergeComment(scanRequest, SCAN_NOT_SUBMITTED_MESSAGE,gitService.isCommentUpdate());
                 }
                 String targetURL = cxProperties.getBaseUrl().concat(GitHubService.CX_USER_SCAN_QUEUE);
                 gitService.errorBlockMerge(scanRequest, targetURL, description);

--- a/src/main/java/com/checkmarx/flow/service/GitHubService.java
+++ b/src/main/java/com/checkmarx/flow/service/GitHubService.java
@@ -138,7 +138,7 @@ public class GitHubService extends RepoService {
     void processPull(ScanRequest request, ScanResults results) {
             String comment = HTMLHelper.getMergeCommentMD(request, results, properties);
             log.debug("comment: {}", comment);
-            sendMergeComment(request, comment);
+            sendMergeComment(request, comment,isCommentUpdate());
     }
 
     public void updateComment(String baseUrl, String comment, ScanRequest scanRequest) {
@@ -641,7 +641,7 @@ public class GitHubService extends RepoService {
         }
         return result;
     }
-    
+    public boolean isCommentUpdate(){return this.properties.isCommentUpdate();}
     @Override
     public boolean isScanSubmittedComment() {
     	return this.properties.isScanSubmittedComment();

--- a/src/main/java/com/checkmarx/flow/service/GitLabService.java
+++ b/src/main/java/com/checkmarx/flow/service/GitLabService.java
@@ -130,7 +130,7 @@ public class GitLabService extends RepoService {
         try {
             String comment = HTMLHelper.getMergeCommentMD(request, results,  properties);
             log.debug("comment: {}", comment);
-            sendMergeComment(request, comment);
+            sendMergeComment(request, comment,isCommentUpdate());
         } catch (HttpClientErrorException e){
             log.error("Error occurred while creating Merge Request comment", e);
             throw new GitLabClientException();
@@ -523,6 +523,8 @@ public class GitLabService extends RepoService {
                 scanRequest.getAdditionalMetadata(FlowConstants.MERGE_ID),
                 commentId);
     }
+
+    public boolean isCommentUpdate(){return this.properties.isCommentUpdate();}
 
 	@Override
 	public boolean isScanSubmittedComment() {

--- a/src/main/java/com/checkmarx/flow/service/RepoService.java
+++ b/src/main/java/com/checkmarx/flow/service/RepoService.java
@@ -27,24 +27,30 @@ public abstract class RepoService {
     
     public abstract boolean isScanSubmittedComment();
 
-    public void sendMergeComment(ScanRequest request, String comment){
+    public void sendMergeComment(ScanRequest request, String comment,boolean commentUpdate){
 
         try {
-            RepoComment commentToUpdate =
-                    PullRequestCommentsHelper.getCommentToUpdate(getComments(request), comment);
-            if (commentToUpdate !=  null) {
-                log.debug("Got candidate comment to update. comment: {}", commentToUpdate.getComment());
-                if (!PullRequestCommentsHelper.shouldUpdateComment(comment, commentToUpdate.getComment())) {
-                    log.debug("sendMergeComment: Comment should not be updated");
-                    return;
+            if(commentUpdate){
+                RepoComment commentToUpdate =
+                        PullRequestCommentsHelper.getCommentToUpdate(getComments(request), comment);
+                if (commentToUpdate !=  null) {
+                    log.debug("Got candidate comment to update. comment: {}", commentToUpdate.getComment());
+                    if (!PullRequestCommentsHelper.shouldUpdateComment(comment, commentToUpdate.getComment())) {
+                        log.debug("sendMergeComment: Comment should not be updated");
+                        return;
+                    }
+                    log.debug("sendMergeComment: Going to update {} pull request comment",
+                            request.getRepoType());
+                    updateComment(commentToUpdate.getCommentUrl(), comment, request);
+                } else {
+                    log.debug("sendMergeComment: Going to create a new {} pull request comment", request.getRepoType());
+                    addComment(request, comment);
                 }
-                log.debug("sendMergeComment: Going to update {} pull request comment",
-                          request.getRepoType());
-                updateComment(commentToUpdate.getCommentUrl(), comment, request);
-            } else {
+            }else {
                 log.debug("sendMergeComment: Going to create a new {} pull request comment", request.getRepoType());
                 addComment(request, comment);
             }
+
         }
         catch (Exception e) {
             // We "swallow" the exception so that the flow will not be terminated because of errors in GIT comments

--- a/src/test/java/com/checkmarx/flow/cucumber/component/ast/parse/GitHubCommentsASTSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/component/ast/parse/GitHubCommentsASTSteps.java
@@ -107,7 +107,7 @@ public class GitHubCommentsASTSteps {
     private void initGitHubServiceMock() {
 
         GitHubServiceAnswerer answerer = new GitHubServiceAnswerer();
-        doAnswer(answerer).when(gitHubService).sendMergeComment(any(), any());
+        doAnswer(answerer).when(gitHubService).sendMergeComment(any(), any(),true);
             
     }
 


### PR DESCRIPTION
### Description

Added a new parameter of GitHub and GitLab named comment-update 
if false, will create a new comment for every scan in PR
```yaml
gitlab:
   comment-update: false
```

```yaml
github:
   comment-update: false
```
### References

https://github.com/checkmarx-ltd/cx-flow/issues/1120

### Testing

tested on GitHub and GitLab 
