### PR TITLE
Project deletion support via CLI command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.gradle.api.tasks.testing.Test
 buildscript {
     ext {
 
-        CxSBSDK = "0.6.18"
+        CxSBSDK = "0.6.19"
         ConfigProviderVersion = '1.0.14'
         //cxVersion = "8.90.5"
         springBootVersion = '3.2.11'

--- a/docs/Execution.md
+++ b/docs/Execution.md
@@ -4,6 +4,7 @@
 * [Parse](#parse)
 * [Batch](#batch)
 * [Project](#project)
+* [Delete](#delete)
 
 ## <a name="webhook">WebHook</a>
 Refer to [Webhook Registration](https://github.com/checkmarx-ltd/cx-flow/wiki/WebHook-Registration) for instructions on registering for WebHooks.
@@ -178,3 +179,31 @@ java -jar cx-flow-<ver>.jar \
 docker pull checkmarx/cx-flow
 docker run checkmarx/cx-flow <applicable parameters>
 ```
+
+## <a name="delete">Delete</a>
+Following Command can be used to only delete project.
+
+*Note:* namespace/branch/repo-name/repo-url are compulsory fields.
+```
+java -jar cx-flow-<ver>.jar \
+--delete \
+--namespace=<namespace> \
+--branch=<branch> \
+--repo-url=<repo-url> \
+--repo-name=<repo-name> \
+--cx-project=<project name>
+```
+
+Following command can be used if project need deleted after the scan.
+
+```
+java -jar cx-flow-<ver>.jar \
+--scan \
+--namespace=<namespace> \
+--branch=<branch> \
+--repo-url=<repo-url> \
+--repo-name=<repo-name> \
+--cx-project=<project name> \
+--delete-project
+```
+*Note:* Project deletion via CLI parameter is not applicable if `--f` parameter is used.

--- a/src/main/java/com/checkmarx/flow/CxFlowRunner.java
+++ b/src/main/java/com/checkmarx/flow/CxFlowRunner.java
@@ -481,9 +481,32 @@ public class CxFlowRunner implements ApplicationRunner {
                     }
                     cxParse(request, f);
                 }
-            } else if (args.containsOption(BATCH_OPTION)) {
+                if(args.containsOption("delete-project")){
+                    if (ScanUtils.empty(namespace) || ScanUtils.empty(repoName) || ScanUtils.empty(branch)) {
+                        log.error("Namespace/Repo/branch must be provided for deleting project via CLI");
+                        exit(ExitCode.BUILD_INTERRUPTED_INTENTIONALLY);
+                    }
+                    log.info("deleting project... ");
+                    deleteProject(request);
+                }
+            }else if(args.containsOption("delete")){
+                if (ScanUtils.empty(namespace) || ScanUtils.empty(repoName) || ScanUtils.empty(branch)) {
+                    log.error("Namespace/Repo/branch must be provided for deleting project via CLI");
+                    exit(ExitCode.BUILD_INTERRUPTED_INTENTIONALLY);
+                }
+                log.info("deleting project... ");
+                deleteProject(request);
+            }  else if (args.containsOption(BATCH_OPTION)) {
                 log.info("Executing batch process");
                 cxBatch(request);
+                if(args.containsOption("delete-project")){
+                    if (ScanUtils.empty(namespace) || ScanUtils.empty(repoName) || ScanUtils.empty(branch)) {
+                        log.error("Namespace/Repo/branch must be provided for deleting project via CLI");
+                        exit(ExitCode.BUILD_INTERRUPTED_INTENTIONALLY);
+                    }
+                    log.info("deleting project... ");
+                    deleteProject(request);
+                }
             } else if (args.containsOption("project")) {
                 if (ScanUtils.empty(cxProject)) {
                     log.error("cx-project must be provided when --project option is used");
@@ -496,6 +519,14 @@ public class CxFlowRunner implements ApplicationRunner {
                     request.setScanId(scanId);
                 }
                 publishLatestScanResults(request);
+                if(args.containsOption("delete-project")){
+                    if (ScanUtils.empty(namespace) || ScanUtils.empty(repoName) || ScanUtils.empty(branch)) {
+                        log.error("Namespace/Repo/branch must be provided for deleting project via CLI");
+                        exit(ExitCode.BUILD_INTERRUPTED_INTENTIONALLY);
+                    }
+                    log.info("deleting project... ");
+                    deleteProject(request);
+                }
             } else if (args.containsOption("scan") || args.containsOption(IAST_OPTION)) {
                 log.info("Executing scan process");
                 request.setCliMode(CliMode.SCAN);
@@ -551,6 +582,14 @@ public class CxFlowRunner implements ApplicationRunner {
 
                 if (args.containsOption(IAST_OPTION)) {
                     configureIast(request, scanTag, args);
+                }
+                if(args.containsOption("delete-project")){
+                    if (ScanUtils.empty(namespace) || ScanUtils.empty(repoName) || ScanUtils.empty(branch)) {
+                        log.error("Namespace/Repo/branch must be provided for deleting project via CLI");
+                        exit(ExitCode.BUILD_INTERRUPTED_INTENTIONALLY);
+                    }
+                    log.info("deleting project... ");
+                    deleteProject(request);
                 }
             }
         } catch (Exception e) {
@@ -910,18 +949,24 @@ public class CxFlowRunner implements ApplicationRunner {
     }
 
     public void deleteProject(ScanRequest request) {
+        List<VulnerabilityScanner> enabledScanners  = getEnabledScanners(request);
+        validateEnabledScanners(enabledScanners);
+        enabledScanners.forEach(scanner-> scanner.deleteProject(request));
+    }
 
-        Optional<SastScanner> sastScanner = getEnabledScanners(request)
-                .stream().filter(scanner -> scanner instanceof SastScanner)
-                .map(scanner -> ((SastScanner) scanner))
-                .findFirst();
+    private void validateEnabledScanners(List<VulnerabilityScanner> enabledScanners) {
 
-        if(!sastScanner.isPresent()){
-            log.warn("Delete branch for non-SAST scanner is not supported");
-            return;
+        boolean isCxGoEnabled = enabledScanners.stream().anyMatch(scanner -> scanner instanceof CxGoScanner);
+
+        if (isCxGoEnabled && enabledScanners.size() > 1) {
+            throw new MachinaRuntimeException("CxGo scanner cannot be set with any other scanner");
         }
 
-        sastScanner.ifPresent(scanner -> scanner.deleteProject(request));
+        boolean isSastAndASTScannersFound = enabledScanners.stream().anyMatch(scanner -> scanner instanceof ASTScanner)
+                && enabledScanners.stream().anyMatch(scanner -> scanner instanceof SastScanner);
+        if (isSastAndASTScannersFound) {
+            throw new MachinaRuntimeException("Both SAST & AST-SAST scanners cannot be set together");
+        }
     }
 
 }

--- a/src/main/java/com/checkmarx/flow/service/VulnerabilityScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/VulnerabilityScanner.java
@@ -7,7 +7,7 @@ import com.checkmarx.sdk.dto.ScanResults;
 import javax.annotation.CheckForNull;
 import java.io.File;
 
-public interface VulnerabilityScanner {
+public interface VulnerabilityScanner  {
     @CheckForNull
     ScanResults scan(ScanRequest scanRequest);
 
@@ -20,4 +20,7 @@ public interface VulnerabilityScanner {
     ScanResults getLatestScanResults(ScanRequest request);
 
     boolean isEnabled();
+    default void deleteProject(ScanRequest request) {
+
+    }
 }


### PR DESCRIPTION
### Description

Added two CLI parameter `--delete` and `--delete-project` where `--delete` is standalone parameter if want to use only to delete project and `--delete-project ` can be used with --scan or --project or --batch.

### References

https://github.com/checkmarx-ltd/cx-flow/issues/734

