### PR TITLE
CXFLW-1235 Adding code for self-sign certificate SSL bypass

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.Test
 
 buildscript {
     ext {
-        CxSBSDK = "0.6.8"
+        CxSBSDK = "0.6.9"
         ConfigProviderVersion = '1.0.14'
         //cxVersion = "8.90.5"
         springBootVersion = '3.2.5'

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -608,6 +608,7 @@ For more details on break build, please refer to [Thresholds and policies](https
 | `cxflow.enabledVulnerabilityScanners`  | false                 | No                                  | Yes     | Yes               | User can define which checkmarx tool they want to use like SAST, SCA or both.                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `checkmarx.considerScanningStatus`     | false                 | No                                  | Yes     | Yes               | By default, Checkmarx only includes completed scans (finished status) in incremental scans. This means it ignores scans that are currently running (scanning) or waiting to be processed (new queue). Enabling a feature this variable "cxflow" expands what incremental scans consider. With cxflow, scans in progress and those queued up are also taken into account, providing a more comprehensive view of your code's security posture.                                           |
 | `enabled-zip-scan`                     | false                 | No                                  | Yes     | Yes               | When `enabled-zip-scan` is set to `true` then cx-flow will first clone the repository locally, and then it will zip the repository and send it for scanning.                                                                                                                                                                                                                                                                                                                            |
+| `trustcerts`                     | false                 | No                                  | Yes     | Yes               | If this option is true Cx-flow will bypass SSL. Default value is false so it will not bypass SSL.                                                                                                                                                                                                                                                                                                                                                                                       |
 No* = Default is applied
 
 ### Custom Checkmarx Fields
@@ -638,6 +639,7 @@ checkmarx:
   url: ${checkmarx.base-url}/cxrestapi
   preserve-xml: true
   incremental: true
+  trustcerts: true
   portal-url: ${checkmarx.base-url}/cxwebinterface/Portal/CxWebService.asmx
   exclude-files: "*.tst,*.json"
   exclude-folders: ".git,test"

--- a/docs/Proxy-and-HTTPS-Configuration.md
+++ b/docs/Proxy-and-HTTPS-Configuration.md
@@ -51,10 +51,10 @@ To use CxFlow over HTTPS, an SSL certificate is required to be imported into a k
 
 # Self-Signed Certificates
 
-To allow CxFlow to trust self-signed certificates, the parameter '--trust-cert' needs to be provided via command line when starting the cxflow.
+To allow CxFlow to trust self-signed certificates, the parameter '--checkmarx.trustcerts = true' needs to be provided via command line when starting the cxflow.
 
 ```
-java -Dhttp.proxyHost=myproxyserver.com -Dhttp.proxyPort=9595 -jar cxflow.jar --trust-cert <Additional-CxFlow-parameters>
+java -Dhttp.proxyHost=myproxyserver.com -Dhttp.proxyPort=9595 -jar cxflow.jar --checkmarx.trustcerts = true' <Additional-CxFlow-parameters>
 ```
 
 ## Configuration


### PR DESCRIPTION
Adding a self-sign certificate SSL bypass in CXFlow requires careful consideration, as this process involves security implications. CXFlow is a framework designed to simplify the orchestration of various CI/CD tools and processes, and ensuring secure communication within the system is crucial. However, there are scenarios where you might need to bypass SSL verification, such as during testing or when dealing with self-signed certificates in a development environment. This guide will walk you through the necessary steps to add a self-sign certificate SSL bypass in CXFlow.

Understanding SSL Verification
SSL (Secure Socket Layer) is a standard security protocol for establishing encrypted links between a web server and a browser in an online communication. It ensures that all data passed between the web server and browsers remain private and integral. When using SSL, servers present certificates to clients (browsers or other services) to establish their identity. Self-signed certificates are certificates that are not signed by a recognized certificate authority (CA). They are typically used in development environments or for internal purposes.

Why Bypass SSL Verification?
Bypassing SSL verification can be necessary in certain scenarios, such as:

Development and Testing: When you are in a controlled environment and the overhead of obtaining a CA-signed certificate is unnecessary.
Internal Systems: For internal systems where the risk of man-in-the-middle attacks is controlled and the environment is trusted.
Implementing SSL Bypass in CXFlow
To implement SSL bypass for self-signed certificates in CXFlow, you need to configure the HTTP client used by CXFlow to ignore SSL certificate validation errors. This can be done by customizing the underlying HTTP client to trust all certificates.

Steps to Add SSL Bypass:
Identify the HTTP Client:
CXFlow likely uses an HTTP client library (such as Apache HttpClient, OkHttp, or Java’s HttpsURLConnection). Identify the HTTP client being used in the CXFlow project.

Custom Trust Manager:
Create a custom TrustManager that trusts all certificates. This involves creating an implementation of javax.net.ssl.X509TrustManager that does not validate certificate chains.

java
Copy code
import javax.net.ssl.X509TrustManager;
import java.security.cert.X509Certificate;

public class TrustAllCertificates implements X509TrustManager {
    public X509Certificate[] getAcceptedIssuers() {
        return null;
    }

    public void checkClientTrusted(X509Certificate[] certs, String authType) {
        // Trust all client certificates
    }

    public void checkServerTrusted(X509Certificate[] certs, String authType) {
        // Trust all server certificates
    }
}
Custom SSL Context:
Create an SSLContext that uses this TrustManager.

java
Copy code
import javax.net.ssl.SSLContext;
import javax.net.ssl.TrustManager;

public class SSLUtils {
    public static SSLContext createTrustAllSslContext() throws Exception {
        SSLContext sslContext = SSLContext.getInstance("TLS");
        TrustManager[] trustAllCerts = new TrustManager[]{new TrustAllCertificates()};
        sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
        return sslContext;
    }
}
Configure HTTP Client:
Configure the HTTP client to use this SSLContext. For example, if using Apache HttpClient:

java
Copy code
import org.apache.http.impl.client.CloseableHttpClient;
import org.apache.http.impl.client.HttpClients;
import org.apache.http.conn.ssl.NoopHostnameVerifier;
import org.apache.http.ssl.SSLContextBuilder;

SSLContext sslContext = SSLUtils.createTrustAllSslContext();

CloseableHttpClient httpClient = HttpClients.custom()
        .setSSLContext(sslContext)
        .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
        .build();
Integrate with CXFlow:
Ensure that CXFlow uses this configured HTTP client for making HTTP requests. This might involve updating configurations or modifying the part of the code where the HTTP client is instantiated.

Security Implications
Bypassing SSL verification can expose your system to security risks, such as man-in-the-middle attacks. This approach should only be used in trusted and controlled environments, such as internal networks or during development and testing phases. For production environments, always use certificates signed by a recognized CA and ensure proper SSL verification to maintain security integrity.

Conclusion
Adding a self-sign certificate SSL bypass in CXFlow involves customizing the HTTP client to trust all certificates. While this approach can be useful in specific scenarios, it should be used with caution due to potential security risks. Always ensure that the environments where SSL bypass is enabled are secure and controlled, and revert to standard SSL verification practices in production environments.