### PR TITLE
Reduce PR decoration changes with configuration

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -837,20 +837,22 @@ github:
   max-description-length : <should be greater than 4 and less than 50000>
   max-delay : <minimum value should be 3>
   comment-update: false
+  zero-vulnerability-summary: true
 ```
 
-| Configuration            | Default        | Description                                                                                                                                                                                                       |
-|--------------------------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `webhook-token`          |                | Token used as a shared secret when calling the CxFlow WebHook WebService.  It authenticates users for the request. GitHub signs the request with this value, and the signature is validated on the receiving end. |
-| `token`                  |                | The API token with access to the repository, with at least Read only access to the code, the ability to add comments to pull requests, and the ability to create GitHub Issues.                                   |
-| `url`                    |                | Main repo url for GitHub                                                                                                                                                                                          |
-| `api-url`                |                | The API endpoint for GitHub, which is a different context or potentially FQDN than the main repo url.                                                                                                             |
-| `false-positive-label`   | false-positive | A label that can be defined within the GitHub Issue feedback that is used to ignore issues                                                                                                                        |
-| `block-merge`            | false          | When triggering scans based on PullRequest, this will create a new status of pending, which will block the merge ability until the scan is complete in Checkmarx.                                                 |
-| `scan-submitted-comment` | true           | Comment on PullRequest with "Scan submitted (or not submitted) to Checkmarx ...".                                                                                                                                 | 
-| `max-description-length` | 50000          | Manages number of characters to view in issue description.(value should be greater than 4 and less than 50000)                                                                                                    |
-| `max-delay`              |                | When Secondary rate limit is hit, it will delay each API call for issue creation(Mininum value should be 3)                                                                                                       |
-| `comment-update`         | true           | if false, will create a new comment for every scan                                                                                                                                                                |
+| Configuration                | Default        | Description                                                                                                                                                                                                       |
+|------------------------------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `webhook-token`              |                | Token used as a shared secret when calling the CxFlow WebHook WebService.  It authenticates users for the request. GitHub signs the request with this value, and the signature is validated on the receiving end. |
+| `token`                      |                | The API token with access to the repository, with at least Read only access to the code, the ability to add comments to pull requests, and the ability to create GitHub Issues.                                   |
+| `url`                        |                | Main repo url for GitHub                                                                                                                                                                                          |
+| `api-url`                    |                | The API endpoint for GitHub, which is a different context or potentially FQDN than the main repo url.                                                                                                             |
+| `false-positive-label`       | false-positive | A label that can be defined within the GitHub Issue feedback that is used to ignore issues                                                                                                                        |
+| `block-merge`                | false          | When triggering scans based on PullRequest, this will create a new status of pending, which will block the merge ability until the scan is complete in Checkmarx.                                                 |
+| `scan-submitted-comment`     | true           | Comment on PullRequest with "Scan submitted (or not submitted) to Checkmarx ...".                                                                                                                                 | 
+| `max-description-length`     | 50000          | Manages number of characters to view in issue description.(value should be greater than 4 and less than 50000)                                                                                                    |
+| `max-delay`                  |                | When Secondary rate limit is hit, it will delay each API call for issue creation(Mininum value should be 3)                                                                                                       |
+| `comment-update`             | true           | if false, will create a new comment for every scan                                                                                                                                                                |
+| `zero-vulnerability-summary` | false          | if true, will not comment in PR decoration any details for scans as vulnerabilities are zero.                                                                                                                     |
 **Note**: A service account is required with access to the repositories that will be scanned, pull requests that will be commented on, and GitHub issues that will be created/updated.
 
 ### <a name="gitlab">GitLab</a>
@@ -863,18 +865,20 @@ gitlab:
   false-positive-label: false-positive
   block-merge: true
   comment-update: false
+  zero-vulnerability-summary: true
 ```
 
-| Configuration            | Default        | Description                                                                                                                                                                         |
-|--------------------------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `webhook-token`          |                | Token used as a shared secret when calling the CxFlow WebHook WebService.  It authenticates users for the request.                                                                  |
-| `token`                  |                | This is the API token with access to the repository, with at least Read only access to code, the ability to add comments to pull requests, and the ability to create GitLab issues. |
-| `url`                    |                | Main repo url for GitLab.                                                                                                                                                           |
-| `api-url`                |                | The API endpoint for GitLab, which serves a different context or potential FQDN than the main repo url.                                                                             |
-| `false-positive-label`   | false-positive | A label that can be defined within the GitLab Issue feedback to ignore issues                                                                                                       |
-| `block-merge`            | false          | When triggering scans based on Merge Request, the Merge request is marked as WIP in GitLab, which blocks the merge ability until the scan is complete in Checkmarx.                 |
-| `scan-submitted-comment` | true           | Comment on Merge Request with "Scan submitted (or not submitted) to Checkmarx ...".                                                                                                 |
-| `comment-update`         | true           | if false, will create a new comment for every scan                                                                                                                                  |
+| Configuration                | Default        | Description                                                                                                                                                                         |
+|------------------------------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `webhook-token`              |                | Token used as a shared secret when calling the CxFlow WebHook WebService.  It authenticates users for the request.                                                                  |
+| `token`                      |                | This is the API token with access to the repository, with at least Read only access to code, the ability to add comments to pull requests, and the ability to create GitLab issues. |
+| `url`                        |                | Main repo url for GitLab.                                                                                                                                                           |
+| `api-url`                    |                | The API endpoint for GitLab, which serves a different context or potential FQDN than the main repo url.                                                                             |
+| `false-positive-label`       | false-positive | A label that can be defined within the GitLab Issue feedback to ignore issues                                                                                                       |
+| `block-merge`                | false          | When triggering scans based on Merge Request, the Merge request is marked as WIP in GitLab, which blocks the merge ability until the scan is complete in Checkmarx.                 |
+| `scan-submitted-comment`     | true           | Comment on Merge Request with "Scan submitted (or not submitted) to Checkmarx ...".                                                                                                 |
+| `comment-update`             | true           | if false, will create a new comment for every scan                                                                                                                                  |
+| `zero-vulnerability-summary` | false          | if true, will not comment in PR decoration any details for scans as vulnerabilities are zero.                                                                                       |
 
 **Note**: A service account is required with access to the repositories that are going to be scanned, pull requests that are commented on, and GitLab issues that are created/updated.
 
@@ -890,25 +894,26 @@ azure:
   block-merge: true
   closed-status: Closed
   open-status: Active
+  zero-vulnerability-summary: true
 ```
 
-| Configuration          | Default        | Description                                                                                                                                                                             |
-|------------------------|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `webhook-token`        |                | **<user>:<token>** as defined when registering the event in ADO.  Used as a shared secret when calling the CxFlow WebHook WebService.  It authenticates users for the request.          |
-| `token`                |                | This is the API token with access to the repository. It has at least Read only access to code, the ability to add comments to pull requests, and the ability to create Azure WorkItems. |
-| `url`                  |                | Main repo url for Azure DevOps, including high level namespace.  **Note**: this is only required when running from the command line and not for WebHooks.                               |
-| `issue-type`           | issue          | The WorkItem type within Azure, i.e. issue / impediment.                                                                                                                                |
-| `issue-body`           | description    | The body to enter free text regarding the issue.  The default across various workItem types are **Description** or **System.Description**.                                              |
-| `app-tag-prefix`       | app            | Used for tracking existing issues.  Issues are tagged with this value, if **app** is provided (without namespace/repo/branch)                                                           | 
-| `owner-tag-prefix`     | owner          | Used for tracking existing issues.  Issues are tagged with this value                                                                                                                   |
-| `repo-tag-prefix`      | repo           | Used for tracking existing issues.  Issues are tagged with this value                                                                                                                   |
-| `branch-label-prefix`  | branch         | Used for tracking existing issues.  Issues are tagged with this value                                                                                                                   |
-| `api-version`          | 5.0            | Azure DevOps API version to use                                                                                                                                                         |
-| `open-status`          |                | Status when re-opening a a workItem                                                                                                                                                     |
-| `closed-status`        |                | Status when closing a workItem                                                                                                                                                          |
-| `false-positive-label` | false-positive | A label/tag that can be defined within the Azure Issue feedback being used to ignore issues.                                                                                            |
-| `block-merge`          | false          | When triggering scans is based on pull request, this marks the Pull in blocked state until the scan is complete at Checkmarx.                                                           |
-
+| Configuration                | Default        | Description                                                                                                                                                                             |
+|------------------------------|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `webhook-token`              |                | **<user>:<token>** as defined when registering the event in ADO.  Used as a shared secret when calling the CxFlow WebHook WebService.  It authenticates users for the request.          |
+| `token`                      |                | This is the API token with access to the repository. It has at least Read only access to code, the ability to add comments to pull requests, and the ability to create Azure WorkItems. |
+| `url`                        |                | Main repo url for Azure DevOps, including high level namespace.  **Note**: this is only required when running from the command line and not for WebHooks.                               |
+| `issue-type`                 | issue          | The WorkItem type within Azure, i.e. issue / impediment.                                                                                                                                |
+| `issue-body`                 | description    | The body to enter free text regarding the issue.  The default across various workItem types are **Description** or **System.Description**.                                              |
+| `app-tag-prefix`             | app            | Used for tracking existing issues.  Issues are tagged with this value, if **app** is provided (without namespace/repo/branch)                                                           | 
+| `owner-tag-prefix`           | owner          | Used for tracking existing issues.  Issues are tagged with this value                                                                                                                   |
+| `repo-tag-prefix`            | repo           | Used for tracking existing issues.  Issues are tagged with this value                                                                                                                   |
+| `branch-label-prefix`        | branch         | Used for tracking existing issues.  Issues are tagged with this value                                                                                                                   |
+| `api-version`                | 5.0            | Azure DevOps API version to use                                                                                                                                                         |
+| `open-status`                |                | Status when re-opening a a workItem                                                                                                                                                     |
+| `closed-status`              |                | Status when closing a workItem                                                                                                                                                          |
+| `false-positive-label`       | false-positive | A label/tag that can be defined within the Azure Issue feedback being used to ignore issues.                                                                                            |
+| `block-merge`                | false          | When triggering scans is based on pull request, this marks the Pull in blocked state until the scan is complete at Checkmarx.                                                           |
+| `zero-vulnerability-summary` | false          | if true, will not comment in PR decoration any details for scans as vulnerabilities are zero.                                                                                           |
 **Note**: A service account is required with access to the repositories that are scanned, pull requests that are commented on, and Azure WorkItems that are created/updated.
 
 ### <a name="bitbucket">Bitbucket (Cloud and Server)</a>
@@ -919,17 +924,18 @@ bitbucket:
   url: http://bitbucket.org
   api-url: http://api.bitbucket.org
   api-path: /2.0
+  zero-vulnerability-summary: true
 ```
 
-| Configuration            | Default | Description                                                                                                                                                                                                                                                                                                                                       |
-|--------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `webhook-token`          |         | Token used as a shared secret when calling the CxFlow WebHook WebService.  It authenticates users for the request.  The Bitbucket cloud does not allow for a shared secret, therefore a URL parameter called token, must be provided in this case.                                                                                                |
-| `token`                  |         | This is the API token with access to the repository with at least Read only access to code and the ability to add comments to pull requests.  BitBucket requires the **<user>:<token>** format in the configuration. <br />`userid:app password`(Format while using BitBucket Cloud) <br />`userid:password`(Format while using BitBucket Server) |
-| `api-url`                |         | - [https://api.bitbucket.org](https://api.bitbucket.org) (URL for the Cloud BitBucket)<br />- [https://api.companyxyzbitbucket](https://api.companyxyzbitbucket) (URL for the BitBucket server is just the server hostname with `api.` prefixed)                                                                                                  |
-| `url`                    |         | - [https://bitbucket.org](https://api.bitbucket.org) (URL for the Cloud BitBucket)<br />- [https://companyxyzbitbucket](https://api.companyxyzbitbucket)(URL for the BitBucket server is just the server hostname)                                                                                                                                |
-| `api-path`               |         | The API URL path (appended to the URL) for BitBucket                                                                                                                                                                                                                                                                                              |
-| 'scan-submitted-comment` | true    | Comment on Merge Request with "Scan submitted (or not submitted) to Checkmarx ...".                                                                                                                                                                                                                                                               | 
-
+| Configuration                | Default | Description                                                                                                                                                                                                                                                                                                                                       |
+|------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `webhook-token`              |         | Token used as a shared secret when calling the CxFlow WebHook WebService.  It authenticates users for the request.  The Bitbucket cloud does not allow for a shared secret, therefore a URL parameter called token, must be provided in this case.                                                                                                |
+| `token`                      |         | This is the API token with access to the repository with at least Read only access to code and the ability to add comments to pull requests.  BitBucket requires the **<user>:<token>** format in the configuration. <br />`userid:app password`(Format while using BitBucket Cloud) <br />`userid:password`(Format while using BitBucket Server) |
+| `api-url`                    |         | - [https://api.bitbucket.org](https://api.bitbucket.org) (URL for the Cloud BitBucket)<br />- [https://api.companyxyzbitbucket](https://api.companyxyzbitbucket) (URL for the BitBucket server is just the server hostname with `api.` prefixed)                                                                                                  |
+| `url`                        |         | - [https://bitbucket.org](https://api.bitbucket.org) (URL for the Cloud BitBucket)<br />- [https://companyxyzbitbucket](https://api.companyxyzbitbucket)(URL for the BitBucket server is just the server hostname)                                                                                                                                |
+| `api-path`                   |         | The API URL path (appended to the URL) for BitBucket                                                                                                                                                                                                                                                                                              |
+| 'scan-submitted-comment`     | true    | Comment on Merge Request with "Scan submitted (or not submitted) to Checkmarx ...".                                                                                                                                                                                                                                                               | 
+| `zero-vulnerability-summary` | false   | if true, will not comment in PR decoration any details for scans as vulnerabilities are zero.                                                                                                                                                                                                                                                     |
 **Note**: As mentioned in the prerequisites, a service account is required that has appropriate access to the repositories that will be scanned, pull requests that will be commented on, GitHub issues that will be created/updated.
 
 ## <a name="json">JSON Config Override</a>

--- a/src/main/java/com/checkmarx/flow/config/RepoProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/RepoProperties.java
@@ -26,6 +26,7 @@ public class RepoProperties {
     private String flowSummaryHeader = PullRequestCommentsHelper.COMMENT_TYPE_SAST_FINDINGS_2;
     private boolean cxSummary = true;
     private boolean cxTableSummary = false;
+    private boolean zeroVulnerabilitySummary = false;
     private String cxSummaryHeader = "Checkmarx Scan Summary";
     private Map<String, OptionalScmInstanceProperties> optionalInstances;
     private boolean scanSubmittedComment = true;
@@ -186,6 +187,14 @@ public class RepoProperties {
 
     public String getCxSummaryHeader() {
         return cxSummaryHeader;
+    }
+
+    public boolean isZeroVulnerabilitySummary() {
+        return zeroVulnerabilitySummary;
+    }
+
+    public void setZeroVulnerabilitySummary(boolean zeroVulnerabilitySummary) {
+        this.zeroVulnerabilitySummary = zeroVulnerabilitySummary;
     }
 
     public void setCxSummaryHeader(String cxSummaryHeader) {

--- a/src/main/java/com/checkmarx/flow/service/PullRequestCommentsHelper.java
+++ b/src/main/java/com/checkmarx/flow/service/PullRequestCommentsHelper.java
@@ -23,6 +23,8 @@ public class PullRequestCommentsHelper {
 
     private static final String COMMENT_TYPE_SCAN_FAILED_MESSAGE = "Scan failed due to some error.";
 
+    private static final String ZERO_SAST_VULNERABILITY_COMMENT ="No SAST Vulnerability Found!!";
+    private static final String ZERO_SCA_VULNERABILITY_COMMENT ="No SCA Vulnerability Found!!";
     public static boolean isCheckMarxComment(RepoComment comment) {
         String currentComment = comment.getComment();
         return currentComment.contains(COMMENT_TYPE_SAST_FINDINGS_2) && currentComment.contains(COMMENT_TYPE_SAST_FINDINGS_1) ||
@@ -119,9 +121,9 @@ public class PullRequestCommentsHelper {
 
     enum CommentType {
         SCAN_STARTED(Arrays.asList(COMMENT_TYPE_SAST_SCAN_STARTED)),
-        SAST_FINDINGS(Arrays.asList(COMMENT_TYPE_SAST_FINDINGS_1, COMMENT_TYPE_SAST_FINDINGS_2)),
-        SCA(Arrays.asList(COMMENT_TYPE_SCA_FINDINGS)),
-        SCA_AND_SAST(Arrays.asList(COMMENT_TYPE_SAST_FINDINGS_1, COMMENT_TYPE_SAST_FINDINGS_2, COMMENT_TYPE_SCA_FINDINGS)),
+        SAST_FINDINGS(Arrays.asList(COMMENT_TYPE_SAST_FINDINGS_1, COMMENT_TYPE_SAST_FINDINGS_2,ZERO_SAST_VULNERABILITY_COMMENT)),
+        SCA(Arrays.asList(COMMENT_TYPE_SCA_FINDINGS,ZERO_SCA_VULNERABILITY_COMMENT)),
+        SCA_AND_SAST(Arrays.asList(COMMENT_TYPE_SAST_FINDINGS_1, COMMENT_TYPE_SAST_FINDINGS_2, COMMENT_TYPE_SCA_FINDINGS ,ZERO_SAST_VULNERABILITY_COMMENT,ZERO_SCA_VULNERABILITY_COMMENT)),
         SCAN_FAILED_MESSAGE(Arrays.asList(COMMENT_TYPE_SCAN_FAILED_MESSAGE)),
         SCAN_NOT_SUBMITTED(Arrays.asList(COMMENT_TYPE_SAST_SCAN_NOT_SUBMITTED));
 


### PR DESCRIPTION
### Description
A new configuration `zero-vulnerability-summary: true` has been added for all SCM. The default setting value is false. 

If the configuration is true, check if all vulnerabilities count. If everything is 0, add the comment "No SAST Vulnerability Found!!" or "No SCA Vulnerability Found!!" based on the vulnerability scanner instead for complete PR decorating to reduce PR messages. 

### Testing

Tested with SAST and SCA for GITLAB and GITHUB pull request 


