### PR TITLE
CXFLW-1223 Added code for prscans-not-triggered

### DIFF
--- a/src/main/java/com/checkmarx/flow/service/AbstractASTScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/AbstractASTScanner.java
@@ -57,7 +57,9 @@ public abstract class AbstractASTScanner implements VulnerabilityScanner {
             logRequest(scanRequest, internalResults, OperationResult.successful());
             result = toScanResults(internalResults);
         } catch (Exception e) {
+            bugTrackerEventTrigger.triggerOffScanStartedEvent(scanRequest);
             treatError(scanRequest, internalResults, e);
+
         }
         
         return result;

--- a/src/main/java/com/checkmarx/flow/service/AbstractVulnerabilityScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/AbstractVulnerabilityScanner.java
@@ -112,6 +112,7 @@ public abstract class AbstractVulnerabilityScanner implements VulnerabilityScann
             //usually should occur during push event occurring on delete branch
             //therefore need to eliminate the scan process but do not want to create
             //an error stack trace in the log
+            bugTrackers.getBugTrackerEventTrigger().triggerOffScanStartedEvent(scanRequest);
             return getEmptyScanResults();
 
         } catch (Exception e) {
@@ -119,6 +120,7 @@ public abstract class AbstractVulnerabilityScanner implements VulnerabilityScann
             OperationResult scanCreationFailure = new OperationResult(OperationStatus.FAILURE, e.getMessage());
             ScanReport report = new ScanReport(-1, scanRequest, scanRequest.getRepoUrl(), scanCreationFailure);
             report.log();
+            bugTrackers.getBugTrackerEventTrigger().triggerOffScanStartedEvent(scanRequest);
             return getEmptyScanResults();
         }
     }
@@ -290,6 +292,8 @@ public abstract class AbstractVulnerabilityScanner implements VulnerabilityScann
         scanResults.setProjectId(UNKNOWN);
         scanResults.setProject(UNKNOWN);
         scanResults.setScanType(SCAN_TYPE);
+
+
         return scanResults;
     }
 

--- a/src/main/java/com/checkmarx/flow/service/BugTrackerEventTrigger.java
+++ b/src/main/java/com/checkmarx/flow/service/BugTrackerEventTrigger.java
@@ -51,8 +51,8 @@ public class BugTrackerEventTrigger {
             case GITHUBPULL:
                 if (gitService.isScanSubmittedComment() && request.getScanSubmittedComment()) {
                     gitService.sendMergeComment(request, SCAN_MESSAGE,gitService.isCommentUpdate());
+                    gitService.startBlockMerge(request, cxProperties.getUrl());
                 }
-                gitService.startBlockMerge(request, cxProperties.getUrl());
                 break;
 
             case BITBUCKETPULL:

--- a/src/main/java/com/checkmarx/flow/service/FlowService.java
+++ b/src/main/java/com/checkmarx/flow/service/FlowService.java
@@ -70,6 +70,8 @@ public class FlowService {
         resultsService.publishCombinedResults(scanRequest, combinedResults);
     }
 
+
+
     private List<VulnerabilityScanner> getEnabledScanners(ScanRequest scanRequest) {
         List<VulnerabilityScanner> enabledScanners = new ArrayList<>();
 

--- a/src/main/java/com/checkmarx/flow/service/GitHubService.java
+++ b/src/main/java/com/checkmarx/flow/service/GitHubService.java
@@ -274,6 +274,7 @@ public class GitHubService extends RepoService {
                     log.error(URL_INVALID, e);
                 }
             }
+
             HttpEntity<?> httpEntity = new HttpEntity<>(
                     getJSONStatus(PULL_REQUEST_STATUS, url, "Checkmarx Scan Initiated").toString(),
                     createAuthHeaders(request)


### PR DESCRIPTION
this case is it was not LB issue API was failing due to wrong user or user expired issue due to which PR was stuck once you resumed user it started working fine.

 

cxflow is not showing error when api connection is failed.
