### PR TITLE
Replace imgur-hosted CRITICAL icon with wiki-hosted asset

### DIFF
--- a/src/main/java/com/checkmarx/flow/utils/MarkDownHelper.java
+++ b/src/main/java/com/checkmarx/flow/utils/MarkDownHelper.java
@@ -37,7 +37,7 @@ public class MarkDownHelper {
     private static final String GITHUB_USER_PREFIX = "https://user-images.githubusercontent.com/23239410/";
     //private static final String CHECKMARX_LOGO_URL = GITHUB_USER_PREFIX + "92153465-ff743900-ee2c-11ea-9c8d-8141e38feb41.png";
     private static final String CHECKMARX_LOGO_URL = "https://raw.githubusercontent.com/wiki/checkmarx-ltd/cx-flow/Images/checkmarxLogo.png";
-    private static final String CRITICAL_ICON = "https://i.imgur.com/DGKOtBX.png";
+    private static final String CRITICAL_ICON = "https://raw.githubusercontent.com/wiki/checkmarx-ltd/cx-flow/Images/critical.png";
     private static final String HIGH_ICON = GITHUB_USER_PREFIX + "92157087-97285600-ee32-11ea-988f-0aca12c4c126.png";
     private static final String MEDIUM_ICON = GITHUB_USER_PREFIX + "92157093-98598300-ee32-11ea-83d7-af52251a011b.png";
     private static final String LOW_ICON = GITHUB_USER_PREFIX + "92157091-98598300-ee32-11ea-8498-19bd7d62019b.png";


### PR DESCRIPTION
Imgur is blocked in the UK, breaking the CRITICAL severity icon for users in that region. Point CRITICAL_ICON at the cx-flow wiki Images folder, matching the host already used by CHECKMARX_LOGO_URL.

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change.

### References

> Include supporting link to GitHub Issue/PR number

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used
- [ ] Verified that SCA and SAST scan results are as expected
