### PR TITLE
CXFLW-857 Added code for gitlab user

### DIFF
--- a/docs/Frequently-Asked-Questions.md
+++ b/docs/Frequently-Asked-Questions.md
@@ -18,6 +18,7 @@
 * [How do you manage the project creation within CxSAST when running CxFlow in WebHook mode?](#manageprojectcreation)
 * [If using global WebHooks, can specific projects be excluded from scanning?](#globalwebhooks)
 * [Why cxflow spring boot fails to start application if application.xml is present in source code in GitLab pipeline](#applicationxml)
+* [Why does the CXFlow GitLab MR scan comment reflect the repository creator instead of the MR creator?](#mergeomment)
 
 ## <a name="whatiscxflow">Q: What is CxFlow?</a>
 CxFlow is a solution that enables creating projects automatically, scans orchestration and facilitates feedback channels in a closed loop mode.
@@ -114,3 +115,6 @@ Please exclude files which contains windows reserved keyword or folder with wind
 
 ## <a name="ado">Q: How to check all Work Items in ADO ?</a>
 All work items in search bar or run a query in ADO to find all work items.
+
+## <a name="mergeomment">Why does the CXFlow GitLab MR scan comment reflect the repository creator instead of the MR creator?</a>
+If the scan comment is reflecting the repository creator, this is because the token being used is associated with the person or account that initially created the repository. You can find the solution and steps to resolve this issue in the [CXFlow GitLab MR Scan Comment Issue](cxflow_gitlab_scan_issue.md) document.

--- a/docs/cxflow_gitlab_scan_issue.md
+++ b/docs/cxflow_gitlab_scan_issue.md
@@ -1,0 +1,20 @@
+
+# CXFlow GitLab MR Scan Comment Issue
+
+In CXFlow, if the scan comment is reflecting the **repository creator** (instead of the Merge Request (MR) creator), this behavior likely arises because the token being used is associated with the person or account that initially created the repository. This means that all comments from the scan would be posted under that user's identity.
+
+## Suggested Solution to Fix the Issue:
+
+### 1. Use a Separate GitLab Account for Checkmarx:
+- Create a **dedicated GitLab account** in the name of **Checkmarx** (or another service name) specifically for CI/CD pipeline scans.
+- This will ensure that all comments are posted under the "Checkmarx" account, making it easier to identify that the comment comes from the automated scanning process and not the person who created the repository.
+
+### 2. Pass the Token via Pipeline:
+- Configure the **pipeline to pass the token** for the Checkmarx service account when running scans. This can be done by setting the **CI/CD pipeline token** to use the Checkmarx account's token instead of the repository creator's token.
+- This way, all scan-related comments will reflect the Checkmarx account, making it clear that the scan was performed by the tool, not by the repo owner.
+
+## Benefits:
+- **Clear identification**: Using a separate account like "Checkmarx" will clearly show that the comments come from the automated scanning tool, not a specific user.
+- **Simplified management**: Centralizing scan comments under one service account makes it easier to track automated actions.
+
+This approach will help resolve the issue of scan comments reflecting the repository creator, providing better transparency in the process.


### PR DESCRIPTION
Customer:

Sicredi



Description:

https://checkmarx.lightning.force.com/lightning/r/Case/5004K00000A25NeQAJ/view 

The MR comment is shown to be created by the owner of the Repo and not by the user who created the MR. It should be either the user who created the MR or just a generic Checkmarx user (if possible).



Actual Result:

The user who created the repo is the user added in the MR comment in GitLab.



Expected Result:

The user who create the MR is the user added in the GitLab comment.

The user has permission to add comments in GitLab. We need to add this information to the documentation.