### PR TITLE
Added new Jira search API support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -593,9 +593,9 @@ orbs:
 workflows:
   version: 2
 
-  cx-kpi-shipper:
-    jobs:
-      - checkmarx/circleci-kpi-shipper
+#  cx-kpi-shipper:
+#    jobs:
+#      - checkmarx/circleci-kpi-shipper
 
   build_deploy:
     jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR app
 RUN apk update && \
     apk upgrade && \
     apk upgrade
-RUN apk add openjdk17=17.0.15_p6-r0 --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
+RUN apk add openjdk17=17.0.16_p8-r0 --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 RUN apk add libstdc++
 RUN apk add glib

--- a/src/main/java/com/checkmarx/flow/dto/jira/Fields.java
+++ b/src/main/java/com/checkmarx/flow/dto/jira/Fields.java
@@ -1,0 +1,23 @@
+package com.checkmarx.flow.dto.jira;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import java.util.Set;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Fields {
+    private String summary;
+    private String key;
+    private Project project;
+    @JsonProperty("issuetype")
+    private IssueType issueType;
+    private String updated;
+    private String created;
+    private Status status;
+    private Set<String> labels;
+    private Object description;
+    private Priority priority;
+}
+

--- a/src/main/java/com/checkmarx/flow/dto/jira/IssueType.java
+++ b/src/main/java/com/checkmarx/flow/dto/jira/IssueType.java
@@ -1,0 +1,19 @@
+package com.checkmarx.flow.dto.jira;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+import java.net.URI;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class IssueType {
+    private URI self;
+    private String description;
+    private URI iconUrl;
+    private String name;
+    private boolean subtask;
+    private long id;
+    private long avatarId;
+    private int hierarchyLevel;
+}

--- a/src/main/java/com/checkmarx/flow/dto/jira/JiraIssue.java
+++ b/src/main/java/com/checkmarx/flow/dto/jira/JiraIssue.java
@@ -1,0 +1,17 @@
+package com.checkmarx.flow.dto.jira;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+import java.net.URI;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class JiraIssue {
+    private String id;
+    private String key;
+    private URI self;
+    private String expand;
+    private Fields fields;
+}
+

--- a/src/main/java/com/checkmarx/flow/dto/jira/JiraSearchRequest.java
+++ b/src/main/java/com/checkmarx/flow/dto/jira/JiraSearchRequest.java
@@ -1,0 +1,42 @@
+package com.checkmarx.flow.dto.jira;
+
+import java.util.List;
+
+public class JiraSearchRequest {
+    private String jql;
+    private List<String> fields;
+    private Integer maxResults;
+    private String nextPageToken;
+
+    public String getJql() {
+        return jql;
+    }
+
+    public void setJql(String jql) {
+        this.jql = jql;
+    }
+
+    public List<String> getFields() {
+        return fields;
+    }
+
+    public void setFields(List<String> fields) {
+        this.fields = fields;
+    }
+
+    public Integer getMaxResults() {
+        return maxResults;
+    }
+
+    public void setMaxResults(Integer maxResults) {
+        this.maxResults = maxResults;
+    }
+
+    public String getNextPageToken() {
+        return nextPageToken;
+    }
+
+    public void setNextPageToken(String nextPageToken) {
+        this.nextPageToken = nextPageToken;
+    }
+}

--- a/src/main/java/com/checkmarx/flow/dto/jira/JiraSearchResponse.java
+++ b/src/main/java/com/checkmarx/flow/dto/jira/JiraSearchResponse.java
@@ -1,0 +1,21 @@
+package com.checkmarx.flow.dto.jira;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class JiraSearchResponse {
+    @JsonProperty("isLast")
+    private boolean isLast;
+    private List<JiraIssue> issues;
+    @JsonProperty("nextPageToken")
+    private String nextPageToken;
+    private Integer startAt;
+    private Integer maxResults;
+    private Integer total;
+
+}

--- a/src/main/java/com/checkmarx/flow/dto/jira/Priority.java
+++ b/src/main/java/com/checkmarx/flow/dto/jira/Priority.java
@@ -1,0 +1,15 @@
+package com.checkmarx.flow.dto.jira;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+import java.net.URI;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Priority {
+    private URI self;
+    private String iconUrl;
+    private String name;
+    private String id;
+}

--- a/src/main/java/com/checkmarx/flow/dto/jira/Project.java
+++ b/src/main/java/com/checkmarx/flow/dto/jira/Project.java
@@ -1,0 +1,22 @@
+package com.checkmarx.flow.dto.jira;
+
+import com.atlassian.jira.rest.client.api.domain.BasicProject;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+import java.net.URI;
+import java.util.Map;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Project {
+    private Map<String, String> avatarUrls;
+    private Long id;
+    private String key;
+    private String name;
+    private ProjectCategory projectCategory;
+    private URI self;
+    private boolean simplified;
+    private String style;
+}
+

--- a/src/main/java/com/checkmarx/flow/dto/jira/ProjectCategory.java
+++ b/src/main/java/com/checkmarx/flow/dto/jira/ProjectCategory.java
@@ -1,0 +1,14 @@
+package com.checkmarx.flow.dto.jira;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ProjectCategory {
+    private String description;
+    private String id;
+    private String name;
+    private String self;
+}
+

--- a/src/main/java/com/checkmarx/flow/dto/jira/Status.java
+++ b/src/main/java/com/checkmarx/flow/dto/jira/Status.java
@@ -1,0 +1,18 @@
+package com.checkmarx.flow.dto.jira;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+import java.net.URI;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Status {
+    private URI self;
+    private String description;
+    private long id;
+    private StatusCategory statusCategory;
+    private URI iconUrl;
+    private String name;
+}
+

--- a/src/main/java/com/checkmarx/flow/dto/jira/StatusCategory.java
+++ b/src/main/java/com/checkmarx/flow/dto/jira/StatusCategory.java
@@ -1,0 +1,16 @@
+package com.checkmarx.flow.dto.jira;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+import java.net.URI;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StatusCategory {
+    private URI self;
+    private String colorName;
+    private String name;
+    private long id;
+    private String key;
+}

--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -1094,11 +1094,11 @@ public class JiraService {
             log.info("Using Api-Token/Password");
             String credentials = String.format("%s:%s", jiraProperties.getUsername(), jiraProperties.getToken());
             String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes());
-            httpHeaders.set(HttpHeaders.AUTHORIZATION, "Basic " + encodedCredentials);
+            httpHeaders.setBasicAuth(encodedCredentials);
         }
         else {
             log.info("Using Personal Access Token");
-            httpHeaders.set(HttpHeaders.AUTHORIZATION, "Bearer " + jiraProperties.getToken());
+            httpHeaders.setBearerAuth(jiraProperties.getToken());
         }
         return httpHeaders;
     }

--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -15,12 +15,14 @@ import com.checkmarx.flow.constants.SCATicketingConstants;
 import com.checkmarx.flow.dto.BugTracker;
 import com.checkmarx.flow.dto.ScanDetails;
 import com.checkmarx.flow.dto.ScanRequest;
+import com.checkmarx.flow.dto.jira.JiraIssue;
 import com.checkmarx.flow.dto.report.JiraTicketsReport;
 import com.checkmarx.flow.exception.JiraClientException;
 import com.checkmarx.flow.exception.JiraClientRunTimeException;
 import com.checkmarx.flow.exception.MachinaRuntimeException;
 import com.checkmarx.flow.jira9X.IssueFields;
 import com.checkmarx.flow.utils.HTMLHelper;
+import com.checkmarx.flow.utils.JiraSearchUtils;
 import com.checkmarx.flow.utils.ScanUtils;
 import com.checkmarx.sdk.dto.ScanResults;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -87,6 +89,7 @@ public class JiraService {
     private MetadataRestClient metaClient;
 
     private final RestTemplate restTemplate;
+    private final JiraSearchUtils jiraSearchUtils;
     private URI jiraURI;
     private Map<String, ScanResults.XIssue> nonPublishedScanResultsMap = new HashMap<>();
     private List<String> currentNewIssuesList = new ArrayList<>();
@@ -98,13 +101,14 @@ public class JiraService {
     }
 
     public JiraService(JiraProperties jiraProperties, FlowProperties flowProperties,
-                       HelperService helperService,@Qualifier("SSLRestTemplate") RestTemplate restTemplate) {
+                       HelperService helperService, @Qualifier("SSLRestTemplate") RestTemplate restTemplate, JiraSearchUtils jiraSearchUtils) {
         this.jiraProperties = jiraProperties;
         this.flowProperties = flowProperties;
         parentUrl = jiraProperties.getParentUrl();
         grandParentUrl = jiraProperties.getGrandParentUrl();
         this.helperService = helperService;
         this.restTemplate = restTemplate;
+        this.jiraSearchUtils = jiraSearchUtils;
     }
 
     private static void validateFieldRequestParams(String jiraProject, String issueType) {
@@ -255,16 +259,23 @@ public class JiraService {
         HashSet<String> fields = new HashSet<>();
         Collections.addAll(fields, "key", "project", "issuetype", "summary", LABEL_FIELD_TYPE, "created", "updated", "status");
 
-
-        SearchResult searchResults;
-        int totalResultsCount = MAX_RESULTS_ALLOWED;
-        SearchRestClient searchClient = this.client.getSearchClient();
-        //Retrieve JQL results through pagination (jira.max-jql-results per page -> default 50), don't allow less than 10.
-        int maxJqlResultsPerPage = Integer.max(10, jiraProperties.getMaxJqlResults());
-        for (int startAt = 0; startAt < totalResultsCount; startAt += maxJqlResultsPerPage) {
-            searchResults = searchClient.searchJql(jql, maxJqlResultsPerPage, startAt, fields).claim();
-            searchResults.getIssues().forEach(issues::add);
-            totalResultsCount = Integer.min(searchResults.getTotal(), MAX_RESULTS_ALLOWED);
+        //perform enhanced search using rest template when using JIRA cloud else use old search method
+        if(jiraProperties.getDeployType().equalsIgnoreCase("cloud")){
+            List<com.checkmarx.flow.dto.jira.JiraIssue> jiraIssues = jiraSearchUtils.performJiraSearch(jql, fields.stream().toList());
+            for (com.checkmarx.flow.dto.jira.JiraIssue dto : jiraIssues) {
+                issues.add(jiraSearchUtils.mapJiraIssueToIssue(dto));
+            }
+        }else{
+            SearchResult searchResults;
+            int totalResultsCount = MAX_RESULTS_ALLOWED;
+            SearchRestClient searchClient = this.client.getSearchClient();
+            //Retrieve JQL results through pagination (jira.max-jql-results per page -> default 50), don't allow less than 10.
+            int maxJqlResultsPerPage = Integer.max(10, jiraProperties.getMaxJqlResults());
+            for (int startAt = 0; startAt < totalResultsCount; startAt += maxJqlResultsPerPage) {
+                searchResults = searchClient.searchJql(jql, maxJqlResultsPerPage, startAt, fields).claim();
+                searchResults.getIssues().forEach(issues::add);
+                totalResultsCount = Integer.min(searchResults.getTotal(), MAX_RESULTS_ALLOWED);
+            }
         }
         return issues;
     }

--- a/src/main/java/com/checkmarx/flow/service/JiraService.java
+++ b/src/main/java/com/checkmarx/flow/service/JiraService.java
@@ -260,10 +260,13 @@ public class JiraService {
         Collections.addAll(fields, "key", "project", "issuetype", "summary", LABEL_FIELD_TYPE, "created", "updated", "status");
 
         //perform enhanced search using rest template when using JIRA cloud else use old search method
-        if(jiraProperties.getDeployType().equalsIgnoreCase("cloud")){
+        if((StringUtils.isEmpty(jiraProperties.getDeployType()) || jiraProperties.getDeployType().equalsIgnoreCase("cloud"))){
             List<com.checkmarx.flow.dto.jira.JiraIssue> jiraIssues = jiraSearchUtils.performJiraSearch(jql, fields.stream().toList());
-            for (com.checkmarx.flow.dto.jira.JiraIssue dto : jiraIssues) {
-                issues.add(jiraSearchUtils.mapJiraIssueToIssue(dto));
+            if(jiraIssues!=null && !jiraIssues.isEmpty()) {
+                log.debug("JIRA search returned {} issues", jiraIssues.size());
+                for (com.checkmarx.flow.dto.jira.JiraIssue dto : jiraIssues) {
+                    issues.add(jiraSearchUtils.mapJiraIssueToIssue(dto));
+                }
             }
         }else{
             SearchResult searchResults;

--- a/src/main/java/com/checkmarx/flow/utils/JiraSearchUtils.java
+++ b/src/main/java/com/checkmarx/flow/utils/JiraSearchUtils.java
@@ -40,7 +40,7 @@ public class JiraSearchUtils {
     private final JiraProperties jiraProperties;
     private final RestTemplate restTemplate;
 
-    public JiraSearchUtils(JiraProperties jiraProperties,@Qualifier("SSLRestTemplate")RestTemplate restTemplate) {
+    public JiraSearchUtils(JiraProperties jiraProperties,@Qualifier("flowRestTemplate")RestTemplate restTemplate) {
         this.jiraProperties = jiraProperties;
         this.restTemplate = restTemplate;
     }

--- a/src/main/java/com/checkmarx/flow/utils/JiraSearchUtils.java
+++ b/src/main/java/com/checkmarx/flow/utils/JiraSearchUtils.java
@@ -7,6 +7,7 @@ import com.checkmarx.flow.dto.jira.Fields;
 import com.checkmarx.flow.dto.jira.JiraIssue;
 import com.checkmarx.flow.dto.jira.JiraSearchRequest;
 import com.checkmarx.flow.dto.jira.JiraSearchResponse;
+import com.checkmarx.flow.exception.JiraClientRunTimeException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +16,7 @@ import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -55,10 +57,10 @@ public class JiraSearchUtils {
         if(jiraProperties.getTokenType()==null || jiraProperties.getTokenType().name().equalsIgnoreCase("API") || jiraProperties.getTokenType().name().equalsIgnoreCase("PASSWORD")){
             String credentials = String.format("%s:%s", jiraProperties.getUsername(), jiraProperties.getToken());
             String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes());
-            httpHeaders.set(HttpHeaders.AUTHORIZATION, "Basic " + encodedCredentials);
+            httpHeaders.setBasicAuth(encodedCredentials);
         }
         else {
-            httpHeaders.set(HttpHeaders.AUTHORIZATION, "Bearer " + jiraProperties.getToken());
+            httpHeaders.setBearerAuth(jiraProperties.getToken());
         }
         return httpHeaders;
     }
@@ -183,26 +185,30 @@ public class JiraSearchUtils {
      */
     private JiraSearchResponse performGetSearch(String baseUrl,
                                                 String jql, List<String> fields, String nextPageToken,HttpHeaders authHeaders) {
+        try {
+            String getUrl = String.format(ENHANCED_SEARCH_JQL,baseUrl);
+            UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(getUrl)
+                    .queryParam("jql", jql)
+                    .queryParam("fields", String.join(",", fields))
+                    .queryParam("maxResults", jiraProperties.getMaxJqlResults());
 
-        String getUrl = String.format(ENHANCED_SEARCH_JQL,baseUrl);
-        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(getUrl)
-                .queryParam("jql", jql)
-                .queryParam("fields", String.join(",", fields))
-                .queryParam("maxResults", jiraProperties.getMaxJqlResults());
+            if (StringUtils.isNotEmpty(nextPageToken)) {
+                uriBuilder.queryParam("nextPageToken", nextPageToken);
+            }
 
-        if (StringUtils.isNotEmpty(nextPageToken)) {
-            uriBuilder.queryParam("nextPageToken", nextPageToken);
+            String url = uriBuilder.build().toUriString();
+            HttpEntity<?> entity = new HttpEntity<>(authHeaders);
+
+            log.debug("GET Request URL: {}", url);
+
+            ResponseEntity<JiraSearchResponse> response =
+                    restTemplate.exchange(url, HttpMethod.GET, entity, JiraSearchResponse.class);
+
+            return response.getBody();
+
+        } catch (HttpClientErrorException e) {
+            throw new JiraClientRunTimeException("Error occurred during GET request to Jira: " + e.getMessage());
         }
-
-        String url = uriBuilder.build().toUriString();
-        HttpEntity<?> entity = new HttpEntity<>(authHeaders);
-
-        log.debug("GET Request URL: {}", url);
-
-        ResponseEntity<JiraSearchResponse> response =
-                restTemplate.exchange(url, HttpMethod.GET, entity, JiraSearchResponse.class);
-
-        return response.getBody();
     }
 
     /**
@@ -217,22 +223,26 @@ public class JiraSearchUtils {
 
     private JiraSearchResponse performPostSearch( String baseUrl,
                                                  String jql, List<String> fields, String nextPageToken,HttpHeaders authHeaders) {
+        try {
+            String url = String.format(ENHANCED_SEARCH_JQL,baseUrl);
 
-        String url = String.format(ENHANCED_SEARCH_JQL,baseUrl);
+            JiraSearchRequest request = new JiraSearchRequest();
+            request.setJql(jql);
+            request.setFields(fields);
+            request.setMaxResults(jiraProperties.getMaxJqlResults());
+            if (StringUtils.isNotEmpty(nextPageToken)) {
+                request.setNextPageToken(nextPageToken);
+            }
 
-        JiraSearchRequest request = new JiraSearchRequest();
-        request.setJql(jql);
-        request.setFields(fields);
-        request.setMaxResults(jiraProperties.getMaxJqlResults());
-        if (StringUtils.isNotEmpty(nextPageToken)) {
-            request.setNextPageToken(nextPageToken);
+            HttpEntity<JiraSearchRequest> entity = new HttpEntity<>(request, authHeaders);
+
+            log.debug("POST Request URL: {}, Body JQL={}, nextPageToken={}", url, jql, nextPageToken);
+
+            return restTemplate.postForObject(url, entity, JiraSearchResponse.class);
+        } catch (HttpClientErrorException e) {
+            throw new JiraClientRunTimeException("Error occurred during GET request to Jira: " + e.getMessage());
         }
 
-        HttpEntity<JiraSearchRequest> entity = new HttpEntity<>(request, authHeaders);
-
-        log.debug("POST Request URL: {}, Body JQL={}, nextPageToken={}", url, jql, nextPageToken);
-
-        return restTemplate.postForObject(url, entity, JiraSearchResponse.class);
     }
 
     /**
@@ -386,7 +396,7 @@ public class JiraSearchUtils {
     //only used for testing purposes
     public String convertAdfToMarkdown(Object adfObject) {
         ObjectMapper mapper = new ObjectMapper();
-        JsonNode root = mapper.valueToTree(adfObject); // convert Object → JsonNode
+        JsonNode root = mapper.valueToTree(adfObject);
         StringBuilder sb = new StringBuilder();
 
         // Handle root node with type "doc"
@@ -398,7 +408,6 @@ public class JiraSearchUtils {
                 }
             }
         } else if (root.has("doc") && root.get("doc").has("content")) {
-            // Fallback for previous structure
             JsonNode content = root.get("doc").get("content");
             if (content.isArray()) {
                 for (JsonNode node : content) {
@@ -408,7 +417,7 @@ public class JiraSearchUtils {
         }
         return sb.toString().trim();
     }
-
+    //helper function to process each node based on its type
     private void processNode(JsonNode node, StringBuilder sb) {
         String type = node.get("type").asText();
 
@@ -451,7 +460,7 @@ public class JiraSearchUtils {
                 break;
         }
     }
-
+    //helper function to handle text and hardBreak nodes
     private void handleContent(JsonNode child, StringBuilder sb) {
         String type = child.get("type").asText();
         if ("text".equals(type)) {

--- a/src/main/java/com/checkmarx/flow/utils/JiraSearchUtils.java
+++ b/src/main/java/com/checkmarx/flow/utils/JiraSearchUtils.java
@@ -240,7 +240,7 @@ public class JiraSearchUtils {
 
             return restTemplate.postForObject(url, entity, JiraSearchResponse.class);
         } catch (HttpClientErrorException e) {
-            throw new JiraClientRunTimeException("Error occurred during GET request to Jira: " + e.getMessage());
+            throw new JiraClientRunTimeException("Error occurred during POST request to Jira: " + e.getMessage(),e);
         }
 
     }
@@ -395,27 +395,31 @@ public class JiraSearchUtils {
     // function to convert ADF (Atlassian Document Format) to Markdown
     //only used for testing purposes
     public String convertAdfToMarkdown(Object adfObject) {
-        ObjectMapper mapper = new ObjectMapper();
-        JsonNode root = mapper.valueToTree(adfObject);
-        StringBuilder sb = new StringBuilder();
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode root = mapper.valueToTree(adfObject);
+            StringBuilder sb = new StringBuilder();
 
-        // Handle root node with type "doc"
-        if (root.has("type") && "doc".equals(root.get("type").asText()) && root.has("content")) {
-            JsonNode content = root.get("content");
-            if (content.isArray()) {
-                for (JsonNode node : content) {
-                    processNode(node, sb);
+            // Handle root node with type "doc"
+            if (root.has("type") && "doc".equals(root.get("type").asText()) && root.has("content")) {
+                JsonNode content = root.get("content");
+                if (content.isArray()) {
+                    for (JsonNode node : content) {
+                        processNode(node, sb);
+                    }
+                }
+            } else if (root.has("doc") && root.get("doc").has("content")) {
+                JsonNode content = root.get("doc").get("content");
+                if (content.isArray()) {
+                    for (JsonNode node : content) {
+                        processNode(node, sb);
+                    }
                 }
             }
-        } else if (root.has("doc") && root.get("doc").has("content")) {
-            JsonNode content = root.get("doc").get("content");
-            if (content.isArray()) {
-                for (JsonNode node : content) {
-                    processNode(node, sb);
-                }
-            }
+            return sb.toString().trim();
+        } catch (Exception e) {
+            return null;
         }
-        return sb.toString().trim();
     }
     //helper function to process each node based on its type
     private void processNode(JsonNode node, StringBuilder sb) {

--- a/src/main/java/com/checkmarx/flow/utils/JiraSearchUtils.java
+++ b/src/main/java/com/checkmarx/flow/utils/JiraSearchUtils.java
@@ -1,0 +1,480 @@
+package com.checkmarx.flow.utils;
+
+import com.atlassian.jira.rest.client.api.StatusCategory;
+import com.atlassian.jira.rest.client.api.domain.*;
+import com.checkmarx.flow.config.JiraProperties;
+import com.checkmarx.flow.dto.jira.Fields;
+import com.checkmarx.flow.dto.jira.JiraIssue;
+import com.checkmarx.flow.dto.jira.JiraSearchRequest;
+import com.checkmarx.flow.dto.jira.JiraSearchResponse;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.joda.time.DateTime;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * This class provides utility methods to perform Jira searches using JQL for JIRA Cloud.
+ * It supports both GET and POST requests based on the complexity of the JQL query.
+ * It handles pagination to retrieve all matching issues and maps the results to
+ * the appropriate domain objects.
+ */
+
+@Slf4j
+@Component
+public class JiraSearchUtils {
+    private static final String ENHANCED_SEARCH_JQL = "%s/rest/api/3/search/jql";
+    private final JiraProperties jiraProperties;
+    private final RestTemplate restTemplate;
+
+    public JiraSearchUtils(JiraProperties jiraProperties,@Qualifier("SSLRestTemplate")RestTemplate restTemplate) {
+        this.jiraProperties = jiraProperties;
+        this.restTemplate = restTemplate;
+    }
+
+    /**
+     * creates HttpHeaders with authentication details
+     * @return HttpHeaders with auth information
+     */
+    private HttpHeaders createAuthHeaders() {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        httpHeaders.set(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
+
+        if(jiraProperties.getTokenType()==null || jiraProperties.getTokenType().name().equalsIgnoreCase("API") || jiraProperties.getTokenType().name().equalsIgnoreCase("PASSWORD")){
+            String credentials = String.format("%s:%s", jiraProperties.getUsername(), jiraProperties.getToken());
+            String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes());
+            httpHeaders.set(HttpHeaders.AUTHORIZATION, "Basic " + encodedCredentials);
+        }
+        else {
+            httpHeaders.set(HttpHeaders.AUTHORIZATION, "Bearer " + jiraProperties.getToken());
+        }
+        return httpHeaders;
+    }
+
+    /**
+     * Main function to perform a Jira search using JQL.
+     * It handles pagination and returns a list of all matching JiraIssue objects.
+     * Chooses between GET and POST requests based on JQL complexity and length.
+     * @param jql The JQL query string.
+     * @param fields List of fields to retrieve for each issue.
+     * @return List of JiraIssue objects matching the JQL query.
+     */
+
+    public List<JiraIssue> performJiraSearch( String jql, List<String> fields) {
+        log.info("Perform EnhancedJQL Search...");
+        List<JiraIssue> allIssues = new ArrayList<>();
+        String nextPageToken = null;
+        // Use pagination to retrieve all issues
+        //nextPageToken is a string token provided by Jira to fetch the next set of results
+        do {
+            JiraSearchResponse response;
+
+            // If JQL is large or contains complex characters, use POST
+            if (shouldUsePostRequest(jql, fields)) {
+                response = performPostSearch(jiraProperties.getUrl(), jql, fields, nextPageToken,createAuthHeaders());
+            } else {
+                response = performGetSearch( jiraProperties.getUrl(), jql, fields, nextPageToken,createAuthHeaders());
+            }
+
+            if (response != null && response.getIssues() != null) {
+                allIssues.addAll(response.getIssues());
+            }
+
+            nextPageToken = response != null ? response.getNextPageToken() : null;
+
+        } while (StringUtils.isNotEmpty(nextPageToken));
+
+        return allIssues;
+    }
+
+
+    /**
+     * Performs a Jira search and returns a SearchResult.
+     * Uses pagination and maps the final result to SearchResult.
+     * Chooses between GET and POST requests based on JQL complexity and length.
+     * @param jql The JQL query string.
+     * @param fields List of fields to retrieve for each issue.
+     * @return SearchResult containing all matching issues.
+     */
+    public SearchResult performJiraSearchResult(String jql, List<String> fields) {
+        log.info("Perform EnhancedJQL Search for SearchResult...");
+        String nextPageToken = null;
+        List<JiraIssue> allIssues = new ArrayList<>();
+
+        do {
+            JiraSearchResponse response;
+            if (shouldUsePostRequest(jql, fields)) {
+                response = performPostSearch(jiraProperties.getUrl(), jql, fields, nextPageToken, createAuthHeaders());
+            } else {
+                response = performGetSearch(jiraProperties.getUrl(), jql, fields, nextPageToken, createAuthHeaders());
+            }
+
+            if (response != null && response.getIssues() != null) {
+                allIssues.addAll(response.getIssues());
+            }
+            //lastResponse = response;
+            nextPageToken = response != null ? response.getNextPageToken() : null;
+        } while (StringUtils.isNotEmpty(nextPageToken));
+
+        // Build a SearchResult using the last response's paging info and all collected issues
+        JiraSearchResponse resultDto = new JiraSearchResponse();
+            resultDto.setStartAt(0);
+            resultDto.setMaxResults(allIssues.size());
+            resultDto.setTotal(allIssues.size());
+        resultDto.setIssues(allIssues);
+
+        return mapJiraSearchResponseToSearchResult(resultDto);
+    }
+
+    /**
+     * Perform a check to determine if a POST request should be used based on JQL complexity and length.
+     * @param jql The JQL query string.
+     * @param fields List of fields to retrieve for each issue.
+     * @return true if POST should be used, false for GET.
+     */
+    private boolean shouldUsePostRequest(String jql, List<String> fields) {
+        // Use POST if:
+        // 1. JQL is longer than 1500 characters (safe margin for URL limits)
+        // 2. JQL contains special characters that might cause URL encoding issues
+        // 3. Total URL would exceed safe length
+
+        String encodedJql = URLEncoder.encode(jql, StandardCharsets.UTF_8);
+        int estimatedUrlLength;
+        if(fields!=null){
+            String fieldsParam = String.join(",", fields);
+            estimatedUrlLength= jiraProperties.getUrl().length() +
+                    ENHANCED_SEARCH_JQL.length() +
+                    "?jql=".length() + encodedJql.length() +
+                    "&maxResults=".length() + String.valueOf(jiraProperties.getMaxJqlResults()).length() +
+                    "&fields=".length() + fieldsParam.length();
+        }else{
+            estimatedUrlLength = jiraProperties.getUrl().length() +
+                    ENHANCED_SEARCH_JQL.length() +
+                    "?jql=".length() + encodedJql.length() +
+                    "&maxResults=".length() + String.valueOf(jiraProperties.getMaxJqlResults()).length();
+        }
+
+        // Estimate URL length
+        return jql.length() > 1500 || estimatedUrlLength > 1800 ||
+                jql.contains("\"") || jql.contains("'") || jql.contains("&");
+    }
+
+    /**
+     *
+     * Performs a GET request to the Jira search API with the provided JQL and fields.
+     * @param baseUrl Base URL of the Jira instance.
+     * @param jql The JQL query string.
+     * @param fields List of fields to retrieve for each issue.
+     * @param nextPageToken Token for pagination to fetch the next set of results.
+     * @param authHeaders HttpHeaders containing authentication details.
+     * @return JiraSearchResponse containing the search results.
+     */
+    private JiraSearchResponse performGetSearch(String baseUrl,
+                                                String jql, List<String> fields, String nextPageToken,HttpHeaders authHeaders) {
+
+        String getUrl = String.format(ENHANCED_SEARCH_JQL,baseUrl);
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(getUrl)
+                .queryParam("jql", jql)
+                .queryParam("fields", String.join(",", fields))
+                .queryParam("maxResults", jiraProperties.getMaxJqlResults());
+
+        if (StringUtils.isNotEmpty(nextPageToken)) {
+            uriBuilder.queryParam("nextPageToken", nextPageToken);
+        }
+
+        String url = uriBuilder.build().toUriString();
+        HttpEntity<?> entity = new HttpEntity<>(authHeaders);
+
+        log.debug("GET Request URL: {}", url);
+
+        ResponseEntity<JiraSearchResponse> response =
+                restTemplate.exchange(url, HttpMethod.GET, entity, JiraSearchResponse.class);
+
+        return response.getBody();
+    }
+
+    /**
+     * Performs a POST request to the Jira search API with the provided JQL and fields.
+     * @param baseUrl Base URL of the Jira instance.
+     * @param jql The JQL query string.
+     * @param fields List of fields to retrieve for each issue.
+     * @param nextPageToken Token for pagination to fetch the next set of results.
+     * @param authHeaders HttpHeaders containing authentication details.
+     * @return JiraSearchResponse containing the search results.
+     */
+
+    private JiraSearchResponse performPostSearch( String baseUrl,
+                                                 String jql, List<String> fields, String nextPageToken,HttpHeaders authHeaders) {
+
+        String url = String.format(ENHANCED_SEARCH_JQL,baseUrl);
+
+        JiraSearchRequest request = new JiraSearchRequest();
+        request.setJql(jql);
+        request.setFields(fields);
+        request.setMaxResults(jiraProperties.getMaxJqlResults());
+        if (StringUtils.isNotEmpty(nextPageToken)) {
+            request.setNextPageToken(nextPageToken);
+        }
+
+        HttpEntity<JiraSearchRequest> entity = new HttpEntity<>(request, authHeaders);
+
+        log.debug("POST Request URL: {}, Body JQL={}, nextPageToken={}", url, jql, nextPageToken);
+
+        return restTemplate.postForObject(url, entity, JiraSearchResponse.class);
+    }
+
+    /**
+     * Maps a JiraIssue DTO to an Issue(jira rest client) domain object.
+     * Only maps the most relevant fields; others are set to null or empty as needed.
+     * @param dto JiraIssue DTO
+     * @return Mapped Issue object
+     */
+
+    public Issue mapJiraIssueToIssue(JiraIssue dto) {
+        if (dto == null || dto.getFields() == null) {
+            log.debug("JiraIssue or its fields are null");
+            return null;
+        }
+
+        Fields fields = dto.getFields();
+        // Map only the most relevant fields; others set to null or empty as needed
+        // we only need fields "key", "project", "issuetype", "summary", labels, "created", "updated", "status"
+        return new Issue(
+                fields.getSummary(), //summary
+                dto.getSelf(), // self
+                dto.getKey(), // key
+                parseId(dto.getId()),  // id
+                mapProject(fields.getProject()), // project
+                mapIssueType(fields.getIssueType()),// issueType
+                mapStatus(fields.getStatus()),// status
+                convertAdfToMarkdown(fields.getDescription()), // description
+                mapPriority(fields.getPriority()), // priority
+                null, // resolution
+                List.of(), // attachments
+                null, // reporter
+                null, // assignee
+                toDateTime(fields.getCreated()), // created
+                toDateTime(fields.getUpdated()), // updated
+                null, // dueDate
+                List.of(), // affectedVersions
+                List.of(), // fixVersions
+                List.of(), // components
+                null, // timeTracking
+                List.of(), // issueFields
+                List.of(), // comments
+                null, // transitionsUri
+                List.of(), // issueLinks
+                null, // votes
+                List.of(), // worklogs
+                null, // watchers
+                List.of(), // expandos
+                List.of(), // subtasks
+                null, // changelog
+                null, // operations
+                fields.getLabels() // labels
+        );
+    }
+
+    private BasicPriority mapPriority(com.checkmarx.flow.dto.jira.Priority priority) {
+        if (priority == null) {
+            log.debug("Priority is null");
+            return null;
+        }
+        return new BasicPriority(priority.getSelf(),parseId(priority.getId()), priority.getName());
+    }
+
+
+    private Long parseId(String id) {
+        try {
+            return id != null ? Long.valueOf(id) : null;
+        } catch (NumberFormatException e) {
+            log.debug("Invalid issue ID: {}", id, e);
+            return null;
+        }
+    }
+
+    private BasicProject mapProject(com.checkmarx.flow.dto.jira.Project project) {
+        if (project == null) {
+            log.debug("Project is null");
+            return null;
+        }
+        return new BasicProject(project.getSelf(), project.getKey(), project.getId(), project.getName());
+    }
+
+    private IssueType mapIssueType(com.checkmarx.flow.dto.jira.IssueType issueType) {
+        if (issueType == null) {
+            log.debug("IssueType is null");
+            return null;
+        }
+        return new IssueType(
+                issueType.getSelf(),
+                issueType.getId(),
+                issueType.getName(),
+                issueType.isSubtask(),
+                issueType.getDescription(),
+                issueType.getIconUrl()
+        );
+    }
+
+    private Status mapStatus(com.checkmarx.flow.dto.jira.Status status) {
+        if (status == null) {
+            log.debug("Status is null");
+            return null;
+        }
+        com.checkmarx.flow.dto.jira.StatusCategory category = status.getStatusCategory();
+        StatusCategory mappedCategory = null;
+        if (category != null) {
+            mappedCategory = new StatusCategory(
+                    category.getSelf(),
+                    category.getName(),
+                    category.getId(),
+                    category.getKey(),
+                    category.getColorName()
+            );
+        }
+        return new Status(
+                status.getSelf(),
+                status.getId(),
+                status.getName(),
+                status.getDescription(),
+                status.getIconUrl(),
+                mappedCategory
+        );
+    }
+
+    private DateTime toDateTime(String date) {
+        return date != null ? new DateTime(date) : null;
+    }
+
+    /**
+     * Maps a JiraSearchResponse DTO to a SearchResult.
+     * @param dto JiraSearchResponse DTO
+     * @return SearchResult with mapped issues
+     */
+    public SearchResult mapJiraSearchResponseToSearchResult(JiraSearchResponse dto) {
+        if (dto == null || dto.getIssues() == null) {
+            log.debug("JiraSearchResponse or its issues are null");
+            return new SearchResult(0, 0, 0, List.of());
+        }
+        List<Issue> mappedIssues = new ArrayList<>();
+        for (com.checkmarx.flow.dto.jira.JiraIssue jiraIssue : dto.getIssues()) {
+            Issue mapped = mapJiraIssueToIssue(jiraIssue);
+            if (mapped != null) {
+                mappedIssues.add(mapped);
+            }
+        }
+        int startIndex = dto.getStartAt() != null ? dto.getStartAt() : 0;
+        int maxResults = dto.getMaxResults() != null ? dto.getMaxResults() : mappedIssues.size();
+        int total = dto.getTotal() != null ? dto.getTotal() : mappedIssues.size();
+        return new SearchResult(startIndex, maxResults, total, mappedIssues);
+    }
+
+
+    // function to convert ADF (Atlassian Document Format) to Markdown
+    //only used for testing purposes
+    public String convertAdfToMarkdown(Object adfObject) {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.valueToTree(adfObject); // convert Object → JsonNode
+        StringBuilder sb = new StringBuilder();
+
+        // Handle root node with type "doc"
+        if (root.has("type") && "doc".equals(root.get("type").asText()) && root.has("content")) {
+            JsonNode content = root.get("content");
+            if (content.isArray()) {
+                for (JsonNode node : content) {
+                    processNode(node, sb);
+                }
+            }
+        } else if (root.has("doc") && root.get("doc").has("content")) {
+            // Fallback for previous structure
+            JsonNode content = root.get("doc").get("content");
+            if (content.isArray()) {
+                for (JsonNode node : content) {
+                    processNode(node, sb);
+                }
+            }
+        }
+        return sb.toString().trim();
+    }
+
+    private void processNode(JsonNode node, StringBuilder sb) {
+        String type = node.get("type").asText();
+
+        switch (type) {
+            case "paragraph":
+                JsonNode paragraphContent = node.get("content");
+                if (paragraphContent != null) {
+                    for (JsonNode child : paragraphContent) {
+                        handleContent(child, sb);
+                    }
+                }
+                sb.append("\n\n");
+                break;
+
+            case "rule":
+                sb.append("---\n\n");
+                break;
+
+            case "codeBlock":
+                sb.append("```");
+                String language = node.has("attrs") && node.get("attrs").has("language")
+                        ? node.get("attrs").get("language").asText()
+                        : "";
+                if (!language.isEmpty()) {
+                    sb.append(language);
+                }
+                sb.append("\n");
+                if (node.has("content")) {
+                    for (JsonNode codeLine : node.get("content")) {
+                        if (codeLine.has("text")) {
+                            sb.append(codeLine.get("text").asText()).append("\n");
+                        }
+                    }
+                }
+                sb.append("```\n\n");
+                break;
+
+            default:
+                // skip unsupported types
+                break;
+        }
+    }
+
+    private void handleContent(JsonNode child, StringBuilder sb) {
+        String type = child.get("type").asText();
+        if ("text".equals(type)) {
+            String text = child.get("text").asText();
+            if (child.has("marks")) {
+                for (JsonNode mark : child.get("marks")) {
+                    String markType = mark.get("type").asText();
+                    switch (markType) {
+                        case "strong":
+                            text = "**" + text + "**";
+                            break;
+                        case "link":
+                            String href = mark.get("attrs").get("href").asText();
+                            text = "[" + text + "](" + href + ")";
+                            break;
+                    }
+                }
+            }
+            sb.append(text);
+        } else if ("hardBreak".equals(type)) {
+            sb.append("\n");
+        }
+    }
+
+
+}

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/end2end/genericendtoend/BugTracker.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/end2end/genericendtoend/BugTracker.java
@@ -16,6 +16,7 @@ import com.atlassian.jira.rest.client.internal.async.CustomAsynchronousJiraRestC
 import com.checkmarx.flow.config.GitLabProperties;
 import com.checkmarx.flow.config.JiraProperties;
 
+import com.checkmarx.flow.utils.JiraSearchUtils;
 import com.checkmarx.sdk.config.CxGoProperties;
 import com.checkmarx.sdk.config.CxProperties;
 import io.atlassian.util.concurrent.Promise;
@@ -32,11 +33,13 @@ enum BugTracker {
         private JiraRestClient client;
         private SearchRestClient searchClient;
         private String jqlQuery;
+        private JiraSearchUtils jiraSearchUtils;
 
 
         @Override
         void init(GenericEndToEndSteps genericEndToEndSteps) {
             jiraProperties = genericEndToEndSteps.jiraProperties;
+            jiraSearchUtils = genericEndToEndSteps.jiraSearchUtils;
             CustomAsynchronousJiraRestClientFactory factory = new CustomAsynchronousJiraRestClientFactory();
             URI jiraURI;
             try {
@@ -49,6 +52,7 @@ enum BugTracker {
             client = factory.createWithBasicHttpAuthenticationCustom(jiraURI, jiraProperties.getUsername(),
                     jiraProperties.getToken(), jiraProperties.getHttpTimeout());
             searchClient = client.getSearchClient();
+
         }
 
         @Override
@@ -67,21 +71,22 @@ enum BugTracker {
             SearchResult result = null;
             boolean found = false;
             for (int retries = 0; retries < NUMBER_OF_RETRIES; retries++) {
-                Promise<SearchResult> temp = searchClient.searchJql(jqlQuery, 10, 0, fields);
+                //Promise<SearchResult> temp = searchClient.searchJql(jqlQuery, 10, 0, fields);
+                SearchResult tempResult = jiraSearchUtils.performJiraSearchResult(jqlQuery, new ArrayList<>(fields));
                 try {
                     TimeUnit.SECONDS.sleep(RETRY_TIMEOUT_IN_SECONDS);
                     log.info("checking for issues in jira project '{}' starting attempt {}", jiraProperties.getProject(), retries + 1);
                 } catch (Exception e) {
                     log.warn("error in jira verifyIssueCreated loop: {}", e.getMessage());
                 }
-                try {
-                    result = temp.get(500, TimeUnit.MILLISECONDS);
-                } catch (Exception e) {
-                    log.info("failed attempt {}", retries + 1);
-                }
+//                try {
+//                    result = temp.get(500, TimeUnit.MILLISECONDS);
+//                } catch (Exception e) {
+//                    log.info("failed attempt {}", retries + 1);
+//                }
 
-                if (result != null && result.getTotal() > 0) {
-                    log.info("Found {} issues in jira project", result.getTotal());
+                if (tempResult != null && tempResult.getTotal() > 0) {
+                    log.info("Found {} issues in jira project", tempResult.getTotal());
                     found = true;
                     break;
                 }
@@ -100,11 +105,12 @@ enum BugTracker {
                 Set<String> fields = new HashSet<>();
                 fields.addAll(
                         Arrays.asList("key", "project", "issuetype", "summary", "labels", "created", "updated", "status"));
-                Promise<SearchResult> temp = searchClient.searchJql(jqlQuery, 10, 0, fields);
-                SearchResult result = temp.get(500, TimeUnit.MILLISECONDS);
+                //Promise<SearchResult> temp = searchClient.searchJql(jqlQuery, 10, 0, fields);
+                //SearchResult result = temp.get(500, TimeUnit.MILLISECONDS);
+                SearchResult tempResult = jiraSearchUtils.performJiraSearchResult(jqlQuery, new ArrayList<>(fields));
 
                 boolean isfound = false;
-                for (Issue currentIssue : result.getIssues()) {
+                for (Issue currentIssue : tempResult.getIssues()) {
                     isfound = true;
                     client.getIssueClient().deleteIssue(currentIssue.getKey(), false);
                 }

--- a/src/test/java/com/checkmarx/flow/cucumber/integration/end2end/genericendtoend/GenericEndToEndSteps.java
+++ b/src/test/java/com/checkmarx/flow/cucumber/integration/end2end/genericendtoend/GenericEndToEndSteps.java
@@ -4,6 +4,7 @@ import com.checkmarx.flow.CxFlowApplication;
 import com.checkmarx.flow.config.*;
 import com.checkmarx.flow.cucumber.common.utils.TestUtils;
 
+import com.checkmarx.flow.utils.JiraSearchUtils;
 import com.checkmarx.sdk.config.ScaProperties;
 import io.cucumber.java.After;
 import io.cucumber.java.en.And;
@@ -48,6 +49,7 @@ public class GenericEndToEndSteps {
      * bug-trackers
      */
     @Autowired JiraProperties jiraProperties;
+    @Autowired JiraSearchUtils jiraSearchUtils;
 
     private Repository repository;
     private BugTracker bugTracker;

--- a/src/test/java/com/checkmarx/jira/JiraTestUtils.java
+++ b/src/test/java/com/checkmarx/jira/JiraTestUtils.java
@@ -7,6 +7,7 @@ import com.atlassian.jira.rest.client.api.domain.IssueType;
 import com.atlassian.jira.rest.client.api.domain.SearchResult;
 import com.atlassian.jira.rest.client.internal.async.CustomAsynchronousJiraRestClientFactory;
 import com.checkmarx.flow.config.JiraProperties;
+import com.checkmarx.flow.utils.JiraSearchUtils;
 import com.checkmarx.flow.utils.ScanUtils;
 import com.checkmarx.sdk.dto.sast.Filter;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -16,6 +17,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.TestComponent;
 import org.springframework.http.*;
 import org.springframework.web.client.HttpClientErrorException;
@@ -26,7 +28,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 
 @TestComponent
@@ -41,6 +44,8 @@ public class JiraTestUtils implements IJiraTestUtils {
 
     @Autowired
     private JiraProperties jiraProperties;
+    @Autowired
+    private JiraSearchUtils jiraSearchUtils;
 
     @PostConstruct
     public void initClient() {
@@ -53,7 +58,6 @@ public class JiraTestUtils implements IJiraTestUtils {
                 log.error("Error constructing URI for JIRA", e);
             }
             this.client = factory.createWithBasicHttpAuthenticationCustom(jiraURI, jiraProperties.getUsername(), jiraProperties.getToken(), jiraProperties.getHttpTimeout());
-
         }
     }
 
@@ -63,7 +67,7 @@ public class JiraTestUtils implements IJiraTestUtils {
     }
 
     private SearchResult search(String jql) {
-        return  client.getSearchClient().searchJql(jql).claim();
+        return  jiraSearchUtils.performJiraSearchResult(jql,List.of("*all"));
     }
 
     private SearchResult search(String jql, int startAtIndex) {
@@ -86,12 +90,12 @@ public class JiraTestUtils implements IJiraTestUtils {
     @Override
     public Set<Issue> geAllIssuesInProject(String projectKey) {
         List<Issue> issues = new ArrayList<>();
-        SearchResult searchResult = search(getSearchAllProjectJql(projectKey), issues.size());
+        SearchResult searchResult = search(getSearchAllProjectJql(projectKey));
         searchResult.getIssues().forEach(issues::add);
-        while (issues.size() < searchResult.getTotal()) {
-            searchResult = search(getSearchAllProjectJql(projectKey), issues.size());
-            searchResult.getIssues().forEach(issues::add);
-        }
+//        while (issues.size() < searchResult.getTotal()) {
+//            searchResult = search(getSearchAllProjectJql(projectKey), issues.size());
+//            searchResult.getIssues().forEach(issues::add);
+//        }
         Set<Issue> result = new HashSet<>(issues);
         log.info("found {} issues in project '{}'", issues.size(), projectKey);
         return result;
@@ -128,7 +132,7 @@ public class JiraTestUtils implements IJiraTestUtils {
     }
 
     private String getIssueSeverity(String issueDescription) {
-        return getIssueBodyPart(issueDescription,"Severity:");
+        return getFieldValueFromDescription(issueDescription,"Severity");
     }
 
     @Override
@@ -195,14 +199,29 @@ Line #222:
     @Override
     public String getIssueVulnerabilityStatus(String projectKey) {
         Issue issue = getFirstIssue(projectKey);
-        String statusLine = issue.getDescription().split(System.lineSeparator())[13];
-        return statusLine;
+        //String statusLine = issue.getDescription().split(System.lineSeparator())[13];
+        return getFieldValueFromDescription(issue.getDescription(),"Status");
     }
 
     @Override
     public String getIssueRecommendedFixLink(String projectKey) {
         Issue issue = getFirstIssue(projectKey);
-        return  Objects.requireNonNull(issue.getDescription()).split(System.lineSeparator())[20];
+        Pattern pattern = Pattern.compile("^.*\\[Recommended Fix\\]\\([^)]+\\).*$", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
+        Matcher matcher = pattern.matcher(issue.getDescription());
+        if (matcher.find()) {
+            return matcher.group().trim();
+        }
+        return null;
+    }
+
+    private String getFieldValueFromDescription(String description, String fieldName) {
+        String regex = String.format("\\*{0,2}\\s*%s:\\s*\\*{0,2}\\s*(.+)", Pattern.quote(fieldName));
+        Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+        Matcher matcher = pattern.matcher(description);
+        if (matcher.find()) {
+            return matcher.group(1).trim();
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
### Description
Enhanced Jira Search API Support
Implemented support for the following Jira Search APIs:

[GET JQL Search](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/?utm_source=chatgpt.com#api-rest-api-3-search-jql-get)
 – Enables searching issues using JQL via HTTP GET.

[POST JQL Search](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/?utm_source=chatgpt.com#api-rest-api-3-search-jql-post)
 – Provides advanced JQL search capabilities with support for longer queries and request bodies.

### Testing

Tested on Jira cloud with SAST 9.7 and SCA

