### PR TITLE
Allow combining zipExclude and zipInclude patterns

### DIFF
--- a/src/main/java/com/checkmarx/flow/service/AbstractVulnerabilityScanner.java
+++ b/src/main/java/com/checkmarx/flow/service/AbstractVulnerabilityScanner.java
@@ -399,12 +399,7 @@ public abstract class AbstractVulnerabilityScanner implements VulnerabilityScann
             overrideScanPreset(request);
             String zipExclude = request.getZipExclude() != null ? request.getZipExclude() : flowProperties.getZipExclude();
             String zipInclude = request.getZipInclude() != null ? request.getZipInclude() : flowProperties.getZipInclude();
-            if(zipInclude!=null && zipExclude!=null)
-            {
-                log.error("Both zipExclude and zipInclude is not supported at same time.");
-                throw new ExitThrowable(3);
-            }
-            File zipFile = ZipUtils.zipToTempFile(path, zipExclude,zipInclude);
+            File zipFile = ZipUtils.zipToTempFile(path, zipExclude, zipInclude);
             ScanDetails details = executeCxScan(request, zipFile);
             results = getScanResults(request, details.getProjectId(), details.getScanId());
             log.debug("Deleting temp file {}", zipFile.getPath());


### PR DESCRIPTION
By submitting a PR to this repository, I agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md).

### Description

Remove the condition in `AbstractVulnerabilityScanner` that blocked using both `zipExclude` and `zipInclude` at the same time (Exit 3). The underlying `ZipUtils.addToZip` method already handles both patterns correctly — it excludes files matching the exclude pattern AND only includes files matching the include pattern in a single pass (line 108).

### References

Closes #1474

### Testing

- Verified that `ZipUtils.addToZip` (line 108) already evaluates both `excludePatterns` and `includePatterns` together in its condition
- The removed code was the only place preventing combined usage — no other code paths check for this combination

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable)
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
- [x] Verified that SCA and SAST scan results are as expected