### PR TITLE
pr-CXFLW-1296 Improved documentation for GitLab dashboard.

### DIFF
--- a/docs/Tutorials.md
+++ b/docs/Tutorials.md
@@ -46,12 +46,12 @@
 <br/>
 
 
-## <a name="requirementsfortutorials">Requirements For Tutorials:</a> 
+## <a name="requirementsfortutorials">Requirements For Tutorials:</a>
 * Create a folder on the C:\ drive called CxFlow
 * Into this folder, download the latest CxFlow .jar for JDK8
-<br/>https://github.com/checkmarx-ltd/cx-flow/releases
-<br/>The Java 11 version will have -java11 at the end of the file name 
-<br/>**Note** This guide is using CxFlow version 1.6.12, if you download another version, input your version in the command below
+  <br/>https://github.com/checkmarx-ltd/cx-flow/releases
+  <br/>The Java 11 version will have -java11 at the end of the file name
+  <br/>**Note** This guide is using CxFlow version 1.6.12, if you download another version, input your version in the command below
 * Download the appropriate version of the example application.yml file for your CxSAST version from https://github.com/checkmarx-ts/cicd-examples/tree/master/cxflow/YML-templates
 
 <br/> Under the Checkmarx heading, you should enter your service account's username, password, and confirm the base-url. Under the Source Control heading please enter your token and web-hook token if you have entered a value for the web-token different from this guide's value of 12345. Finally, enter another port if you are using a port other than 8982.  **Note** Each lesson will walk through creating a personal access token in the source control.
@@ -78,13 +78,13 @@ This quick start guide describes how to trigger a CxSAST scan on a Pull Request 
 Requirements:
 * Create a folder called CxFlow
 * Into this folder, download the latest CxFlow .jar for JDK8
-<br>https://github.com/checkmarx-ltd/cx-flow/releases
-<br>**Note** This guide is using CxFlow version 1.5.4, if you download another version, input your version in the command below
+  <br>https://github.com/checkmarx-ltd/cx-flow/releases
+  <br>**Note** This guide is using CxFlow version 1.5.4, if you download another version, input your version in the command below
 * In the folder create a file titled application.yml
-* Add the text below to the application.yml file replacing any values enclosed in ###\<\>### with your appropriate value 
-<br> Under the Checkmarx heading, you should enter your service account's username, password, and confirm the base-url. Under the GitHub heading please enter your GitHub token and web-hook token if you have entered a value for the web-token different from this guide's value of 12345. Finally, enter another port if you are using a port other than 8982.
-<br>**Note** This .yml file is for CxSAST version 8.9. For later versions, navigate to the 9.0 link on the side bar
-<br>**Note** The client-secret value included here is the correct value for CxSAST and is not actually a secret value. It is the OIDC client secret used for API login to Checkmarx.
+* Add the text below to the application.yml file replacing any values enclosed in ###\<\>### with your appropriate value
+  <br> Under the Checkmarx heading, you should enter your service account's username, password, and confirm the base-url. Under the GitHub heading please enter your GitHub token and web-hook token if you have entered a value for the web-token different from this guide's value of 12345. Finally, enter another port if you are using a port other than 8982.
+  <br>**Note** This .yml file is for CxSAST version 8.9. For later versions, navigate to the 9.0 link on the side bar
+  <br>**Note** The client-secret value included here is the correct value for CxSAST and is not actually a secret value. It is the OIDC client secret used for API login to Checkmarx.
 
 ```
 server:
@@ -141,9 +141,9 @@ ngrok http 8982
 * Import code from your favorite small demo codebase on github. This guide will use <br>https://github.com/psiinon/bodgeit
 * Create a token by clicking on your profile in upper right corner > settings
     * Click Developer settings > Personal Access Tokens > Generate New Token
-    * Give the token a name, for example cxFlow-minimal, and both repo:status and public_repo scopes. 
+    * Give the token a name, for example cxFlow-minimal, and both repo:status and public_repo scopes.
     * Ensure "Issues" are enabled on the project Settings > Options > Features > Issues
-[[/Images/guide1.png|Example name and scope for GitHub token]]
+      [[/Images/guide1.png|Example name and scope for GitHub token]]
     * Copy this token and keep it safe. It should be posted into the token \<\> of the application.yml
 * Once the .yml is completely filled out, start CxFlow in webhook mode by opening CMD prompt/shell, navigate to your CxFlow directory (created above) and entering the following, after updating the path\to\CxFlow folder:
 ```
@@ -158,16 +158,16 @@ java -jar cx-flow-1.6.19.jar --spring.config.location="<path\to>\CxFlow\applicat
     * Click Add Webhook, there should be a checkmarx next to the hook name now
 * Open your IDE of choice. This demo will use IntelliJ
     * Check out code using Check out from Version Control, input the URL for your repo example:
-<br>[https://github.com/<username\>/CxFlowGitHub](http://github.com)
+      <br>[https://github.com/<username\>/CxFlowGitHub](http://github.com)
     * Open README.md and add a line, example: CxFlowMasterPush-Test1
     * Commit to local git repo and push to origin with comments by clicking the following: VCS > Git > Commit File enter a message like CxFlow push to a protected branch
     * Click commit and push
     * Click Push and enter GitHub credentials on popup. Username is your username, password is the token you created above.
 * Navigate to the Checkmarx web portal. You should see a new scan in the CxSAST queue
-<br>Notice the project name is the RepoName-Branch
-<br>Notice the team is the GitHub organization. This is set by the team line in the .yml file. It auto creates a team if it does not exist. This can be overridden in the config file with the multi-tenant setting. Please see the CxFlow configuration page for more information.
-* When the scan finishes, you should see issues on the Issue tab of your GitHub repo 
-<br>[https://github.com/<username\>/CxFlowGitHub/issues](http://github.com/)
+  <br>Notice the project name is the RepoName-Branch
+  <br>Notice the team is the GitHub organization. This is set by the team line in the .yml file. It auto creates a team if it does not exist. This can be overridden in the config file with the multi-tenant setting. Please see the CxFlow configuration page for more information.
+* When the scan finishes, you should see issues on the Issue tab of your GitHub repo
+  <br>[https://github.com/<username\>/CxFlowGitHub/issues](http://github.com/)
 * Examine the following issue CX SQL_Injection @ roost/basket.jsp [main]
 * Open the Checkmarx link and examine the finding
 * We will now trigger CxFlow from a Pull Request to a protected branch, from branch security-fix to main
@@ -209,16 +209,16 @@ ResetSet rs = preparedStatement.executeQuery();
 [Back to Table of Contents](#tableofcontents)
 * Open your IDE of choice. This tutorial will use IntelliJ
     * Check out code using Check out from Version Control, input the URL for your repo example:
-<br/>https://github.com/<username\>/CxFlowBodgeit
+      <br/>https://github.com/<username\>/CxFlowBodgeit
     * Open README.md and add a line, example: CxFlowMasterPush-Test1
     * Commit to local git repo and push to origin with comments by clicking the following: VCS > Git > Commit File enter a message like CxFlow push to a protected branch
     * Click commit and push
     * Click Push and enter the source control credentials on popup. Username is your username, password is the personal access token you created.
 * Navigate to the Checkmarx web portal. You should see a new scan in the CxSAST queue
-<br/>**Notice** the project name is the RepoName-Branch
-<br/>**Notice** the team is the organization. This is set by the team line in the .yml file. It auto creates a team if it does not exist. This can be overridden in the config file with the multi-tenant setting. Please see the CxFlow configuration page for more information.
-* When the scan finishes, you should see issues on the Issue tab of your repo 
-<br/>[https://github.com/<username\>/CxFlowBodgeit/issues](http://github.com/)
+  <br/>**Notice** the project name is the RepoName-Branch
+  <br/>**Notice** the team is the organization. This is set by the team line in the .yml file. It auto creates a team if it does not exist. This can be overridden in the config file with the multi-tenant setting. Please see the CxFlow configuration page for more information.
+* When the scan finishes, you should see issues on the Issue tab of your repo
+  <br/>[https://github.com/<username\>/CxFlowBodgeit/issues](http://github.com/)
 * Examine the following issue CX SQL_Injection @ root/basket.jsp [main]
 * Open the Checkmarx link and examine the finding
 * We will now trigger CxFlow from a Pull Request to a protected branch, from the branch security-fix to main
@@ -254,7 +254,7 @@ ResetSet rs = preparedStatement.executeQuery();
     * Click Merge Pull Request > Confirm Merge to accept the risk CxSAST has posted in the comments
 * After confirming the pull request, there will be a new CxSAST scan in the Checkmarx web portal for the master branch
 * In Issues section of the source control there will be one fewer vulnerability
-* In the Checkmarx web portal, the CxFlowBodgeit-main project will now have both solved and recurrent issues. 
+* In the Checkmarx web portal, the CxFlowBodgeit-main project will now have both solved and recurrent issues.
 
 ## <a name="github">GitHub Webhook Tutorial</a>
 * [Prep](#githubprep)
@@ -281,9 +281,9 @@ bug-tracker: GitHub
 * Import code from your favorite small demo codebase on github. This guide will use <br>https://github.com/psiinon/bodgeit
 * Create a token by clicking on your profile in upper right corner > settings
     * Click Developer settings > Personal Access Tokens > Generate New Token
-    * Give the token a name, for example cxFlow-minimal, and both repo:status and public_repo scopes. 
+    * Give the token a name, for example cxFlow-minimal, and both repo:status and public_repo scopes.
     * Ensure "Issues" are enabled on the project Settings > Options > Features > Issues
-[[/Images/guide1.png|Example name and scope for GitHub token]]
+      [[/Images/guide1.png|Example name and scope for GitHub token]]
     * Copy this token and keep it safe. It should be posted into the token \<\> of the application.yml
     * After .YML file is completely filled out and saved, start CxFlow in webhook mode by opening a CMD prompt
 
@@ -308,7 +308,7 @@ This tutorial is designed to teach the following topics:
 * How to scan on a Merge Request to a Protected Branch
 * How to scan on a Push to Protected Branch
 * GitLab Issue Creation on a Push to Protected Branch
-        
+
 ### <a name="gitlabprep">GitLab Prep</a>
 ##### [Top of Tutorial](#gitlabWebhook)
 * Update the bugtracker section of the application.yml file with the following
@@ -333,19 +333,19 @@ bug-tracker: GitLab
     * Copy this token and keep safe - it should be pasted into the token: <> of the application.yml
 * After .YML file is completely filled out and saved, start CxFlow in webhook mode by opening a CMD prompt and typing the following
 
-* Create a webhook by selecting Projects>Your Projects and select the repo you just created 
+* Create a webhook by selecting Projects>Your Projects and select the repo you just created
 * Click Settings>Webhooks and fill in details
     * URL = ngrok location of CxFlow that is running - example: https://xxxx.ngrok.io
     * Secret = webhook-token: from .yml file - example: 12345
     * Trigger = Push events, Merge request events
     * Click Add Webhook
-* Continue to [Triggering Webhook Scans with CxFlow](#webhooktriggering) 
+* Continue to [Triggering Webhook Scans with CxFlow](#webhooktriggering)
 
 ## <a name="gitlabcicd">GitLab CI/CD</a>
-  * [Requirements](#gitlabcicdrequirements)
-  * [CI/CD Variables](#gitlabcicdvaiables)
-  * [Pipeline Configuration](#gitlabpipelineconfiguration)
-  * [Run Pipeline and review the results](#gitlabrunpipeline)
+* [Requirements](#gitlabcicdrequirements)
+* [CI/CD Variables](#gitlabcicdvaiables)
+* [Pipeline Configuration](#gitlabpipelineconfiguration)
+* [Run Pipeline and review the results](#gitlabrunpipeline)
 
 [Back to Tutorials Table of Contents](#tableofcontents)
 
@@ -357,19 +357,19 @@ The following steps represent the containerized CxFlow CLI integration flow:
 2. During the test stage of GitLab’s CI/CD pipeline, Checkmarx’s containerized CxFlow CLI is invoked
 3. CxFlow CLI triggers a security scan via the Checkmarx Scan Manager
 4. Results can be configured to be displayed with GitLab’s ecosystem or a supported bug tracker via CxFlow YAML configuration
-   * a. Results will be within Checkmarx Scan Results within the Checkmarx Manager Server
-   * b. Results can be accessed within GitLab’s Merge Request Overview (if the scan was initiated during a Merge Request)
-   * c. Results can be accessed within GitLab’s Issues if configured (or can be filtered into external bug tracker tools)
-   * d. Results can be accessed within GitLab’s security dashboard, if you have access to it (Gold/Ultimate packages or if your project is public)
+    * a. Results will be within Checkmarx Scan Results within the Checkmarx Manager Server
+    * b. Results can be accessed within GitLab’s Merge Request Overview (if the scan was initiated during a Merge Request)
+    * c. Results can be accessed within GitLab’s Issues if configured (or can be filtered into external bug tracker tools)
+    * d. Results can be accessed within GitLab’s security dashboard, if you have access to it (Gold/Ultimate packages or if your project is public)
 
 ` ! Within GitLab, CxFlow CLI will zip the source directory of the repository and send it to the Checkmarx Scan Manager to perform the security scan `
- 
+
 ##### [Top of Tutorial](#gitlabcicd)
 ### <a name="gitlabcicdrequirements">Requirements</a>
 GitLab can access a running Checkmarx CxSAST Server with an up-to-date Checkmarx license
 If performing CxSCA scans, you must have a valid CxSCA license and GitLab must be able to access the CxSCA tenant
 To review scan results within GitLab’s Security Dashboard, you need the Gold/Ultimate tier or the GitLab project must be public
-  * To review results in the issue management of your choice (i.e. JIRA) configuration is needed in the CxFlow YAML file, please refer to [Bug Tracker documentation](https://github.com/checkmarx-ltd/cx-flow/wiki/Bug-Trackers-and-Feedback-Channels)
+* To review results in the issue management of your choice (i.e. JIRA) configuration is needed in the CxFlow YAML file, please refer to [Bug Tracker documentation](https://github.com/checkmarx-ltd/cx-flow/wiki/Bug-Trackers-and-Feedback-Channels)
 
 ##### [Top of Tutorial](#gitlabcicd)
 ### <a name="gitlabcicdvaiables">CI/CD Variables</a>
@@ -378,23 +378,23 @@ Edit the CI/CD variables under Settings → CI / CD → Variables and add the fo
 
 [[/Images/gitlab_settings.png]]
 
-Variable/ Inputs     | Value 
+Variable/ Inputs     | Value
 --------------------|-------------------
-GITLAB_TOKEN | <p>API token to create Merge Request Overview entries, should have “api” privileges. <br>To create a personal token, click your GitLab profile in the upper right corner >settings <br><br>- Click Access Tokens and add a personal access token.Click Access Tokens and add a personal access token. <br>- Give the token api, read_user, write_repository, read_registry scopes. <br><br> For additional information on creating a Personal Access Token, refer to [GitLab: Personal Access Tokens](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) </p> 
-CX_FLOW_BUG_TRACKER   (Type: Variable)| Type of bug tracking ('GitLabDashboard' or ‘GitLab’).  For vulnerabilities to be exported to GitLab’s Dashboard, use ‘GitLabDashboard’ and for vulnerabilities to be added to GitLab’s Issues, use ‘GitLab’  For more details on complete list of Bug Trackers, please refer to [CxFlow Configuration](https://github.com/checkmarx-ltd/cx-flow/wiki/Configuration) 
+GITLAB_TOKEN | <p>API token to create Merge Request Overview entries, should have “api” privileges. <br>To create a personal token, click your GitLab profile in the upper right corner >settings <br><br>- Click Access Tokens and add a personal access token.Click Access Tokens and add a personal access token. <br>- Give the token api, read_user, write_repository, read_registry scopes. <br><br> For additional information on creating a Personal Access Token, refer to [GitLab: Personal Access Tokens](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) </p>
+CX_FLOW_BUG_TRACKER   (Type: Variable)| Type of bug tracking ('GitLabDashboard' or ‘GitLab’).  For vulnerabilities to be exported to GitLab’s Dashboard, use ‘GitLabDashboard’ and for vulnerabilities to be added to GitLab’s Issues, use ‘GitLab’  For more details on complete list of Bug Trackers, please refer to [CxFlow Configuration](https://github.com/checkmarx-ltd/cx-flow/wiki/Configuration)
 CX_FLOW_ENABLED_VULNERABILITY_SCANNERS | Vulnerability Scanners (sast, sca, ast, cxgo). Multiple comma separated values allowed.
-CHECKMARX_PASSWORD   (Type: Variable) | Password for CxSAST 
-CHECKMARX_SERVER   (Type: Variable) | The base URL of CxSAST Manager Server (i.e. https://checkmarx.company.com) 
-CHECKMARX_USERNAME   (Type: Variable) | User Name for the CxSAST Manager.  User must have ‘SAST Scanner’ privileges.  For more information on CxSAST roles, please refer to [CxSAST / CxOSA Roles and Permissions](https://checkmarx.atlassian.net/wiki/spaces/KC/pages/1178009601/CxSAST+CxOSA+Roles+and+Permissions+v9.0.0+and+up) 
-CHECKMARX_TEAM   (Type: Variable) | Checkmarx Team Name (i.e. /CxServer/teamname) 
+CHECKMARX_PASSWORD   (Type: Variable) | Password for CxSAST
+CHECKMARX_SERVER   (Type: Variable) | The base URL of CxSAST Manager Server (i.e. https://checkmarx.company.com)
+CHECKMARX_USERNAME   (Type: Variable) | User Name for the CxSAST Manager.  User must have ‘SAST Scanner’ privileges.  For more information on CxSAST roles, please refer to [CxSAST / CxOSA Roles and Permissions](https://checkmarx.atlassian.net/wiki/spaces/KC/pages/1178009601/CxSAST+CxOSA+Roles+and+Permissions+v9.0.0+and+up)
+CHECKMARX_TEAM   (Type: Variable) | Checkmarx Team Name (i.e. /CxServer/teamname)
 CHECKMARX_CLIENT_SECRET | Checkmarx OIDC Client Secret
-SCA_TENANT   (Type: Variable) | The name of the CxSCA Account (i.e. SCA-CompanyName).  **Only needed if you have a valid license for CxSCA** 
-SCA_USERNAME   (Type: Variable) | The username of the CxSCA Account.  **Only needed if you have a valid license for CxSCA**  
-SCA_PASSWORD   (Type: Variable) | The password of the CxSCA Account.  **Only needed if you have a valid license for CxSCA** 
+SCA_TENANT   (Type: Variable) | The name of the CxSCA Account (i.e. SCA-CompanyName).  **Only needed if you have a valid license for CxSCA**
+SCA_USERNAME   (Type: Variable) | The username of the CxSCA Account.  **Only needed if you have a valid license for CxSCA**
+SCA_PASSWORD   (Type: Variable) | The password of the CxSCA Account.  **Only needed if you have a valid license for CxSCA**
 CXGO_CLIENT_SECRET | Client-Secret needed for AST Cloud (CxGo).
 AST_API_URL | API URL for AST scan
 AST_WEBAPPURL | WebApp URL for AST scan
-AST_CLIENT_ID | Client-ID configured within AST. 
+AST_CLIENT_ID | Client-ID configured within AST.
 AST_CLIENT_SECRET | Client-Secret within AST.
 PARAMS | Any additional parameters for CxFlow. For a full list of all the parameters, check [here](https://github.com/checkmarx-ltd/cx-flow/wiki/Configuration)
 
@@ -462,7 +462,7 @@ While the scan results will always be available in the Checkmarx UI, users can a
 * Security Dashboard
 
 #### Merge Request Discussion
-When you have configured the .gitlab-ci.yml file to scan on merge_requests issues (please refer to [GitLab: Pipelines for Merge Requests](https://docs.gitlab.com/ee/ci/merge_request_pipelines/)), a high level report of the Checkmarx scan will be displayed within GitLab Merge Request Overview.  
+When you have configured the .gitlab-ci.yml file to scan on merge_requests issues (please refer to [GitLab: Pipelines for Merge Requests](https://docs.gitlab.com/ee/ci/merge_request_pipelines/)), a high level report of the Checkmarx scan will be displayed within GitLab Merge Request Overview.
 
 An example of a Merge Request with a Checkmarx scan report can be found in the below image.
 [[/Images/gitlab_merge_request.png]]
@@ -476,17 +476,58 @@ An example of Issues created can be found in the below image.
 [[/Images/gitlab_issues.png]]
 
 #### Security Dashboard
-With the Gold/Ultimate tier for GitLab, or if the project is public, you can review results in GitLab’s Security Dashboard.For information on GitLab’s Security Dashboard, please refer to [GitLab: Security Dashboard](https://docs.gitlab.com/ee/user/application_security/security_dashboard/index.html)
+To integrate GitLab’s Security Dashboard with CxFlow, you need to configure CxFlow to use GitLab as the bug tracker. This setup will allow CxFlow to create and manage security issues directly in GitLab, leveraging the Security Dashboard to display results from SAST (Static Application Security Testing) and SCA (Software Composition Analysis) scans.
+
+#### Configuration Steps
+#### Update CxFlow Configuration:
+* You need to configure the `butracker` and `bug-tracker-impl` settings in your CxFlow YAML configuration file to use GitLabDashboard.
+#### Enable SAST or SCA:
+* Ensure that either SAST or SCA scans are enabled in your project settings. This will generate the necessary artifacts (`gl-sast-report` and `gl-sca-report`).
+  #### Example YAML Configuration
+Here’s an example of how you might configure your `*.ci.yml` file:
 
 An example of vulnerabilities displayed in the Security Dashboard can be found in the below image.
+```
+cxflow:
+  zip-exclude: projects/[^c].*,src/.*,\.angular/.*,\.vscode/.*,\.git/.*,node_modules/.*,apps/.*,dist/.*,coverage/.*,tmp/.*,out-tsc/.*,e2e/.*,server/.*,test/.*,\.gitlab/.*,\.husky/.*,deploy/.*,dev-cluster/.*,ng-serve/.*,proxy-configs/.*,re-docs/.*,schema/.*,scripts/.*,projects/schema/.*,projects/volterra-clients/.*,projects/stellar-testing/.*,package.json,package-lock.json,tsconfig.json,tsconfig.*.json,README.md,.*\.spec\.ts,.*\.scss,.*\.type\.ts
+  bug-tracker: GitLabDashboard
+  branchProtectionEnabled: false
+  bug-tracker-impl:
+    # - Azure
+    # - Csv
+    # - CxXml
+    # - CxXml
+    # - GitHub
+    # - GitLab
+     - GitLabDashboard
+    # - GitLab
+    # - Rally
+    # - Json
+    # - PDF
+    # - JIRA
+    # - Sarif
+    # - SonarQube
+    # - GITHUBPULL
+    # - BITBUCKETCOMMIT
+  branches:
+```
+
+#### Artifacts Generated
+* gl-sast-report: This artifact contains the results of the SAST scan. It includes details about any vulnerabilities found in the source code.
+* gl-sca-report: This artifact contains the results of the SCA scan. It includes details about any vulnerabilities found in the dependencies and third-party libraries used by the project.
+####  Benefits of Integration
+* Centralized Security Management: By integrating CxFlow with GitLab’s Security Dashboard, you can manage all security issues in one place.
+* Automated Issue Creation: CxFlow automatically creates and updates issues in GitLab based on the results of SAST and SCA scans.
+* Enhanced Visibility: The Security Dashboard provides a comprehensive view of the security posture of your project, making it easier to track and address vulnerabilities.
+
 ##### [Top of Tutorial](#gitlabcicd)
 
 ## Sample GitLab config files for different scanners
 
- * [GitLab config for AST](https://github.com/checkmarx-ltd/cx-flow/blob/master/src/main/resources/samples/gitlab/gitlab-ast-sample.yml)
- * [GitLab config for SAST and SCA combined](https://github.com/checkmarx-ltd/cx-flow/blob/master/src/main/resources/samples/gitlab/gitlab-sast-sca-sample.yml)
- * [GitLab config for AST Cloud](https://github.com/checkmarx-ltd/cx-flow/blob/master/src/main/resources/samples/gitlab/gitlab-astcloud-sample.yml)
- * [GitLab config for SCA](https://github.com/checkmarx-ltd/cx-flow/blob/master/src/main/resources/samples/gitlab/gitlab-sca-sample.yml)
+* [GitLab config for AST](https://github.com/checkmarx-ltd/cx-flow/blob/master/src/main/resources/samples/gitlab/gitlab-ast-sample.yml)
+* [GitLab config for SAST and SCA combined](https://github.com/checkmarx-ltd/cx-flow/blob/master/src/main/resources/samples/gitlab/gitlab-sast-sca-sample.yml)
+* [GitLab config for AST Cloud](https://github.com/checkmarx-ltd/cx-flow/blob/master/src/main/resources/samples/gitlab/gitlab-astcloud-sample.yml)
+* [GitLab config for SCA](https://github.com/checkmarx-ltd/cx-flow/blob/master/src/main/resources/samples/gitlab/gitlab-sca-sample.yml)
 
 ## <a name="azure">Azure DevOps Webhook Lab</a>
 * [Prep](#adoprep)
@@ -512,20 +553,20 @@ bug-tracker: Azure
 * Create a new private project called CxFlowBodgeit
     * Make sure repo type is Git under Advanced
 * Click Repos & Import code from your favorite small demo codebase on GitHub
-    * This tutorial will use https://github.com/psiinon/bodgeit 
+    * This tutorial will use https://github.com/psiinon/bodgeit
 * Create a token by clicking your profile in upper right corner > Personal Access Tokens
     * Give the token a name and change Expiration to Custom defined and set to a year
     * Give the token full access to Work Items, Code, Build, Release
     * Copy this token and keep safe - it should be pasted into the token: <> of the application-azure.yml
-* After .YML file is completely filled out and saved, start CxFlow in webhook mode 
-* Create a webhook by selecting in the upper left corner Azure DevOps &  select the new repo you just created 
+* After .YML file is completely filled out and saved, start CxFlow in webhook mode
+* Create a webhook by selecting in the upper left corner Azure DevOps &  select the new repo you just created
 * Create a Webhook for Merge Requests
     * Click Project Settings \> Service hooks \> Create subscription and fill in details
     * Click Web Hooks then Next
         * Change drop down to Pull request created
         * Repository = CxFlowADO
         * Branch = main
-        * URL = https://<cxflow\>/ado/pull 
+        * URL = https://<cxflow\>/ado/pull
         * **Note** <cxflow\> is https ngrok location of CxFlow that is running
         * Example: https://xxxxx.ngrok.io/ado/pull
         * Basic authentication username = webhook-token: left side of : from .yml file - example: cxflow
@@ -537,12 +578,12 @@ bug-tracker: Azure
         * Change drop down to Code pushed
         * Repository = CxFlowADO
         * Branch = main
-        * URL = https://<cxflow\>/ado/push 
+        * URL = https://<cxflow\>/ado/push
         * **Note** <cxflow\> is https ngrok location of cxflow that is running
         * Example: https://xxxxx.ngrok.io/ado/push
         * Basic authentication username = webhook-token: left side of : from .yml file - example: cxflow
         * Basic authentication password = webhook-token: right side of : from .yml file - example: 12345
-    * Click Add Webhook 
+    * Click Add Webhook
 * Continue to [Triggering Webhook Scans with CxFlow](#webhooktriggering)
 
 ##### [Top of Tutorial](#azure)
@@ -564,14 +605,14 @@ This documentation is to help organizations create and run CxFlow in Azure DevOp
 
 * Utilize CxFlow as a Stage/Task in ADO Pipelines
 * Automatically determine matching variables between the Azure Pipeline and Checkmarx
-     * Variables can optionally be statically set by the developer team
+    * Variables can optionally be statically set by the developer team
 * Automatically generating work items from the pipeline if required
 * Cross platform Azure DevOps Agent support
     * Docker image for cross organisation updating
     * Updating the image will update all projects configurations
 * Ability to create custom workflows for pipelines to run via the endpoint script
     * Run multi-stage CxFlow jobs
-<br/>Below are examples of Azure DevOps Pipeline YAML files that use CxFlow to scan the code and create [Work Items](https://docs.microsoft.com/en-us/azure/devops/boards/work-items/about-work-items?view=azure-devops&tabs=agile-process) with vulnerabilities. CxFlow is invoked with custom workflow(s) that an organization might require.
+      <br/>Below are examples of Azure DevOps Pipeline YAML files that use CxFlow to scan the code and create [Work Items](https://docs.microsoft.com/en-us/azure/devops/boards/work-items/about-work-items?view=azure-devops&tabs=agile-process) with vulnerabilities. CxFlow is invoked with custom workflow(s) that an organization might require.
 
 ### <a name="windowsagents">Windows Agents</a>
 ##### [Top of Tutorial](#adopipeline)
@@ -694,7 +735,7 @@ These scripts are used on an Azure DevOps Agent as part of a Pipeline. They prov
 ### <a name="adopipelinebuilding">Building</a>
 ##### [Top of Tutorial](#adopipeline)
 **Docker Image**<br/>
-We recommend that organizations create a git repository of these files to track changes and easily deploy the images for all pipelines in the organisation in a private registry. 
+We recommend that organizations create a git repository of these files to track changes and easily deploy the images for all pipelines in the organisation in a private registry.
 <br/>Note: This Docker image can be used for any pipelines as long as the ADO variables being supplied are updated to corresponding build systems/bug tracking systems.
 <br/>**Command Line Interface**
 <br/> In the working directory of the source code, run the following commands:
@@ -761,7 +802,7 @@ stages:
 ## <a name="bitbucket">Bitbucket Cloud Webhook Tutorial</a>
 * [Prep](#bitbucketprep)
 * [Triggering Webhook Scans with CxFlow](#webhooktriggering)
-  
+
 [Back to Table of Contents](#tableofcontents)
 <br/>
 
@@ -777,15 +818,15 @@ This tutorial is designed to teach the following topics:
 * [Connect JIRA and Bitbucket](https://support.atlassian.com/bitbucket-cloud/docs/connect-bitbucket-cloud-to-jira-software-cloud/)
 * Create a new private repository named CxFlowBodgeit by clicking the + button on the sidebar
 * Click Import repository to import code from your favorite small demo codebase on GitHub
-    * This tutorial will use https://github.com/psiinon/bodgeit 
+    * This tutorial will use https://github.com/psiinon/bodgeit
 * Create an app password by clicking your profile in lower-left corner & Personal settings
     * Click App Passwords & Create app password
     * Create a Label (i.e. CxFlow)
     * Give the app password all Read/Write access to Pull requests & Webhooks
     * Copy this app password and keep safe - it should be pasted into the token: <> of the application.yml
     * The app password in the YML file should follow the format `<userid>:<app password>`
-* Once the YAML file is completely filled out and saved, start CxFlow in webhook mode 
-* In Bitbucket, create a webhook by selecting Repositories & select the new repo you just created 
+* Once the YAML file is completely filled out and saved, start CxFlow in webhook mode
+* In Bitbucket, create a webhook by selecting Repositories & select the new repo you just created
 * Click Repository settings>Webhooks>Add Webhook and fill in details
     * Title = CxFlow
     * URL = ngrok location of cxflow that is running + ?token=webtoken from yml file - example: https://xxxxx.ngrok.io?token=12345
@@ -867,7 +908,7 @@ Thresholds for High Issue is passed as '--cx-flow.thresholds.High=0' inside 'par
 * [Prep](#cliprep)
 * [Triggering CLI Scans with CxFlow](#clitriggering)
 * [Back to Tutorials Table of Contents](#tableofcontents)
-<br/>
+  <br/>
 
 This tutorial is designed to teach the following topics:
 * How to configure a Jira Cloud project for CxFlow
@@ -890,7 +931,7 @@ This tutorial is designed to teach the following topics:
     * Project Name = APPSEC
     * Project Key = APPSEC
     * **Note** The 'Jira Project' field in the .yml file corresponds to this 'Project Key' and is case sensitive
-* Create an API token from your Atlassian account: 
+* Create an API token from your Atlassian account:
     * Log in to https://id.atlassian.com/manage-profile/security/api-tokens
     * Click Create API token.
     * From the dialog that appears, enter ‘CxFlow’ and click Create.
@@ -906,7 +947,7 @@ This tutorial is designed to teach the following topics:
     * Description = CxSAST Vulnerability Type
     * Select the checkboxes next to APPSEC: Kanban Bug Screen & APPSEC: Kanban Default Issue Screen
     * Click Update
-*Note :* Jira's credentials configuration differs for on-premises and cloud environments, Please refer to [Bug Trackers and Feedback Channels](https://github.com/checkmarx-ltd/cx-flow/wiki/Bug-Trackers-and-Feedback-Channels#cred) chapter for more details
+      *Note :* Jira's credentials configuration differs for on-premises and cloud environments, Please refer to [Bug Trackers and Feedback Channels](https://github.com/checkmarx-ltd/cx-flow/wiki/Bug-Trackers-and-Feedback-Channels#cred) chapter for more details
 ### <a name="clitriggering">Triggering Scans with CxFlow</a>
 ##### [Top of Tutorial](#clijira)
 
@@ -923,7 +964,7 @@ git clone https://github.com/ethicalhack3r/DVWA.git
 cd C:\CxFlow
 java -jar cx-flow-1.6.19.jar --spring.config.location="C:\CxFlow\application.yml" --scan --f="./DVWA" --cx-team="CxServer\SP\Company" --cx-project="DVWA" --app="DVWA"
 ```
-* **Note** The url for the jira section of the .yml file should be the one assigned to you when you first start your Jira account, for example 
+* **Note** The url for the jira section of the .yml file should be the one assigned to you when you first start your Jira account, for example
 ```
 url: https://<username>.atlassian.net/
 ```
@@ -962,15 +1003,15 @@ This tutorial is designed to teach the following topics:
 ##### [Top of Tutorial](#batch)
 * Create a folder on the C:\ drive called CxFlow
 * Into this folder, download the latest CxFlow .jar for JDK8
-<br/>https://github.com/checkmarx-ltd/cx-flow/releases
-<br/>The Java 11 version will have -java11 at the end of the file name 
-<br/>**Note** This guide is using CxFlow version 1.6.12, if you download another version, input your version in the command below
+  <br/>https://github.com/checkmarx-ltd/cx-flow/releases
+  <br/>The Java 11 version will have -java11 at the end of the file name
+  <br/>**Note** This guide is using CxFlow version 1.6.12, if you download another version, input your version in the command below
 * Create a new file called EmailPNEVulns.ps1 in C:\Flow with the text at the bottom of the page and replace any values surrounded in ###<\>### with your appropriate values, see [SMTP Server Prep](#smtpserverprep) steps below
 * In the same folder create a file titled application-email.yml
-* Add the text below to the application-email.yml file replacing any values enclosed in ###\<\>### with your appropriate value 
-<br/> Under the Checkmarx heading, you should enter your service account's username, password, and confirm the base-url. Under the GitHub heading please enter your GitHub token and web-hook token if you have entered a value for the web-token different from this guide's value of 12345. Finally, enter another port if you are using a port other than 8982.
-<br/>**Note** This .yml file is for CxSAST version 8.9. For later versions, navigate to the 9.0 link on the side bar
-<br/>**Note** The client-secret value included here is the correct value for CxSAST and is not actually a secret value. It is the OIDC client secret used for API login to Checkmarx.
+* Add the text below to the application-email.yml file replacing any values enclosed in ###\<\>### with your appropriate value
+  <br/> Under the Checkmarx heading, you should enter your service account's username, password, and confirm the base-url. Under the GitHub heading please enter your GitHub token and web-hook token if you have entered a value for the web-token different from this guide's value of 12345. Finally, enter another port if you are using a port other than 8982.
+  <br/>**Note** This .yml file is for CxSAST version 8.9. For later versions, navigate to the 9.0 link on the side bar
+  <br/>**Note** The client-secret value included here is the correct value for CxSAST and is not actually a secret value. It is the OIDC client secret used for API login to Checkmarx.
 ```yaml
 server:
   port: 8982
@@ -1016,13 +1057,13 @@ cx-xml:
     * https://signup.sendgrid.com/
     * **Note** After April 6, 2020, Single Sender Verification may be required, see:
     *  https://sendgrid.com/docs/ui/sending-email/sender-verification#adding-a-sender
-* Confirm your email address 
+* Confirm your email address
 * Click Email API \> Integration Guide on the left sidebar
     * Choose SMTP Relay
     * My First API Key Name - CxSAST
     * Click Create Key and add to the application-email.yml file
 * Scan the following GitHub project using source control scan in CxSAST under the following team
-    * URL = https://github.com/ethicalhack3r/DVWA.git  
+    * URL = https://github.com/ethicalhack3r/DVWA.git
     * Team = CxServer\SP\Company
     * Project Name = DVWA
 * After the scan completes, open the CxViewer & mark all SQL_Injection as Proposed Not Exploitable
@@ -1184,7 +1225,7 @@ GitHub Actions:
 
 How does the CxFlow GitHub Action work ?
 
-The action is available on the GitHub marketplace. The source is available here:  
+The action is available on the GitHub marketplace. The source is available here:
 
 GitHub actions rely on a .yml workflow definition file stored under /.github/workflows.
 
@@ -1201,38 +1242,38 @@ Since the application.yml provided by the CxFlow GitHub Action doesn’t contain
 Create a new file named cx.config at the root of your repository (main branch) containing the following (adapt the values with your specific environment details).
 
 {
-  "application": "DSVW",
-  "branches": ["develop", "main"],
-  "bugTracker": "JIRA",
-  "jira": {
-	"project": "DSVW",
-	"issue_type": "Bug",
-	"opened_status": ["Open","Reopen"],
-	"closed_status": ["Closed","Done"],
-	"open_transition": "Reopen Issue",
-	"close_transition": "Close Issue",
-	"close_transition_field": "resolution",
-	"close_transition_value": "Done",
-	"priorities": {
-	  "High": "High",
-	  "Medium": "Medium",
-	  "Low": "Low"
-	},
-	"fields": [
-	  {
-		"type": "result",
-		"name": "application",
-		"jira_field_name": "Application",
-		"jira_field_type": "label"
-	  },
-	  {
-		"type": "result",
-		"name": "category",
-		"jira_field_name": "Category",
-		"jira_field_type": "label"
-	  }
-	]
-  }
+"application": "DSVW",
+"branches": ["develop", "main"],
+"bugTracker": "JIRA",
+"jira": {
+"project": "DSVW",
+"issue_type": "Bug",
+"opened_status": ["Open","Reopen"],
+"closed_status": ["Closed","Done"],
+"open_transition": "Reopen Issue",
+"close_transition": "Close Issue",
+"close_transition_field": "resolution",
+"close_transition_value": "Done",
+"priorities": {
+"High": "High",
+"Medium": "Medium",
+"Low": "Low"
+},
+"fields": [
+{
+"type": "result",
+"name": "application",
+"jira_field_name": "Application",
+"jira_field_type": "label"
+},
+{
+"type": "result",
+"name": "category",
+"jira_field_name": "Category",
+"jira_field_type": "label"
+}
+]
+}
 }
 
 Step 2: Create a workflow
@@ -1395,7 +1436,7 @@ jobs:
 ### Extra configuration:
 <br>Additional parameters (passed via the params: field) can be found in the [Configuration Definitions section](https://github.com/checkmarx-ltd/cx-flow/wiki#configuration-details).<br>
 
-<br>For example, only process Urgent and Confirmed results by adding this parameter:<br> 
+<br>For example, only process Urgent and Confirmed results by adding this parameter:<br>
 ```
 --cx-flow.filter-state=Confirmed,Urgent
 ```
@@ -1462,8 +1503,8 @@ jobs:
 <br>The following must be set up:<br>
 
 * CxIAST Management Server (refer to CxIAST Setup Guide and Installing the CxIAST Management Server)
-* The application under test (AUT) (refer to Configuring the AUT Environment)  
-* Jenkins server (refer to Installing Jenkins) 
+* The application under test (AUT) (refer to Configuring the AUT Environment)
+* Jenkins server (refer to Installing Jenkins)
 * Bug Tracker (refer to Bug Tracker)
 
 ### <a name="iastgeneralprocedures">General Procedure</a>
@@ -1850,7 +1891,7 @@ csv:
 | `Information`       | `INFO`             |
 
 ## <a name="branchedProject">CxSAST Branching Project</a>
-CxFlow supports creating branched project in CxSAST from a project created from default branch of a repository when event type is **PUSH** on the feature branch, or from a project created from the target branch of a PR when event type is **PULL** on the feature branch, without incrementing the count of utilized licensed project. 
+CxFlow supports creating branched project in CxSAST from a project created from default branch of a repository when event type is **PUSH** on the feature branch, or from a project created from the target branch of a PR when event type is **PULL** on the feature branch, without incrementing the count of utilized licensed project.
 
 ### <a name="stepsforbranchproject">Steps to create branched project</a>
 * Set cx-branch option under checkmarx section in the application yml file to true.
@@ -1860,19 +1901,19 @@ CxFlow supports creating branched project in CxSAST from a project created from 
     cx-branch:true  
 ```
 
-* When a PUSH event is created from any feature branch of a repository, and a licensed project for the repository's default branch is not already present in CxSAST, then a licensed project for the default branch is first created with no scans and then a branched project is created from it for the feature branch. 
-  * No project exists in CxSAST for the repository `JavaVulnerabilityLabE`
-[[Images/no_project_present.PNG|No Project in CxSAST for the repository]]
-  * The repository has two branches defined `master` which is default, and `feature-branch` which is a feature branch.
-[[Images/fbranch.png|Branches in the repository]]
-  * **PUSH** event is created from the `feature-branch` branch of the repository.
-  * Licensed project for default branch `master` with name `javaVulnerabilityLabE-master` is created.
-  * Branched project for `feature-branch` with name `JavaVulnerabilityLabE-feature-branch` is created.
-[[Images/branchedProjectScan.png|Projects created in CxSAST]]
+* When a PUSH event is created from any feature branch of a repository, and a licensed project for the repository's default branch is not already present in CxSAST, then a licensed project for the default branch is first created with no scans and then a branched project is created from it for the feature branch.
+    * No project exists in CxSAST for the repository `JavaVulnerabilityLabE`
+      [[Images/no_project_present.PNG|No Project in CxSAST for the repository]]
+    * The repository has two branches defined `master` which is default, and `feature-branch` which is a feature branch.
+      [[Images/fbranch.png|Branches in the repository]]
+    * **PUSH** event is created from the `feature-branch` branch of the repository.
+    * Licensed project for default branch `master` with name `javaVulnerabilityLabE-master` is created.
+    * Branched project for `feature-branch` with name `JavaVulnerabilityLabE-feature-branch` is created.
+      [[Images/branchedProjectScan.png|Projects created in CxSAST]]
 
 * When a PULL event is created from any feature branch of a repository to a target branch and a project for the target branch does not exists in CxSAST then s licensed project for target branch is first created and then a branched project for the default branch is created.
-[[Images/no_project_present.PNG|No Project in CxSAST for the repository]]
-  * **PULL** event is created from `feature-branch` to a target branch `demo-master`
-  * Licensed project for target branch `demo-master` with name `JavaVulnerabilityLabE-demo-master` is created.
-  * Branched project for `feature-branch` with name `JavaVulnerabilityLabE-feature-branch` is created.
-[[Images/branchedProjectOnPull.png|Projects created in CxSAST]]
+  [[Images/no_project_present.PNG|No Project in CxSAST for the repository]]
+    * **PULL** event is created from `feature-branch` to a target branch `demo-master`
+    * Licensed project for target branch `demo-master` with name `JavaVulnerabilityLabE-demo-master` is created.
+    * Branched project for `feature-branch` with name `JavaVulnerabilityLabE-feature-branch` is created.
+      [[Images/branchedProjectOnPull.png|Projects created in CxSAST]]


### PR DESCRIPTION
Hello team,

Following your document:
https://github.com/checkmarx-ltd/cx-flow/wiki/Tutorials#cicd-variables

It seems it is possible to use a bug tracker type "GitLabDashboard"
And there are many places which mention "GitLabDasboard"

    - if: '$CX_FLOW_BUG_TRACKER == "GitLabDashboard" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
However, in the code, we can see only those:

public class BugTracker {
    private Type type;

public enum Type {
        JIRA("JIRA"),
        BITBUCKETCOMMIT("BITBUCKETCOMMIT"),
        BITBUCKETPULL("BITBUCKETPULL"),
        BITBUCKETSERVERPULL("BITBUCKETSERVERPULL"),
        bitbucketserverpull("bitbucketserverpull"),
        ADOPULL("ADOPULL"),
        adopull("adopull"),
        GITHUBPULL("GITHUBPULL"),
        githubpull("githubpull"),
        GITHUBCOMMIT("GITHUBCOMMIT"),
        GITLABCOMMIT("GITLABCOMMIT"),
        GITLABMERGE("GITLABMERGE"),
        gitlabmerge("gitlabmerge"),
        EMAIL("EMAIL"),
        CUSTOM("CUSTOM"),
        NONE("NONE"),
        WAIT("WAIT"),
        wait("wait");

        private String type;

        Type(String type) {
            this.type = type;
        }

        public String getType() {
            return type;
        }
    }
There is no "GitLabDashboard"

Is that expected?

Can we change the Type, or remove this from the doc?

Also, could you please add more concrete documentation for :
https://github.com/checkmarx-ltd/cx-flow/wiki/Tutorials#security-dashboard

It is only three lines, while "merge request" for instance, has more descriptions, screenshots, etc