### PR TITLE
filter dev, test & indirect dependencies not working

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
     ext {
-        CxSBSDK = "0.6.8"
+        CxSBSDK = "0.6.9"
         ConfigProviderVersion = '1.0.14'
         //cxVersion = "8.90.5"
         springBootVersion = '3.2.5'


### PR DESCRIPTION
For More Details : Please refer SF case : 00196418



Hi Team, we use CxFlow to runs scans in our gitlab pipelines and send the results to Jira - PFA our CI template.

We have previously tried to filter out dev, test & indirect dependencies as we do not require these to have issues raised in Jira, but it is not working - see lines 114 & 115 in the attached template.

In the CxFlow documentation, the only relevant thing I have found is here https://github.com/checkmarx-ltd/cx-flow/wiki/CxSCA-Integration#adding-the-cxsca-configuration . But it's not clear if I can filter out dev & test dependencies as well. Please can you suggest how we can prevent dev, test & indirect dependencies having Jira issues?