### PR TITLE
added scan and project tags for SCA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR app
 RUN apk update && \
     apk upgrade && \
     apk upgrade
-RUN apk add openjdk17=17.0.10_p7-r0 --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
+RUN apk add openjdk17=17.0.11_p9-r0 --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 RUN apk add libstdc++
 RUN apk add glib

--- a/build-11.gradle
+++ b/build-11.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext {
 
 
-        CxSBSDK = "0.6.2"
+        CxSBSDK = "0.6.6"
         ConfigProviderVersion = '1.0.14'
         //cxVersion = "8.90.5"
         springBootVersion = '3.2.4'

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
     ext {
-        CxSBSDK = "0.6.4"
+        CxSBSDK = "0.6.6"
         ConfigProviderVersion = '1.0.14'
         //cxVersion = "8.90.5"
         springBootVersion = '3.2.4'

--- a/docs/CxSCA-Integration.md
+++ b/docs/CxSCA-Integration.md
@@ -40,6 +40,8 @@ sca:
   manifests-include-pattern: "!**/*.xml, **/*.yml"
   fingerprints-include-pattern: "**/*.yml"
   preserve-xml: true
+  project-tags: "k1:k2,dev"
+  scan-tags: "s1:s2,p1:p2,prod"
   filter-severity:
     - High
   filter-policy-violation: true
@@ -70,6 +72,8 @@ sca:
   manifests-include-pattern: "!**/*.xml, **/*.yml"
   fingerprints-include-pattern: "**/*.yml"
   preserve-xml: true
+  project-tags: "k1:k2,dev"
+  scan-tags: "s1:s2,p1:p2,prod"
   filter-severity:
     - High
   filter-policy-violation: true
@@ -269,7 +273,9 @@ CxFlow supports configuration as code for CxSAST and CxSCA scans.
                 "fingerprintsIncludePattern": "**/*.yml",
 		"team": "/CxServer/MyTeam/SubTeam",
 		"projectName" : "SampleProjectName",
-		"expPathSastProjectName": "SampleProjectName"
+		"expPathSastProjectName": "SampleProjectName",
+		"projectTags": "k1:k2,dev"
+		"scanTags": "s1:s2,prod,p1:p2"
 	}
 }
 ```

--- a/src/main/java/com/checkmarx/flow/service/ScaConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ScaConfigurationOverrider.java
@@ -13,10 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -138,12 +135,12 @@ public class ScaConfigurationOverrider {
             overrideReport.put("ManifestsIncludePattern",manifestsIncludePattern);
         });
         sca.map(Sca :: getProjectTags).ifPresent(projectTags->{
-            scaConfig.setProjectTags(projectTags);
-            overrideReport.put("projectTags", String.valueOf(projectTags));
+            scaConfig.setProjectTags(Arrays.asList(projectTags.split(",")));
+            overrideReport.put("projectTags", projectTags);
         });
         sca.map(Sca :: getScanTags).ifPresent(scanTags->{
-            scaConfig.setScanTags(scanTags);
-            overrideReport.put("scanTags", String.valueOf(scanTags));
+            scaConfig.setScanTags(Arrays.asList(scanTags.split(",")));
+            overrideReport.put("scanTags", scanTags);
         });
 
         overrideSeverityFilters(request, sca, overrideReport);

--- a/src/main/java/com/checkmarx/flow/service/ScaConfigurationOverrider.java
+++ b/src/main/java/com/checkmarx/flow/service/ScaConfigurationOverrider.java
@@ -137,6 +137,14 @@ public class ScaConfigurationOverrider {
             scaConfig.setManifestsIncludePattern(manifestsIncludePattern);
             overrideReport.put("ManifestsIncludePattern",manifestsIncludePattern);
         });
+        sca.map(Sca :: getProjectTags).ifPresent(projectTags->{
+            scaConfig.setProjectTags(projectTags);
+            overrideReport.put("projectTags", String.valueOf(projectTags));
+        });
+        sca.map(Sca :: getScanTags).ifPresent(scanTags->{
+            scaConfig.setScanTags(scanTags);
+            overrideReport.put("scanTags", String.valueOf(scanTags));
+        });
 
         overrideSeverityFilters(request, sca, overrideReport);
 


### PR DESCRIPTION
### Description

Added new parameters for SCA for project tags and scan tags.
```yaml

sca:
 project-tags: "k1:k2,dev"
 scan-tags: "s1:s2,prod"
```

also added cx.config parameter 
```
"projectTags": "k1:k2,dev",
"scanTags": "s1:s2,prod,p1:p2"
```

### Testing

Tested on SCA and ScaResolver with CLI and WebHook mode.


