### PR TITLE
Fix to prevent double slash in generated fileUrls

### DIFF
--- a/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
+++ b/src/main/java/com/checkmarx/flow/utils/ScanUtils.java
@@ -287,7 +287,7 @@ public class ScanUtils {
 
         String branch = request.getBranch();
         if(!ScanUtils.empty(request.getRepoUrl()) && !ScanUtils.empty(branch)) {
-            String repoUrl = request.getRepoUrl().replace(".git", "/");
+            String repoUrl = request.getRepoUrl().replaceFirst("\\.git.*$", "/");
             if(!(repoUrl.substring(repoUrl.length() - 1).equals("/"))){
                 repoUrl = repoUrl.concat("/");
             }


### PR DESCRIPTION
### Description

Currently to start building fileUrl it fetches repoUrl and replaces ".git" with "/ " but if repoUrl ends with "/ " then after replacement Url ends up with 2 slashes.

> Input : https://github.com/mns-one/cx-flow.git
> Output : https://github.com/mns-one/cx-flow/

> Input : https://github.com/mns-one/cx-flow.git/
> Output : https://github.com/mns-one/cx-flow//

Updated replace() to replaceFirst() to also replace any trailing slashes or characters after ".git"

### References

> #1481 

### Testing

Tested locally by passing repo links to that code line and checking the output for:
>https://github.com/mns-one/cx-flow.git
https://github.com/mns-one/cx-flow.git/
and for any other leftover trailing characters after ".git"

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
- [ ] Verified that SCA and SAST scan results are as expected
