### PR TITLE
CXFLW-1590 Fixed issue for Pr feedback false

### DIFF
--- a/src/main/java/com/checkmarx/flow/config/FlowProperties.java
+++ b/src/main/java/com/checkmarx/flow/config/FlowProperties.java
@@ -53,6 +53,8 @@ public class FlowProperties {
     private boolean disablePRFeedBack = false;
 
 
+
+
     private Integer profilingDepth = 1;
     private String profileConfig = "CxProfile.json";
     private boolean trackApplicationOnly = false;

--- a/src/main/java/com/checkmarx/flow/service/ResultsService.java
+++ b/src/main/java/com/checkmarx/flow/service/ResultsService.java
@@ -156,10 +156,16 @@ public class ResultsService {
                     if (gitService.isScanSubmittedComment() && request.getScanSubmittedComment()) {
                         gitService.processPull(request, results);
                         gitService.endBlockMerge(request, results, scanDetails);
+                    }else if(!flowProperties.isDisablePRFeedBack()){
+                        gitService.processPull(request, results);
                     }
+
+
                     break;
                 case GITLABCOMMIT:
                     if (gitLabService.isScanSubmittedComment() && request.getScanSubmittedComment() ) {
+                        gitLabService.processCommit(request, results);
+                    }else if(!flowProperties.isDisablePRFeedBack()){
                         gitLabService.processCommit(request, results);
                     }
                     break;
@@ -167,6 +173,8 @@ public class ResultsService {
                     if (gitLabService.isScanSubmittedComment() && request.getScanSubmittedComment()) {
                         gitLabService.processMerge(request, results);
                         gitLabService.endBlockMerge(request);
+                    }else if(!flowProperties.isDisablePRFeedBack()){
+                        gitLabService.processMerge(request, results);
                     }
                     break;
                 case BITBUCKETCOMMIT:
@@ -177,18 +185,24 @@ public class ResultsService {
                 case BITBUCKETPULL:
                     if (bbService.isScanSubmittedComment() && request.getScanSubmittedComment()) {
                         bbService.processMerge(request, results);
+                    }else if(!flowProperties.isDisablePRFeedBack()){
+                        bbService.processMerge(request, results);
                     }
                     break;
                 case BITBUCKETSERVERPULL:
                     if (bbService.isScanSubmittedComment() && request.getScanSubmittedComment()) {
                         bbService.processServerMerge(request, results, scanDetails);
                         bbService.setBuildEndStatus(request, results, scanDetails);
+                    }else if(!flowProperties.isDisablePRFeedBack()){
+                        bbService.processServerMerge(request, results, scanDetails);
                     }
                     break;
                 case ADOPULL:
                     if (adoService.isScanSubmittedComment() && request.getScanSubmittedComment()) {
                         adoService.processPull(request, results);
                         adoService.endBlockMerge(request, results, scanDetails);
+                    }else if(!flowProperties.isDisablePRFeedBack()){
+                        adoService.processPull(request, results);
                     }
                     break;
                 case EMAIL:


### PR DESCRIPTION
Description
Since version 1.7.01, when passing argument --gitlab.scan-submitted-comment="false", instead of only disabling the MR comment that says "Scan submitted to checkmarx", it also disable the comment containing the scan summary. This contradicts the documentation and makes it impossible to only disable the scan submitted comment. This is caused by this if that was added in ResultsService in version 1.7.01:

case GITLABMERGE:
  if (gitLabService.isScanSubmittedComment() && request.getScanSubmittedComment()) {
      gitLabService.processMerge(request, results);
      gitLabService.endBlockMerge(request);
  }
Expected Behavior
When scan-submitted-comment is set to false, cxflow should still add the scan summary as a merge request comment but should not comment to say that a scan was submitted to checkmarx.

Actual Behavior
When scan-submitted-comment is set to false, cxflow does not comment in the merge request at all. It runs a scan and does nothing with the result.

Reproduction
Start from this [template](https://github.com/checkmarx-ltd/cx-flow/blob/develop/templates/gitlab/v4/Checkmarx.gitlab-ci.yml) and modify checkmarx-scan-mr to send this argument to cxflow : --gitlab.scan-submitted-comment="false"

Run the merge request pipeline. cxflow will run but won't comment the scan summary to your merge request.

Environment Details
Tested on cxflow 1.7.06 with java 17.