### PR TITLE
Mask GitHub personal access tokens in logs

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -56,6 +56,9 @@
                 <maskPattern>token=(.+?)[&amp;\s]</maskPattern>
                 <maskPattern>"access_token":"([^"]+)"</maskPattern>
                 <maskPattern>Authorization: Bearer (.+)</maskPattern>
+		<!-- Mask GitHub tokens -->
+		<maskPattern>https://([_a-zA-Z0-9]+)@github.com</maskPattern>
+		<maskPattern>Authorization: token ([_a-zA-Z0-9]+)$</maskPattern>
                 <pattern>${CONSOLE_LOG_PATTERN}</pattern>
             </layout>
         </encoder>
@@ -86,6 +89,9 @@
                 <maskPattern>token=(.+?)\s</maskPattern>
                 <maskPattern>"access_token":"([^"]+)"</maskPattern>
                 <maskPattern>Authorization: Bearer (.+)</maskPattern>
+		<!-- Mask GitHub tokens -->
+		<maskPattern>https://([_a-zA-Z0-9]+)@github.com</maskPattern>
+		<maskPattern>Authorization: token ([_a-zA-Z0-9]+)$</maskPattern>
                 <pattern>${FILE_LOG_PATTERN}</pattern>
             </layout>
         </encoder>


### PR DESCRIPTION
Add mask patterns for two cases where GitHub personal access tokens can appear in the CxFlow log:

- When logging HTTP headers
- When logging URLs (https://<pat>@github.com/...)

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change.
When DEBUG logging is enabled, both the Authorization header and URLs may be logged (depending on for which packages DEBUG logging is enabled). For example (fictional PATs):

```
2024-05-06 09:34:56.474 DEBUG 11084 --- [nio-8080-exec-1] o.a.h.headers                             [9vM0IhZt] : http-outgoing-0 >> Authorization: token ghp_Ab9cd8eFgHijklmn9OPqrstU0VWXyzU0cuXYZ
```
And:
```
2024-05-06 09:07:43.072 DEBUG 12752 --- [      flow-web1] c.c.s.s.CxService                         [ZucKYfPL] : Creating scan with params: CxScanParams{teamName='/CxServer/SP', projectName='james-bostock-cx-test-cxflow-server-james-bostock-cx-patch-3', incremental=false, isPublic=true, forceScan=false, fileExclude=null, folderExclude=null, scanPreset='Checkmarx Default', scanConfiguration='null', sourceType=GIT, gitUrl='https://ghp_Ab9cd8eFgHijklmn9OPqrstU0VWXyzU0cuXYZ@github.com/james-bostock-cx/test-cxflow-server.git', filePath='null', customFields=null, scanCustomFields=null, postAction='null', emailNotifications='null'} and comment: "CxFlow Automated Scan"
```

### References

> Include supporting link to GitHub Issue/PR number
N/A

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Tested manually. Here are the corresponding log messages after this change is applied:
```
2024-05-06 13:46:05.685 DEBUG 17824 --- [nio-8080-exec-2] o.a.h.headers                             [VtGXu8BY] : http-outgoing-0 >> Authorization: token ****************************************
```
And:
```
2024-05-06 13:46:07.406 DEBUG 17824 --- [      flow-web1] c.c.s.s.CxService                         [VtGXu8BY] : Creating scan with params: CxScanParams{teamName='/CxServer/SP', projectName='james-bostock-cx-test-cxflow-server-james-bostock-cx-patch-6', incremental=false, isPublic=true, forceScan=false, fileExclude=null, folderExclude=null, scanPreset='Checkmarx Default', scanConfiguration='Default Configuration', sourceType=GIT, gitUrl='https://****************************************@github.com/james-bostock-cx/test-cxflow-server.git', filePath='null', customFields=null, scanCustomFields=null, postAction='null', emailNotifications='null'} and comment: "CxFlow Automated Scan"
```

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
- [ ] Verified that SCA and SAST scan results are as expected
